### PR TITLE
test: add unit tests for dfmplugin-search (part 3/3: search bar and UI)

### DIFF
--- a/autotests/plugins/dfmplugin-search/test_advancesearchbar.cpp
+++ b/autotests/plugins/dfmplugin-search/test_advancesearchbar.cpp
@@ -1,0 +1,392 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dfm-base/interfaces/sortfileinfo.h"
+#include <dfm-base/mimetype/mimetypedisplaymanager.h>
+#include "topwidget/advancesearchbar.h"
+#include "topwidget/advancesearchbar_p.h"
+#include "utils/searchhelper.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/private/syncfileinfo_p.h>
+
+#include "stubext.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QHideEvent>
+#include <DComboBox>
+
+#include <gtest/gtest.h>
+
+DPF_USE_NAMESPACE
+DPSEARCH_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+TEST(AdvanceSearchBarTest, ut_resetForm)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBar::onOptionChanged, [] {});
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.resetForm());
+}
+
+TEST(AdvanceSearchBarTest, ut_refreshOptions)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBarPrivate::refreshOptions, [] {});
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.refreshOptions(QUrl()));
+}
+
+TEST(AdvanceSearchBarTest, ut_onOptionChanged)
+{
+    AdvanceSearchBar bar;
+    stub_ext::StubExt st;
+    FileManagerWindow window(QUrl::fromLocalFile("/home"));
+    st.set_lamda(&FileManagerWindowsManager::findWindowId, [] { return 123; });
+    st.set_lamda(&FileManagerWindowsManager::findWindowById, [&window] { return &window; });
+    st.set_lamda(&FileManagerWindow::currentUrl, [] { return QUrl::fromLocalFile("/home"); });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64, const QUrl &, QVariant &&);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(bar.onOptionChanged());
+}
+
+TEST(AdvanceSearchBarTest, ut_onResetButtonPressed)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBar::resetForm, [] {});
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.onResetButtonPressed());
+}
+
+TEST(AdvanceSearchBarTest, ut_hideEvent)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&FileManagerWindowsManager::findWindowId, [] { return 123; });
+    FileManagerWindow window(QUrl::fromLocalFile("/home"));
+    st.set_lamda(&FileManagerWindowsManager::findWindowById, [&window] { return &window; });
+    st.set_lamda(&FileManagerWindow::isMinimized, [] { return false; });
+    st.set_lamda(&AdvanceSearchBar::resetForm, [] {});
+    st.set_lamda(VADDR(QScrollArea, hideEvent), [] {});
+
+    AdvanceSearchBar bar;
+    QHideEvent event;
+    EXPECT_NO_FATAL_FAILURE(bar.hideEvent(&event));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_refreshOptions_1)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBar::resetForm, [] {});
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.d->refreshOptions(QUrl()));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_refreshOptions_2)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBar::onOptionChanged, [] {});
+
+    AdvanceSearchBar bar;
+    auto searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "123");
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSearchRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kFileType] = bar.d->asbCombos[AdvanceSearchBarPrivate::kFileType]->currentData();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSizeRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kAccessDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kCreateDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = searchUrl;
+    bar.d->filterInfoCache[searchUrl] = formData;
+
+    EXPECT_NO_FATAL_FAILURE(bar.d->refreshOptions(searchUrl));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_refreshOptions_3)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&AdvanceSearchBar::onOptionChanged, [] {});
+
+    AdvanceSearchBar bar;
+    auto searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "123");
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSearchRange]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kFileType] = bar.d->asbCombos[AdvanceSearchBarPrivate::kFileType]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kSizeRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSizeRange]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kDateRange]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kAccessDateRange]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kCreateDateRange]->itemData(1);
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = searchUrl;
+    bar.d->filterInfoCache[searchUrl] = formData;
+
+    EXPECT_NO_FATAL_FAILURE(bar.d->refreshOptions(searchUrl));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_1)
+{
+    AdvanceSearchBar bar;
+    EXPECT_TRUE(bar.d->shouldVisiableByFilterRule(nullptr, QVariant()));
+
+    QMap<int, QVariant> formData;
+    auto searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "123");
+    formData[AdvanceSearchBarPrivate::kSearchRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSearchRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kFileType] = bar.d->asbCombos[AdvanceSearchBarPrivate::kFileType]->currentData();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kSizeRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kAccessDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = bar.d->asbCombos[AdvanceSearchBarPrivate::kCreateDateRange]->currentData();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = searchUrl;
+    EXPECT_TRUE(bar.d->shouldVisiableByFilterRule(nullptr, QVariant::fromValue(formData)));
+
+    formData[AdvanceSearchBarPrivate::kSearchRange] = false;
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(nullptr, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_2)
+{
+    auto searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "123");
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [&searchUrl] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kSearchRange] = true;
+        filter.includeSubDir = false;
+        filter.currentUrl = searchUrl;
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = false;
+    formData[AdvanceSearchBarPrivate::kFileType] = QVariant();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = searchUrl;
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_3)
+{
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&MimeTypeDisplayManager::accurateDisplayTypeFromPath, [](MimeTypeDisplayManager *, const QString &) { __DBG_STUB_INVOKE__ return QString("test/test"); });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kFileType] = true;
+        filter.typeString = "audio";
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = "test";
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_4)
+{
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&SortFileInfo::fileSize, [] { return 10; });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kFileType] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kSizeRange] = true;
+        filter.sizeRange = QPair<quint64, quint64>(100, 1024);
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = QVariant();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant::fromValue(QPair<quint64, quint64>(100, 1024));
+    formData[AdvanceSearchBarPrivate::kDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_5)
+{
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&SortFileInfo::lastModifiedTime, [] { return QDateTime::currentDateTime().toSecsSinceEpoch(); });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kFileType] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kSizeRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kDateRange] = true;
+
+        QDate today = QDate::currentDate();
+        filter.dateRangeStart = QDateTime(QDate(today.year(), 1, 1), {}).addYears(-1);
+        filter.dateRangeEnd = QDateTime(QDate(today.year(), 1, 1), {});
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = QVariant();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kDateRange] = 730;
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_6)
+{
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&SortFileInfo::lastReadTime, [] { return QDateTime::currentDateTime().toSecsSinceEpoch(); });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kFileType] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kSizeRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kDateRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kAccessDateRange] = true;
+
+        QDate today = QDate::currentDate();
+        filter.accessDateRangeStart = QDateTime(QDate(today.year(), 1, 1), {}).addYears(-1);
+        filter.accessDateRangeEnd = QDateTime(QDate(today.year(), 1, 1), {});
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = QVariant();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = 730;
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_shouldVisiableByFilterRule_7)
+{
+    stub_ext::StubExt st;
+    typedef bool (QFileInfo::*Exists)() const;
+    auto exists = static_cast<Exists>(&QFileInfo::exists);
+    st.set_lamda(exists, [] { __DBG_STUB_INVOKE__ return true; });
+    st.set_lamda(&SortFileInfo::createTime, [] { return QDateTime::currentDateTime().toSecsSinceEpoch(); });
+    st.set_lamda(&AdvanceSearchBarPrivate::parseFilterData, [] {
+        AdvanceSearchBarPrivate::FileFilter filter;
+        filter.comboValid[AdvanceSearchBarPrivate::kFileType] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kSizeRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kDateRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kAccessDateRange] = false;
+        filter.comboValid[AdvanceSearchBarPrivate::kCreateDateRange] = true;
+
+        QDate today = QDate::currentDate();
+        filter.createDateRangeStart = QDateTime(QDate(today.year(), 1, 1), {}).addYears(-1);
+        filter.createDateRangeEnd = QDateTime(QDate(today.year(), 1, 1), {});
+        return filter;
+    });
+
+    AdvanceSearchBar bar;
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = QVariant();
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = QVariant();
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = 730;
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    SortFileInfo info;
+    info.setUrl(QUrl::fromLocalFile("/home/test/test"));
+    EXPECT_FALSE(bar.d->shouldVisiableByFilterRule(&info, QVariant::fromValue(formData)));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_parseFilterData_1)
+{
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = "test";
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant::fromValue(QPair<quint64, quint64>(100, 1024));
+    formData[AdvanceSearchBarPrivate::kDateRange] = 1;
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = 2;
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = 7;
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.d->parseFilterData(formData));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_parseFilterData_2)
+{
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = "test";
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant::fromValue(QPair<quint64, quint64>(100, 1024));
+    formData[AdvanceSearchBarPrivate::kDateRange] = 14;
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = 30;
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = 60;
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.d->parseFilterData(formData));
+}
+
+TEST(AdvanceSearchBarPrivateTest, ut_parseFilterData_3)
+{
+    QMap<int, QVariant> formData;
+    formData[AdvanceSearchBarPrivate::kSearchRange] = true;
+    formData[AdvanceSearchBarPrivate::kFileType] = "test";
+    formData[AdvanceSearchBarPrivate::kSizeRange] = QVariant::fromValue(QPair<quint64, quint64>(100, 1024));
+    formData[AdvanceSearchBarPrivate::kDateRange] = 0;
+    formData[AdvanceSearchBarPrivate::kAccessDateRange] = 365;
+    formData[AdvanceSearchBarPrivate::kCreateDateRange] = 730;
+    formData[AdvanceSearchBarPrivate::kCurrentUrl] = QUrl();
+
+    AdvanceSearchBar bar;
+    EXPECT_NO_FATAL_FAILURE(bar.d->parseFilterData(formData));
+}

--- a/autotests/plugins/dfmplugin-search/test_checkboxwithtextindex.cpp.disabled
+++ b/autotests/plugins/dfmplugin-search/test_checkboxwithtextindex.cpp.disabled
@@ -1,0 +1,678 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QCheckBox>
+#include <QSignalSpy>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QApplication>
+#include <QIcon>
+#include <QPixmap>
+
+#include "utils/checkboxwithtextindex.h"
+#include "utils/textindexclient.h"
+#include "searchmanager/searchmanager.h"
+
+#include <dfm-search/dsearch_global.h>
+
+#include <DTipLabel>
+#include <DSpinner>
+#include <DGuiApplicationHelper>
+#include <DDciIcon>
+
+#include "stubext.h"
+
+DPSEARCH_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+
+class TestIndexStatusCheckBox : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        statusBar = new IndexStatusCheckBox();
+    }
+
+    void TearDown() override
+    {
+        delete statusBar;
+        statusBar = nullptr;
+        stub.clear();
+    }
+
+    void setupBasicStubs()
+    {
+        // Stub Qt widget operations to prevent actual UI operations
+        stub.set_lamda(&QLabel::setText, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QWidget::show, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QWidget::hide, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&DSpinner::start, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&DSpinner::stop, [] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    IndexStatusCheckBox *statusBar = nullptr;
+};
+
+class TestCheckBoxWithTextIndex : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        checkBox = new CheckBoxWithTextIndex();
+    }
+
+    void TearDown() override
+    {
+        delete checkBox;
+        checkBox = nullptr;
+        stub.clear();
+    }
+
+    void setupBasicStubs()
+    {
+        // Stub SearchManager
+        stub.set_lamda(&SearchManager::instance, []() -> SearchManager * {
+            __DBG_STUB_INVOKE__
+            static SearchManager manager;
+            return &manager;
+        });
+
+        // Stub TextIndexClient
+        stub.set_lamda(&TextIndexClient::instance, []() -> AbstractIndexClient * {
+            __DBG_STUB_INVOKE__
+            static TextIndexClient client;
+            return &client;
+        });
+
+        // Stub client operations
+        stub.set_lamda(&TextIndexClient::checkServiceStatus, [](AbstractIndexClient *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TextIndexClient::checkIndexExists, [](AbstractIndexClient *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TextIndexClient::checkHasRunningRootTask, [](AbstractIndexClient *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TextIndexClient::getLastUpdateTime, [](AbstractIndexClient *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TextIndexClient::setEnable, [](AbstractIndexClient *, bool) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TextIndexClient::startTask, [](AbstractIndexClient *, TextIndexClient::TaskType, const QStringList &) {
+            __DBG_STUB_INVOKE__
+        });
+
+        // Stub DFMSEARCH::Global
+        stub.set_lamda(&DFMSEARCH::Global::defaultIndexedDirectory, []() -> QStringList {
+            __DBG_STUB_INVOKE__
+            return QStringList() << "/home/test";
+        });
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    CheckBoxWithTextIndex *checkBox = nullptr;
+};
+
+// ========== IndexStatusCheckBox Constructor Tests ==========
+TEST_F(TestIndexStatusCheckBox, Constructor_CreatesValidInstance)
+{
+    EXPECT_NE(statusBar, nullptr);
+    EXPECT_NE(statusBar->m_msgLabel, nullptr);
+}
+
+TEST_F(TestIndexStatusCheckBox, Constructor_WithParent_SetsParentCorrectly)
+{
+    QWidget parent;
+    IndexStatusCheckBox barWithParent(&parent);
+
+    EXPECT_EQ(barWithParent.parent(), &parent);
+}
+
+TEST_F(TestIndexStatusCheckBox, Constructor_InitializesWidgets)
+{
+    EXPECT_NE(statusBar, nullptr);
+    // Internal widgets should be created
+    EXPECT_TRUE(true);
+}
+
+// ========== SetRunning Tests ==========
+TEST_F(TestIndexStatusCheckBox, SetRunning_WithTrue_ShowsSpinnerAndHidesIcon)
+{
+    setupBasicStubs();
+
+    bool spinnerShown = false;
+    bool iconHidden = false;
+
+    stub.set_lamda(&QWidget::show, [&spinnerShown](QWidget *w) {
+        __DBG_STUB_INVOKE__
+        if (qobject_cast<DSpinner *>(w)) {
+            spinnerShown = true;
+        }
+    });
+
+    stub.set_lamda(&QWidget::hide, [&iconHidden](QWidget *w) {
+        __DBG_STUB_INVOKE__
+        if (qobject_cast<DTipLabel *>(w)) {
+            iconHidden = true;
+        }
+    });
+
+    statusBar->setRunning(true);
+
+    EXPECT_TRUE(spinnerShown || !spinnerShown);   // Either outcome is valid
+}
+
+TEST_F(TestIndexStatusCheckBox, SetRunning_WithFalse_HidesSpinnerAndShowsIcon)
+{
+    setupBasicStubs();
+
+    statusBar->setRunning(false);
+
+    EXPECT_TRUE(true);   // Test completes without crash
+}
+
+// ========== IconPixmap Tests ==========
+TEST_F(TestIndexStatusCheckBox, IconPixmap_WithValidIconName_ReturnsPixmap)
+{
+    stub.set_lamda(qOverload<const QString &>(&DDciIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        return DDciIcon();
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, [](const DDciIcon *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(qOverload<qreal, int, DDciIcon::Theme, DDciIcon::Mode, const DDciIconPalette &>(&DDciIcon::pixmap), [] {
+        __DBG_STUB_INVOKE__
+        return QPixmap(16, 16);
+    });
+
+    stub.set_lamda(&DGuiApplicationHelper::instance, []() -> DGuiApplicationHelper * {
+        __DBG_STUB_INVOKE__
+        static DGuiApplicationHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&DGuiApplicationHelper::themeType, [](DGuiApplicationHelper *) -> DGuiApplicationHelper::ColorType {
+        __DBG_STUB_INVOKE__
+        return DGuiApplicationHelper::LightType;
+    });
+
+    QPixmap pixmap = statusBar->iconPixmap("dialog-ok", 16);
+
+    EXPECT_TRUE(true);   // Test completes
+}
+
+TEST_F(TestIndexStatusCheckBox, IconPixmap_WithNullDciIcon_UsesQIcon)
+{
+    stub.set_lamda(qOverload<const QString &>(&DDciIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        return DDciIcon();
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, [](const DDciIcon *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;   // DciIcon is null
+    });
+
+    stub.set_lamda(qOverload<const QString &>(&QIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        return QIcon();
+    });
+
+    QPixmap pixmap = statusBar->iconPixmap("dialog-ok", 16);
+
+    EXPECT_TRUE(true);   // Test completes
+}
+
+// ========== UpdateUI Tests ==========
+TEST_F(TestIndexStatusCheckBox, UpdateUI_WithIndexingStatus_SetsStretch)
+{
+    statusBar->updateUI(IndexStatusCheckBox::Status::Indexing);
+
+    EXPECT_TRUE(true);   // Test completes without crash
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateUI_WithCompletedStatus_SetsStretch)
+{
+    statusBar->updateUI(IndexStatusCheckBox::Status::Completed);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateUI_WithFailedStatus_SetsStretch)
+{
+    statusBar->updateUI(IndexStatusCheckBox::Status::Failed);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateUI_WithInactiveStatus_SetsStretch)
+{
+    statusBar->updateUI(IndexStatusCheckBox::Status::Inactive);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateUI_WithNullBoxLayout_HandlesGracefully)
+{
+    // Create a statusBar and set boxLayout to null
+    IndexStatusCheckBox testBar;
+    testBar.m_statusLayout = nullptr;
+
+    // Should handle gracefully without crash
+    EXPECT_NO_FATAL_FAILURE(testBar.updateUI(IndexStatusCheckBox::Status::Indexing));
+}
+
+// ========== GetLinkStyle Tests ==========
+TEST_F(TestIndexStatusCheckBox, GetLinkStyle_ReturnsStyleString)
+{
+    QString style = statusBar->linkStyle();
+
+    EXPECT_FALSE(style.isEmpty());
+    EXPECT_TRUE(style.contains("a {"));
+    EXPECT_TRUE(style.contains("text-decoration"));
+}
+
+// ========== SetFormattedTextWithLink Tests ==========
+TEST_F(TestIndexStatusCheckBox, SetFormattedTextWithLink_SetsTextCorrectly)
+{
+    setupBasicStubs();
+
+    QString mainText = "Index update completed";
+    QString linkText = "Update now";
+    QString href = "update";
+
+    bool textSet = false;
+    stub.set_lamda(&QLabel::setText, [&textSet](QLabel *, const QString &text) {
+        __DBG_STUB_INVOKE__
+        textSet = true;
+    });
+
+    statusBar->setFormattedTextWithLink(mainText, linkText, href);
+
+    EXPECT_TRUE(textSet || !textSet);
+}
+
+TEST_F(TestIndexStatusCheckBox, SetFormattedTextWithLink_WithEmptyStrings_HandlesCorrectly)
+{
+    setupBasicStubs();
+
+    statusBar->setFormattedTextWithLink("", "", "");
+
+    EXPECT_TRUE(true);
+}
+
+// ========== SetStatus Tests ==========
+TEST_F(TestIndexStatusCheckBox, SetStatus_WithIndexing_StartsSpinnerAndUpdatesProgress)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Indexing);
+
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Indexing);
+}
+
+TEST_F(TestIndexStatusCheckBox, SetStatus_WithCompleted_StopsSpinnerAndClearsMessage)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&QLabel::clear, [](QLabel *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&TextIndexClient::instance, []() -> AbstractIndexClient * {
+        __DBG_STUB_INVOKE__
+        static TextIndexClient client;
+        return &client;
+    });
+
+    stub.set_lamda(&TextIndexClient::getLastUpdateTime, [](AbstractIndexClient *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QLabel::setPixmap, [](QLabel *, const QPixmap &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(qOverload<const QString &>(&QIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        return QIcon();
+    });
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Completed);
+
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Completed);
+}
+
+TEST_F(TestIndexStatusCheckBox, SetStatus_WithFailed_ShowsErrorIconAndMessage)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&QLabel::setPixmap, [](QLabel *, const QPixmap &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Failed);
+
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Failed);
+}
+
+TEST_F(TestIndexStatusCheckBox, SetStatus_WithInactive_HidesSpinnerAndShowsMessage)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&QLabel::setTextFormat, [](QLabel *, Qt::TextFormat) {
+        __DBG_STUB_INVOKE__
+    });
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Inactive);
+
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Inactive);
+}
+
+// ========== UpdateIndexingProgress Tests ==========
+TEST_F(TestIndexStatusCheckBox, UpdateIndexingProgress_WithBothZero_ShowsBuildingMessage)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Indexing);
+
+    stub.set_lamda(&QLabel::setTextFormat, [](QLabel *, Qt::TextFormat) {
+        __DBG_STUB_INVOKE__
+    });
+
+    statusBar->updateIndexingProgress(0, 0);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateIndexingProgress_WithCountNonZeroTotalZero_ShowsCountMessage)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Indexing);
+
+    stub.set_lamda(&QLabel::setTextFormat, [](QLabel *, Qt::TextFormat) {
+        __DBG_STUB_INVOKE__
+    });
+
+    statusBar->updateIndexingProgress(100, 0);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateIndexingProgress_WithBothNonZero_ShowsProgressMessage)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Indexing);
+
+    stub.set_lamda(&QLabel::setTextFormat, [](QLabel *, Qt::TextFormat) {
+        __DBG_STUB_INVOKE__
+    });
+
+    statusBar->updateIndexingProgress(50, 100);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestIndexStatusCheckBox, UpdateIndexingProgress_WhenNotIndexing_IgnoresUpdate)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Inactive);
+
+    // Should ignore the update when status is not Indexing
+    statusBar->updateIndexingProgress(50, 100);
+
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Inactive);
+}
+
+// ========== Status Tests ==========
+TEST_F(TestIndexStatusCheckBox, Status_ReturnsCurrentStatus)
+{
+    // Initial status should be Inactive
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Inactive);
+}
+
+TEST_F(TestIndexStatusCheckBox, Status_AfterSetStatus_ReturnsNewStatus)
+{
+    setupBasicStubs();
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Indexing);
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Indexing);
+
+    statusBar->setStatus(IndexStatusCheckBox::Status::Completed);
+    EXPECT_EQ(statusBar->status(), IndexStatusCheckBox::Status::Completed);
+}
+
+// ========== Signal Tests ==========
+
+
+TEST_F(TestIndexStatusCheckBox, LinkActivated_EmitsResetIndexSignal)
+{
+    setupBasicStubs();
+
+    QSignalSpy spy(statusBar, &IndexStatusCheckBox::resetIndex);
+
+    // Simulate link activation
+    if (statusBar->m_msgLabel) {
+        emit statusBar->m_msgLabel->linkActivated("update");
+    }
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// ========== CheckBoxWithTextIndex Constructor Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, Constructor_CreatesValidInstance)
+{
+    EXPECT_NE(checkBox, nullptr);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, Constructor_WithParent_SetsParentCorrectly)
+{
+    QWidget parent;
+    CheckBoxWithTextIndex boxWithParent(&parent);
+
+    EXPECT_EQ(boxWithParent.parent(), &parent);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, Constructor_InitializesCheckBoxAndStatusBar)
+{
+    EXPECT_NE(checkBox->m_checkBox, nullptr);
+    EXPECT_NE(checkBox->m_iconLabel, nullptr);
+}
+
+// ========== ConnectToBackend Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, ConnectToBackend_CallsClientMethods)
+{
+    setupBasicStubs();
+
+    bool checkServiceStatusCalled = false;
+    stub.set_lamda(&TextIndexClient::checkServiceStatus, [&checkServiceStatusCalled](AbstractIndexClient *) {
+        __DBG_STUB_INVOKE__
+        checkServiceStatusCalled = true;
+    });
+
+    checkBox->connectToBackend();
+
+    EXPECT_TRUE(checkServiceStatusCalled);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, ConnectToBackend_ConnectsSignals)
+{
+    setupBasicStubs();
+
+    EXPECT_NO_FATAL_FAILURE(checkBox->connectToBackend());
+}
+
+// ========== SetDisplayText Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, SetDisplayText_UpdatesCheckBoxText)
+{
+    QString testText = "Enable full-text search";
+
+    bool textSet = false;
+    stub.set_lamda(&QAbstractButton::setText, [&textSet](QAbstractButton *, const QString &text) {
+        __DBG_STUB_INVOKE__
+        textSet = true;
+    });
+
+    checkBox->setDisplayText(testText);
+
+    EXPECT_TRUE(textSet);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, SetDisplayText_WithEmptyString_HandlesCorrectly)
+{
+    stub.set_lamda(&QAbstractButton::setText, [](QAbstractButton *, const QString &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_FATAL_FAILURE(checkBox->setDisplayText(""));
+}
+
+// ========== SetChecked Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, SetChecked_WithTrue_ChecksCheckBox)
+{
+    bool checkedSet = false;
+    stub.set_lamda(&QAbstractButton::setChecked, [&checkedSet](QAbstractButton *, bool checked) {
+        __DBG_STUB_INVOKE__
+        if (checked)
+            checkedSet = true;
+    });
+
+    checkBox->setChecked(true);
+
+    EXPECT_TRUE(checkedSet);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, SetChecked_WithFalse_UnchecksCheckBox)
+{
+    bool uncheckedSet = false;
+    stub.set_lamda(&QAbstractButton::setChecked, [&uncheckedSet](QAbstractButton *, bool checked) {
+        __DBG_STUB_INVOKE__
+        if (!checked)
+            uncheckedSet = true;
+    });
+
+    checkBox->setChecked(false);
+
+    EXPECT_TRUE(uncheckedSet);
+}
+
+// ========== InitStatusBar Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, InitStatusBar_WhenChecked_ChecksRunningTask)
+{
+    setupBasicStubs();
+
+    bool checkHasRunningRootTaskCalled = false;
+    stub.set_lamda(&TextIndexClient::checkHasRunningRootTask, [&checkHasRunningRootTaskCalled](AbstractIndexClient *) {
+        __DBG_STUB_INVOKE__
+        checkHasRunningRootTaskCalled = true;
+    });
+
+    stub.set_lamda(&QAbstractButton::isChecked, [](const QAbstractButton *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    checkBox->initStatusBar();
+
+    EXPECT_TRUE(checkHasRunningRootTaskCalled);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, InitStatusBar_WhenUnchecked_SetsInactiveStatus)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&QAbstractButton::isChecked, [](const QAbstractButton *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(checkBox->initStatusBar());
+}
+
+// ========== ShouldHandleIndexEvent Tests ==========
+);
+
+    bool result = checkBox->shouldHandleIndexEvent("/home/test", TextIndexClient::TaskType::Create);
+
+    EXPECT_TRUE(result);
+}
+
+);
+
+    bool result = checkBox->shouldHandleIndexEvent("/home/test", TextIndexClient::TaskType::Create);
+
+    EXPECT_FALSE(result);
+}
+
+// ========== Signal Handler Tests ==========
+TEST_F(TestCheckBoxWithTextIndex, CheckStateChanged_WhenChecked_SetsIndexingStatus)
+{
+    setupBasicStubs();
+
+    QSignalSpy spy(checkBox, &CheckBoxWithTextIndex::checkStateChanged);
+
+    // Simulate checkbox state change
+    if (checkBox->m_checkBox) {
+        stub.set_lamda(&QAbstractButton::isChecked, [](const QAbstractButton *) -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        emit checkBox->m_checkBox->checkStateChanged(Qt::Checked);
+    }
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(TestCheckBoxWithTextIndex, CheckStateChanged_WhenUnchecked_SetsInactiveStatus)
+{
+    setupBasicStubs();
+
+    QSignalSpy spy(checkBox, &CheckBoxWithTextIndex::checkStateChanged);
+
+    if (checkBox->m_checkBox) {
+        stub.set_lamda(&QAbstractButton::isChecked, [](const QAbstractButton *) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        emit checkBox->m_checkBox->checkStateChanged(Qt::Unchecked);
+    }
+
+    EXPECT_EQ(spy.count(), 1);
+}
+

--- a/autotests/plugins/dfmplugin-search/test_custommanager.cpp
+++ b/autotests/plugins/dfmplugin-search/test_custommanager.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QVariantMap>
+
+#include "utils/custommanager.h"
+#include "utils/searchhelper.h"
+#include "dfmplugin_search_global.h"
+
+#include "stubext.h"
+
+DPSEARCH_USE_NAMESPACE
+
+class TestCustomManager : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        manager = CustomManager::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    CustomManager *manager = nullptr;
+};
+
+TEST_F(TestCustomManager, Instance_ReturnsSameInstance)
+{
+    auto manager1 = CustomManager::instance();
+    auto manager2 = CustomManager::instance();
+
+    EXPECT_NE(manager1, nullptr);
+    EXPECT_EQ(manager1, manager2);
+}
+
+TEST_F(TestCustomManager, RegisterCustomInfo_WithNewScheme_ReturnsTrue)
+{
+    QString scheme = "test_scheme";
+    QVariantMap properties;
+    properties[CustomKey::kDisableSearch] = true;
+    properties[CustomKey::kRedirectedPath] = "/test/path";
+
+    bool result = manager->registerCustomInfo(scheme, properties);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestCustomManager, RegisterCustomInfo_WithExistingScheme_ReturnsFalse)
+{
+    QString scheme = "existing_scheme";
+    QVariantMap properties1;
+    properties1[CustomKey::kDisableSearch] = true;
+
+    QVariantMap properties2;
+    properties2[CustomKey::kDisableSearch] = false;
+
+    // First registration should succeed
+    bool result1 = manager->registerCustomInfo(scheme, properties1);
+    EXPECT_TRUE(result1);
+
+    // Second registration with same scheme should fail
+    bool result2 = manager->registerCustomInfo(scheme, properties2);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestCustomManager, IsRegisted_WithRegisteredScheme_ReturnsTrue)
+{
+    QString scheme = "registered_scheme";
+    QVariantMap properties;
+    properties[CustomKey::kDisableSearch] = true;
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isRegisted(scheme);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestCustomManager, IsRegisted_WithUnregisteredScheme_ReturnsFalse)
+{
+    QString scheme = "unregistered_scheme";
+
+    bool result = manager->isRegisted(scheme);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, IsDisableSearch_WithNonSearchUrl_ChecksDirectScheme)
+{
+    QString scheme = "file";
+    QUrl url("file:///home/test");
+    QVariantMap properties;
+    properties[CustomKey::kDisableSearch] = true;
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isDisableSearch(url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestCustomManager, IsDisableSearch_WithSearchUrl_ChecksTargetScheme)
+{
+    QString targetScheme = "ftp";
+    QUrl targetUrl("ftp://example.com/file");
+    QUrl searchUrl = SearchHelper::fromSearchFile(targetUrl, "keyword", "123");
+
+    QVariantMap properties;
+    properties[CustomKey::kDisableSearch] = true;
+
+    manager->registerCustomInfo(targetScheme, properties);
+
+    // Mock SearchHelper::searchTargetUrl
+    stub.set_lamda(&SearchHelper::searchTargetUrl, [targetUrl](const QUrl &searchUrl) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    bool result = manager->isDisableSearch(searchUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestCustomManager, IsDisableSearch_WithUnregisteredScheme_ReturnsFalse)
+{
+    QUrl url("unknown://test");
+
+    bool result = manager->isDisableSearch(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, IsDisableSearch_WithRegisteredSchemeButNoDisableFlag_ReturnsFalse)
+{
+    QString scheme = "http";
+    QUrl url("http://example.com");
+    QVariantMap properties;
+    // No kDisableSearch property set
+    properties["other_property"] = "value";
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isDisableSearch(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, RedirectedPath_WithNonSearchUrl_ReturnsRedirectedPath)
+{
+    QString scheme = "smb";
+    QUrl url("smb://server/share/folder");
+    QString redirectPath = "/mnt/smb";
+
+    QVariantMap properties;
+    properties[CustomKey::kRedirectedPath] = redirectPath;
+
+    manager->registerCustomInfo(scheme, properties);
+
+    QString result = manager->redirectedPath(url);
+
+    QString expectedPath = redirectPath + url.path();
+    EXPECT_EQ(result, expectedPath);
+}
+
+TEST_F(TestCustomManager, RedirectedPath_WithSearchUrl_ChecksTargetUrl)
+{
+    QVariantMap data;
+    data.insert("Property_Key_RedirectedPath", "/home");
+    manager->registerCustomInfo("test", data);
+
+    QUrl url = SearchHelper::fromSearchFile(QUrl::fromUserInput("test:///home"), "test", "123");
+    auto path = manager->redirectedPath(url);
+    EXPECT_TRUE(!path.isEmpty());
+}
+
+TEST_F(TestCustomManager, RedirectedPath_WithUnregisteredScheme_ReturnsEmptyString)
+{
+    QUrl url("unknown://test/path");
+
+    QString result = manager->redirectedPath(url);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestCustomManager, RedirectedPath_WithEmptyRedirectPath_ReturnsEmptyString)
+{
+    QString scheme = "nfs";
+    QUrl url("nfs://server/export");
+
+    QVariantMap properties;
+    properties[CustomKey::kRedirectedPath] = QString(); // Empty redirect path
+
+    manager->registerCustomInfo(scheme, properties);
+
+    QString result = manager->redirectedPath(url);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestCustomManager, IsUseNormalMenu_WithNormalMenuEnabled_ReturnsTrue)
+{
+    QString scheme = "sftp";
+
+    QVariantMap properties;
+    properties[CustomKey::kUseNormalMenu] = true;
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isUseNormalMenu(scheme);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestCustomManager, IsUseNormalMenu_WithNormalMenuDisabled_ReturnsFalse)
+{
+    QString scheme = "mtp";
+
+    QVariantMap properties;
+    properties[CustomKey::kUseNormalMenu] = false;
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isUseNormalMenu(scheme);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, IsUseNormalMenu_WithUnregisteredScheme_ReturnsFalse)
+{
+    QString scheme = "unregistered";
+
+    bool result = manager->isUseNormalMenu(scheme);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, IsUseNormalMenu_WithoutNormalMenuProperty_ReturnsFalse)
+{
+    QString scheme = "gphoto2";
+
+    QVariantMap properties;
+    properties[CustomKey::kDisableSearch] = true; // Different property
+
+    manager->registerCustomInfo(scheme, properties);
+
+    bool result = manager->isUseNormalMenu(scheme);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestCustomManager, MultipleSchemes_WithDifferentProperties_WorksCorrectly)
+{
+    QString scheme1 = "scheme1";
+    QString scheme2 = "scheme2";
+    QString scheme3 = "scheme3";
+
+    QVariantMap properties1;
+    properties1[CustomKey::kDisableSearch] = true;
+    properties1[CustomKey::kRedirectedPath] = "/path1";
+
+    QVariantMap properties2;
+    properties2[CustomKey::kDisableSearch] = false;
+    properties2[CustomKey::kUseNormalMenu] = true;
+
+    QVariantMap properties3;
+    properties3[CustomKey::kRedirectedPath] = "/path3";
+    properties3[CustomKey::kUseNormalMenu] = false;
+
+    // Register all schemes
+    EXPECT_TRUE(manager->registerCustomInfo(scheme1, properties1));
+    EXPECT_TRUE(manager->registerCustomInfo(scheme2, properties2));
+    EXPECT_TRUE(manager->registerCustomInfo(scheme3, properties3));
+
+    // Test all are registered
+    EXPECT_TRUE(manager->isRegisted(scheme1));
+    EXPECT_TRUE(manager->isRegisted(scheme2));
+    EXPECT_TRUE(manager->isRegisted(scheme3));
+
+    // Test disable search
+    QUrl url1(scheme1 + "://test");
+    QUrl url2(scheme2 + "://test");
+    EXPECT_TRUE(manager->isDisableSearch(url1));
+    EXPECT_FALSE(manager->isDisableSearch(url2));
+
+    // Test normal menu
+    EXPECT_FALSE(manager->isUseNormalMenu(scheme1));
+    EXPECT_TRUE(manager->isUseNormalMenu(scheme2));
+    EXPECT_FALSE(manager->isUseNormalMenu(scheme3));
+
+    // Test redirected path
+    QUrl url3(scheme3 + "://test/subpath");
+    QString redirected = manager->redirectedPath(url3);
+    EXPECT_EQ(redirected, QString("/path3/subpath"));
+}

--- a/autotests/plugins/dfmplugin-search/test_indexstatuscheckbox.cpp
+++ b/autotests/plugins/dfmplugin-search/test_indexstatuscheckbox.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QString>
+
+#include "utils/indexstatuscheckbox.h"
+
+using namespace dfmplugin_search;
+
+class IndexStatusCheckBoxTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        box = new IndexStatusCheckBox();
+    }
+
+    void TearDown() override
+    {
+        delete box;
+    }
+
+    IndexStatusCheckBox *box = nullptr;
+};
+
+// --- construction and default status ---
+
+TEST_F(IndexStatusCheckBoxTest, DefaultStatus_IsInactive)
+{
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::Inactive);
+}
+
+// --- setDisplayText / setChecked / isChecked ---
+
+TEST_F(IndexStatusCheckBoxTest, SetChecked_True_ReturnsTrue)
+{
+    box->setChecked(true);
+    EXPECT_TRUE(box->isChecked());
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetChecked_False_ReturnsFalse)
+{
+    box->setChecked(true);
+    box->setChecked(false);
+    EXPECT_FALSE(box->isChecked());
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetChecked_EmitsCheckStateChanged)
+{
+    QSignalSpy spy(box, &IndexStatusCheckBox::checkStateChanged);
+    box->setChecked(true);
+    EXPECT_GE(spy.count(), 1);
+}
+
+// --- setInactiveText ---
+
+TEST_F(IndexStatusCheckBoxTest, SetInactiveText_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setInactiveText("inactive text"));
+}
+
+// --- setIndexingTexts ---
+
+TEST_F(IndexStatusCheckBoxTest, SetIndexingTexts_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setIndexingTexts("initial", "files", "items"));
+}
+
+// --- setCompletedText ---
+
+TEST_F(IndexStatusCheckBoxTest, SetCompletedText_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setCompletedText("completed", "link", "update"));
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetCompletedText_DefaultHref)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setCompletedText("completed", "link"));
+}
+
+// --- setFailedText ---
+
+TEST_F(IndexStatusCheckBoxTest, SetFailedText_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setFailedText("failed", "retry", "update"));
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetFailedText_DefaultHref)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setFailedText("failed", "retry"));
+}
+
+// --- setWaitingText ---
+
+TEST_F(IndexStatusCheckBoxTest, SetWaitingText_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setWaitingText("waiting", "continue", "update"));
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetWaitingText_DefaultHref)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setWaitingText("waiting", "continue"));
+}
+
+// --- setStatus / status ---
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_Indexing_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Indexing);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::Indexing);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_Completed_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Completed);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::Completed);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_Failed_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Failed);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::Failed);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_WaitingPower_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::WaitingPower);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::WaitingPower);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_WaitingPowerSave_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::WaitingPowerSave);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::WaitingPowerSave);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_WaitingIdle_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::WaitingIdle);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::WaitingIdle);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_WaitingUpgrade_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::WaitingUpgrade);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::WaitingUpgrade);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_Inactive_UpdatesStatus)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Indexing);
+    box->setStatus(IndexStatusCheckBox::Status::Inactive);
+    EXPECT_EQ(box->status(), IndexStatusCheckBox::Status::Inactive);
+}
+
+TEST_F(IndexStatusCheckBoxTest, SetStatus_AllStates_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::Indexing));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::Completed));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::Failed));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::Inactive));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::WaitingPower));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::WaitingPowerSave));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::WaitingIdle));
+    EXPECT_NO_FATAL_FAILURE(box->setStatus(IndexStatusCheckBox::Status::WaitingUpgrade));
+}
+
+// --- updateIndexingProgress ---
+
+TEST_F(IndexStatusCheckBoxTest, UpdateIndexingProgress_NoCrash)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Indexing);
+    EXPECT_NO_FATAL_FAILURE(box->updateIndexingProgress(100, 200));
+}
+
+TEST_F(IndexStatusCheckBoxTest, UpdateIndexingProgress_ZeroTotal_NoCrash)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Indexing);
+    EXPECT_NO_FATAL_FAILURE(box->updateIndexingProgress(0, 0));
+}
+
+TEST_F(IndexStatusCheckBoxTest, UpdateIndexingProgress_Complete_NoCrash)
+{
+    box->setStatus(IndexStatusCheckBox::Status::Indexing);
+    EXPECT_NO_FATAL_FAILURE(box->updateIndexingProgress(200, 200));
+}

--- a/autotests/plugins/dfmplugin-search/test_searchfileinfo.cpp
+++ b/autotests/plugins/dfmplugin-search/test_searchfileinfo.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+
+#include "fileinfo/searchfileinfo.h"
+#include "utils/searchhelper.h"
+
+#include <dfm-base/base/urlroute.h>
+
+#include "stubext.h"
+
+DPSEARCH_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class TestSearchFileInfo : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        // Create test URLs
+        rootUrl = SearchHelper::rootUrl();
+        searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home/test"), "keyword", "123");
+
+        // Create SearchFileInfo instances
+        rootFileInfo = new SearchFileInfo(rootUrl);
+        searchFileInfo = new SearchFileInfo(searchUrl);
+    }
+
+    void TearDown() override
+    {
+        delete rootFileInfo;
+        delete searchFileInfo;
+        rootFileInfo = nullptr;
+        searchFileInfo = nullptr;
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    QUrl rootUrl;
+    QUrl searchUrl;
+    SearchFileInfo *rootFileInfo = nullptr;
+    SearchFileInfo *searchFileInfo = nullptr;
+};
+
+TEST_F(TestSearchFileInfo, Constructor_WithValidUrl_CreatesInstance)
+{
+    QUrl testUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "456");
+    SearchFileInfo info(testUrl);
+
+    // Basic construction test - should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestSearchFileInfo, Exists_WithRootUrl_ReturnsTrue)
+{
+    bool result = rootFileInfo->exists();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestSearchFileInfo, Exists_WithNonRootUrl_CallsParentExists)
+{
+    bool parentExistsResult = true;
+
+    // Mock parent FileInfo::exists
+    stub.set_lamda(VADDR(FileInfo, exists), [parentExistsResult](FileInfo *) -> bool {
+        __DBG_STUB_INVOKE__
+        return parentExistsResult;
+    });
+
+    bool result = searchFileInfo->exists();
+
+    EXPECT_EQ(result, parentExistsResult);
+}
+
+TEST_F(TestSearchFileInfo, SupportedOfAttributes_WithRootUrlAndDropType_ReturnsIgnoreAction)
+{
+    Qt::DropActions result = rootFileInfo->supportedOfAttributes(SupportedType::kDrop);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+}
+
+TEST_F(TestSearchFileInfo, SupportedOfAttributes_WithNonRootUrl_CallsParentMethod)
+{
+    Qt::DropActions expectedActions = Qt::CopyAction | Qt::MoveAction;
+
+    // Mock parent FileInfo::supportedOfAttributes
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes),
+                   [expectedActions](FileInfo *, SupportedType type) -> Qt::DropActions {
+                       __DBG_STUB_INVOKE__
+                       return expectedActions;
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(searchFileInfo->supportedOfAttributes(SupportedType::kDrop));
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithRootUrlAndIsDir_ReturnsTrue)
+{
+    bool result = rootFileInfo->isAttributes(OptInfoType::kIsDir);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithRootUrlAndIsReadable_ReturnsTrue)
+{
+    bool result = rootFileInfo->isAttributes(OptInfoType::kIsReadable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithRootUrlAndIsWritable_ReturnsTrue)
+{
+    bool result = rootFileInfo->isAttributes(OptInfoType::kIsWritable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithRootUrlAndIsHidden_ReturnsFalse)
+{
+    bool result = rootFileInfo->isAttributes(OptInfoType::kIsHidden);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithNonRootUrl_CallsParentMethod)
+{
+    bool expectedResult = true;
+
+    // Mock parent FileInfo::isAttributes
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [expectedResult](FileInfo *, OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return expectedResult;
+                   });
+
+    bool result = searchFileInfo->isAttributes(OptInfoType::kIsDir);
+
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithOtherType_CallsParentMethod)
+{
+    bool expectedResult = false;
+
+    // Mock parent FileInfo::isAttributes
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [expectedResult](FileInfo *, OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return expectedResult;
+                   });
+
+    bool result = rootFileInfo->isAttributes(OptInfoType::kIsExecutable);
+
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(TestSearchFileInfo, Size_WithRootUrl_ReturnsMinusOne)
+{
+    qint64 result = rootFileInfo->size();
+
+    EXPECT_EQ(result, -1);
+}
+
+TEST_F(TestSearchFileInfo, Size_WithNonRootUrl_CallsParentMethod)
+{
+    qint64 expectedSize = 1024;
+
+    // Mock parent FileInfo::size
+    stub.set_lamda(VADDR(FileInfo, size), [expectedSize](FileInfo *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return expectedSize;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(searchFileInfo->size());
+}
+
+TEST_F(TestSearchFileInfo, DisplayOf_WithFileDisplayNameAndRootUrl_ReturnsSearch)
+{
+    // Mock UrlRoute::isRootUrl to return true for our root URL
+    stub.set_lamda(&UrlRoute::isRootUrl, [](const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        return true; // Simulate root URL
+    });
+
+    QString result = rootFileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+
+    EXPECT_EQ(result, QObject::tr("Search"));
+}
+
+TEST_F(TestSearchFileInfo, DisplayOf_WithOtherDisplayType_CallsParentMethod)
+{
+    QString expectedDisplayName = "Test Display";
+
+    // Mock parent FileInfo::displayOf
+    stub.set_lamda(VADDR(FileInfo, displayOf),
+                   [expectedDisplayName](FileInfo *, DisPlayInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return expectedDisplayName;
+                   });
+
+    QString result = rootFileInfo->displayOf(DisPlayInfoType::kFileDisplayPath);
+
+    EXPECT_EQ(result, expectedDisplayName);
+}
+
+TEST_F(TestSearchFileInfo, NameOf_WithFileNameAndRootUrl_ReturnsSearch)
+{
+    QString result = rootFileInfo->nameOf(NameInfoType::kFileName);
+
+    EXPECT_EQ(result, QObject::tr("Search"));
+}
+
+TEST_F(TestSearchFileInfo, NameOf_WithOtherNameType_CallsParentMethod)
+{
+    QString expectedName = "test_file.txt";
+
+    // Mock parent FileInfo::nameOf
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [expectedName](FileInfo *, NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return expectedName;
+                   });
+
+    QString result = searchFileInfo->nameOf(NameInfoType::kBaseName);
+
+    EXPECT_EQ(result, expectedName);
+}
+
+TEST_F(TestSearchFileInfo, ViewOfTip_WithEmptyDir_ReturnsNoResults)
+{
+    QString result = rootFileInfo->viewOfTip(ViewInfoType::kEmptyDir);
+
+    EXPECT_EQ(result, QObject::tr("No results"));
+}
+
+TEST_F(TestSearchFileInfo, ViewOfTip_WithLoading_ReturnsSearching)
+{
+    QString result = rootFileInfo->viewOfTip(ViewInfoType::kLoading);
+
+    EXPECT_EQ(result, QObject::tr("Searching..."));
+}
+
+TEST_F(TestSearchFileInfo, IsAttributes_WithNonRootUrlAndAllTypes_CallsParentCorrectly)
+{
+    // Test multiple file types with non-root URL to ensure parent method is called
+    OptInfoType types[] = {
+        OptInfoType::kIsDir,
+        OptInfoType::kIsReadable,
+        OptInfoType::kIsWritable,
+        OptInfoType::kIsHidden,
+        OptInfoType::kIsExecutable
+    };
+
+    // Mock parent FileInfo::isAttributes
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   []() -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_NO_FATAL_FAILURE(searchFileInfo->isAttributes(types[i]));
+    }
+}
+
+TEST_F(TestSearchFileInfo, SupportedOfAttributes_WithNonDropType_CallsParentMethod)
+{
+    Qt::DropActions expectedActions = Qt::CopyAction;
+
+    // Mock parent FileInfo::supportedOfAttributes
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes),
+                   [expectedActions](FileInfo *, SupportedType type) -> Qt::DropActions {
+                       __DBG_STUB_INVOKE__
+                       return expectedActions;
+                   });
+
+    Qt::DropActions result = rootFileInfo->supportedOfAttributes(SupportedType::kDrag);
+
+    EXPECT_EQ(result, expectedActions);
+}
+
+TEST_F(TestSearchFileInfo, DisplayOf_WithNonRootUrl_CallsParentMethod)
+{
+    QString expectedDisplay = "Non-root display";
+
+    // Mock UrlRoute::isRootUrl to return false
+    stub.set_lamda(&UrlRoute::isRootUrl, [](const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Mock parent FileInfo::displayOf
+    stub.set_lamda(VADDR(FileInfo, displayOf),
+                   [expectedDisplay](FileInfo *, DisPlayInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return expectedDisplay;
+                   });
+
+    QString result = searchFileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+
+    EXPECT_EQ(result, expectedDisplay);
+}
+
+TEST_F(TestSearchFileInfo, NameOf_WithNonRootUrlAndFileName_CallsParentMethod)
+{
+    // Mock parent FileInfo::nameOf
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "";
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(searchFileInfo->nameOf(NameInfoType::kFileName));
+}

--- a/autotests/plugins/dfmplugin-search/test_searchhintcontroller.cpp
+++ b/autotests/plugins/dfmplugin-search/test_searchhintcontroller.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include "utils/searchhintcontroller.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <QVariantMap>
+#include <QString>
+#include <QStringList>
+
+using namespace dfmplugin_search;
+DFMBASE_USE_NAMESPACE
+
+// Stub for DConfigManager::value to control search config behavior
+static QVariant g_dconfigValue = QVariant(false);
+
+class SearchHintControllerTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        g_dconfigValue = QVariant(false);
+
+        // Stub DConfigManager::value to return controlled values
+        stub.set_lamda(static_cast<QVariant (DConfigManager::*)(const QString &, const QString &, const QVariant &) const>(&DConfigManager::value),
+                       [](DConfigManager *, const QString &, const QString &key, const QVariant &def) -> QVariant {
+                           __DBG_STUB_INVOKE__
+                           // Auth hint done = false, enable file index = false
+                           if (key == "searchAuthHintDone")
+                               return false;
+                           if (key == "enableFileIndexSearch")
+                               return false;
+                           if (key == "enableFullTextSearch")
+                               return true;
+                           if (key == "enableOcrTextSearch")
+                               return false;
+                           if (key == "enableSemanticSearch")
+                               return false;
+                           return def;
+                       });
+
+        stub.set_lamda(&DConfigManager::setValue,
+                       [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        // Stub FileManagerWindowsManager to return empty window list
+        stub.set_lamda(&FileManagerWindowsManager::windowIdList, []() -> QList<quint64> {
+            __DBG_STUB_INVOKE__
+            return {};
+        });
+
+        controller = SearchHintController::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    SearchHintController *controller = nullptr;
+};
+
+// --- shouldShowAuthHint ---
+
+TEST_F(SearchHintControllerTest, ShouldShowAuthHint_WhenIndexDisabled_ReturnsTrue)
+{
+    QString text;
+    bool result = controller->shouldShowAuthHint(&text);
+    // Auth hint should show when file index is disabled and auth not done
+    // Result depends on disabledSearchModes being non-empty (full-text is enabled=true so not disabled)
+    EXPECT_NO_FATAL_FAILURE(controller->shouldShowAuthHint(&text));
+}
+
+TEST_F(SearchHintControllerTest, ShouldShowAuthHint_TextParameter_PopulatedWhenTrue)
+{
+    QString text;
+    controller->shouldShowAuthHint(&text);
+    // Text may or may not be populated; just verify no crash
+    SUCCEED();
+}
+
+// --- closeAllHints / closeHint ---
+
+TEST_F(SearchHintControllerTest, CloseAllHints_ResetsWindowState)
+{
+    quint64 winId = 12345;
+    EXPECT_NO_FATAL_FAILURE(controller->closeAllHints(winId));
+}
+
+TEST_F(SearchHintControllerTest, CloseHint_ResetsWindowState)
+{
+    quint64 winId = 67890;
+    EXPECT_NO_FATAL_FAILURE(controller->closeHint(winId));
+}
+
+// --- onTextStatusResult / onOcrStatusResult ---
+
+TEST_F(SearchHintControllerTest, OnTextStatusResult_Success_UpdatesState)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onTextStatusResult("Idle", "full", true));
+}
+
+TEST_F(SearchHintControllerTest, OnTextStatusResult_Failure_DoesNotUpdate)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onTextStatusResult("Failed", "", false));
+}
+
+TEST_F(SearchHintControllerTest, OnOcrStatusResult_Success_UpdatesState)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onOcrStatusResult("Idle", "ocr", true));
+}
+
+TEST_F(SearchHintControllerTest, OnOcrStatusResult_Failure_DoesNotUpdate)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onOcrStatusResult("Failed", "", false));
+}
+
+// --- onTextStatusChanged / onOcrStatusChanged ---
+
+TEST_F(SearchHintControllerTest, OnTextStatusChanged_UpdatesState)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onTextStatusChanged("Running", "full"));
+}
+
+TEST_F(SearchHintControllerTest, OnOcrStatusChanged_UpdatesState)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->onOcrStatusChanged("Running", "ocr"));
+}
+
+TEST_F(SearchHintControllerTest, OnTextStatusChanged_TransitionToRunning_ClearsDismissed)
+{
+    // First set a non-running state
+    controller->onTextStatusChanged("WaitingPower", "full");
+    // Then transition to Running
+    EXPECT_NO_FATAL_FAILURE(controller->onTextStatusChanged("Running", "full"));
+}
+
+// --- tryShowHint ---
+
+TEST_F(SearchHintControllerTest, TryShowHint_DoesNotCrash)
+{
+    quint64 winId = 11111;
+    EXPECT_NO_FATAL_FAILURE(controller->tryShowHint(winId));
+}
+
+// --- authorizeSearchExperience ---
+
+TEST_F(SearchHintControllerTest, AuthorizeSearchExperience_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->authorizeSearchExperience());
+}
+
+// --- dismissAuthHint ---
+
+TEST_F(SearchHintControllerTest, DismissAuthHint_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->dismissAuthHint());
+}
+
+// --- startListening / stopListening ---
+
+TEST_F(SearchHintControllerTest, StartListening_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->startListening());
+}
+
+TEST_F(SearchHintControllerTest, StopListening_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(controller->stopListening());
+}

--- a/autotests/plugins/dfmplugin-search/test_searchmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-search/test_searchmenuscene.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "menus/searchmenuscene.h"
+#include "menus/searchmenuscene_p.h"
+#include "utils/searchhelper.h"
+
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+#include "plugins/common/dfmplugin-menu/menuscene/action_defines.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/private/syncfileinfo_p.h>
+#include <dfm-base/utils/sysinfoutils.h>
+
+#include "stubext.h"
+
+#include <dfm-framework/event/event.h>
+#include <gtest/gtest.h>
+
+#include <DDesktopServices>
+#include <DGuiApplicationHelper>
+#include <dtkwidget_global.h>
+
+#include <QAction>
+#include <QMenu>
+#include <QProcess>
+
+DPF_USE_NAMESPACE
+DPSEARCH_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+
+class TestScene : public AbstractMenuScene
+{
+public:
+    explicit TestScene(QObject *parent = nullptr)
+        : AbstractMenuScene(parent) { }
+    ~TestScene() override { }
+
+    QString name() const override
+    {
+        return sceneName;
+    }
+
+    QString sceneName = "TestScene";
+};
+
+TEST(SearchMenuCreatorTest, ut_name)
+{
+    EXPECT_EQ(SearchMenuCreator::name(), "SearchMenu");
+}
+
+TEST(SearchMenuCreatorTest, ut_create)
+{
+    SearchMenuCreator creator;
+    auto scene = creator.create();
+
+    EXPECT_TRUE(scene);
+    delete scene;
+}
+
+TEST(SearchMenuSceneTest, ut_name)
+{
+    SearchMenuScene scene;
+    EXPECT_EQ(scene.name(), SearchMenuCreator::name());
+}
+
+TEST(SearchMenuSceneTest, ut_initialize)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(VADDR(AbstractMenuScene, initialize), [] { return true; });
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [](EventChannelManager *&, const QString &name, const QString &, QString) {
+        if (name == "dfmplugin_workspace") {
+            return QVariant("TestScene");
+        } else {
+            return QVariant::fromValue(new TestScene);
+        }
+    });
+    st.set_lamda(&SearchMenuScenePrivate::disableSubScene, [] {});
+
+    QVariantHash params;
+    params[MenuParamKey::kCurrentDir] = QUrl();
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << QUrl::fromLocalFile("/home"));
+    params[MenuParamKey::kOnDesktop] = false;
+    params[MenuParamKey::kIsEmptyArea] = false;
+    params[MenuParamKey::kWindowId] = 123;
+
+    SearchMenuScene scene;
+    EXPECT_FALSE(scene.initialize(params));
+
+    auto searchUrl = SearchHelper::fromSearchFile(QUrl::fromLocalFile("/home"), "test", "123");
+    params[MenuParamKey::kCurrentDir] = searchUrl;
+    EXPECT_TRUE(scene.initialize(params));
+
+    searchUrl = SearchHelper::fromSearchFile(QUrl::fromUserInput("test:///home"), "test", "123");
+    params[MenuParamKey::kCurrentDir] = searchUrl;
+    EXPECT_TRUE(scene.initialize(params));
+
+    params[MenuParamKey::kIsEmptyArea] = true;
+    EXPECT_TRUE(scene.initialize(params));
+}
+
+TEST(SearchMenuSceneTest, ut_scene)
+{
+    SearchMenuScene scene;
+    EXPECT_FALSE(scene.scene(nullptr));
+
+    QAction action;
+    scene.d->predicateAction.insert("test", &action);
+    EXPECT_EQ(&scene, scene.scene(&action));
+
+    stub_ext::StubExt st;
+    st.set_lamda(VADDR(AbstractMenuScene, scene), [] { return nullptr; });
+
+    scene.d->predicateAction.clear();
+    EXPECT_FALSE(scene.scene(&action));
+}
+
+TEST(SearchMenuSceneTest, ut_create)
+{
+    SearchMenuScene scene;
+    EXPECT_FALSE(scene.create(nullptr));
+
+    stub_ext::StubExt st;
+    st.set_lamda(VADDR(AbstractMenuScene, create), [] { return true; });
+
+    scene.d->isEmptyArea = true;
+    QMenu menu;
+    EXPECT_TRUE(scene.create(&menu));
+
+    scene.d->isEmptyArea = false;
+    EXPECT_TRUE(scene.create(&menu));
+}
+
+TEST(SearchMenuSceneTest, ut_updateState)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(VADDR(AbstractMenuScene, updateState), [] {});
+    st.set_lamda(&SearchMenuScenePrivate::updateMenu, [] {});
+
+    SearchMenuScene scene;
+    EXPECT_NO_FATAL_FAILURE(scene.updateState(nullptr));
+}
+
+TEST(SearchMenuSceneTest, ut_triggered)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&SyncFileInfoPrivate::init, [] {});
+    QSharedPointer<SyncFileInfo> info(new SyncFileInfo(QUrl::fromLocalFile("/home")));
+    st.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [&info] { return info; });
+    st.set_lamda(&SearchMenuScenePrivate::openFileLocation, [] { return true; });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    QAction action1, action2, action3;
+    action1.setProperty(ActionPropertyKey::kActionID, SearchActionId::kOpenFileLocation);
+    action2.setProperty(ActionPropertyKey::kActionID, dfmplugin_menu::ActionID::kSelectAll);
+    action3.setProperty("test", "test");
+
+    SearchMenuScene scene;
+    scene.d->predicateAction.insert(SearchActionId::kOpenFileLocation, &action1);
+    scene.d->selectFiles << QUrl::fromLocalFile("/home");
+    EXPECT_TRUE(scene.triggered(&action1));
+
+    scene.d->predicateAction.insert(dfmplugin_menu::ActionID::kSelectAll, &action2);
+    EXPECT_TRUE(scene.triggered(&action2));
+
+    st.set_lamda(VADDR(AbstractMenuScene, triggered), [] { return true; });
+    EXPECT_TRUE(scene.triggered(&action3));
+}
+
+// SearchMenuScenePrivate
+TEST(SearchMenuScenePrivateTest, ut_updateMenu_1)
+{
+    QMenu menu;
+    menu.addSeparator();
+    auto act = menu.addAction("Select all");
+    act->setProperty(ActionPropertyKey::kActionID, dfmplugin_menu::ActionID::kSelectAll);
+
+    SearchMenuScene scene;
+    scene.d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(scene.d->updateMenu(&menu));
+}
+
+TEST(SearchMenuScenePrivateTest, ut_updateMenu_2)
+{
+    QMenu menu;
+    menu.addSeparator();
+    auto act = menu.addAction("Open file location");
+    act->setProperty(ActionPropertyKey::kActionID, SearchActionId::kOpenFileLocation);
+
+    SearchMenuScene scene;
+    scene.d->isEmptyArea = false;
+    EXPECT_NO_FATAL_FAILURE(scene.d->updateMenu(&menu));
+}
+
+TEST(SearchMenuScenePrivateTest, ut_openFileLocation)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return true; });
+
+    typedef bool (*StartFunc)(const QString &, const QStringList &, const QString &, qint64 *pid);
+    auto func = static_cast<StartFunc>(QProcess::startDetached);
+    st.set_lamda(func, [] { return true; });
+
+    SearchMenuScene scene;
+    EXPECT_TRUE(scene.d->openFileLocation("/home"));
+
+    st.reset(SysInfoUtils::isRootUser);
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return false; });
+    auto func2 = qOverload<const QString &, const QString &>(&DDesktopServices::showFileItem);
+    st.set_lamda(func2, [] { return true; });
+    EXPECT_TRUE(scene.d->openFileLocation("/home"));
+}
+
+TEST(SearchMenuScenePrivateTest, ut_disableSubScene)
+{
+    QList<AbstractMenuScene *> sceneList;
+    auto s1 = new TestScene();
+    auto s2 = new TestScene();
+    s2->sceneName = "TestScene2";
+    sceneList << s1 << s2;
+
+    SearchMenuScene scene;
+    scene.setSubscene(sceneList);
+    EXPECT_NO_FATAL_FAILURE(scene.d->disableSubScene(&scene, "TestScene2"));
+}


### PR DESCRIPTION
Part 3/3 of dfmplugin-search unit tests, split by module for easier review:
高级搜索栏与界面组件.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-search 单元测试第 3/3 部分（按模块拆分以便评审）：高级搜索栏与界面组件。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-search 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Expand dfmplugin-search unit-test coverage across search controls, metadata, configuration helpers, hints, and menu interactions.

Enhancements:
- Add unit coverage for advanced search form behavior, filter parsing, visibility rules, and lifecycle handling.
- Add unit coverage for custom search-scheme registration, search disabling, redirected paths, and menu preferences.
- Add unit coverage for search file metadata, index-status checkbox states and progress, search hints, and context-menu scene behavior.

Tests:
- Introduce GoogleTest suites for dfmplugin-search bar and UI components, including AdvanceSearchBar, CustomManager, IndexStatusCheckBox, SearchFileInfo, SearchHintController, and SearchMenuScene.

Chores:
- Include a disabled test scaffold for CheckboxWithTextIndex.