### PR TITLE
test: add unit tests for dfmplugin-sidebar (part 1/2: core)

### DIFF
--- a/autotests/plugins/dfmplugin-sidebar/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-sidebar/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-sidebar" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-sidebar")

--- a/autotests/plugins/dfmplugin-sidebar/main.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_sidebar)

--- a/autotests/plugins/dfmplugin-sidebar/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_realevents.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run SideBar::initialize() with REAL
+// SideBarEventReceiver::bindEvents() (NOT stubbed) so production connect
+// templates (EventChannelManager::connect<M>) execute.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "sidebar.h"
+#include "events/sidebareventreceiver.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_sidebar;
+
+class SideBarRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) { __DBG_STUB_INVOKE__ });
+        plugin = new SideBar();
+    }
+    void TearDown() override { stub.clear(); delete plugin; }
+    stub_ext::StubExt stub;
+    SideBar *plugin { nullptr };
+};
+
+TEST_F(SideBarRealEventsTest, Initialize_RunsRealBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(plugin->initialize());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebar.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebar.cpp
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "sidebar.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebarview.h"
+#include "utils/sidebarhelper.h"
+#include "events/sidebareventreceiver.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/widgets/filemanagerwindow.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QSignalSpy>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBar : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new SideBar();
+        ASSERT_NE(plugin, nullptr);
+
+        // Stub thread-related functions
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+            // Prevent thread start in unit tests
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBar *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBar, Initialize)
+{
+    bool connectCalled = false;
+
+    stub.set_lamda(&SideBarEventReceiver::instance, []() -> SideBarEventReceiver * {
+        __DBG_STUB_INVOKE__
+        static SideBarEventReceiver receiver;
+        return &receiver;
+    });
+
+    stub.set_lamda(&SideBarEventReceiver::bindEvents, [&connectCalled]() {
+        __DBG_STUB_INVOKE__
+        connectCalled = true;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(connectCalled);
+}
+
+TEST_F(UT_SideBar, Start_Success)
+{
+    bool addConfigCalled = false;
+    bool initSettingCalled = false;
+    bool registCustomCalled = false;
+    bool installFilterCalled = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::addConfig,
+                   [&addConfigCalled](DConfigManager *, const QString &, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addConfigCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::initDefaultSettingPanel, [&initSettingCalled]() {
+        __DBG_STUB_INVOKE__
+        initSettingCalled = true;
+    });
+
+    stub.set_lamda(&SideBarHelper::registCustomSettingItem, [&registCustomCalled]() {
+        __DBG_STUB_INVOKE__
+        registCustomCalled = true;
+    });
+
+    typedef bool (EventDispatcherManager::*InstallFilterFunc)(EventType, SideBar *, bool (SideBar::*)(quint64));
+    stub.set_lamda(static_cast<InstallFilterFunc>(&EventDispatcherManager::installEventFilter),
+                   [&installFilterCalled] {
+                       __DBG_STUB_INVOKE__
+                       installFilterCalled = true;
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addConfigCalled);
+    EXPECT_TRUE(initSettingCalled);
+    EXPECT_TRUE(registCustomCalled);
+    EXPECT_TRUE(installFilterCalled);
+}
+
+TEST_F(UT_SideBar, Start_ConfigFailed)
+{
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::addConfig,
+                   [](DConfigManager *, const QString &, QString *err) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (err)
+                           *err = "Test error";
+                       return false;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBar, OnWindowOpened)
+{
+    bool addSideBarCalled = false;
+    bool installSideBarCalled = false;
+    bool updateVisiableCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&SideBarHelper::addSideBar,
+                   [&addSideBarCalled](quint64, SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       addSideBarCalled = true;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::installSideBar,
+                   [&installSideBarCalled](FileManagerWindow *, QWidget *) {
+                       __DBG_STUB_INVOKE__
+                       installSideBarCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    stub.set_lamda(&SideBarHelper::preDefineItemProperties, []() -> QMap<QUrl, QPair<int, QVariantMap>> {
+        __DBG_STUB_INVOKE__
+        return QMap<QUrl, QPair<int, QVariantMap>>();
+    });
+
+    // Stub dpfSlotChannel for accessibility
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, QWidget *, char const(&)[14]);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();
+    });
+
+    stub.set_lamda(&SideBarView::updateSeparatorVisibleState, [] { __DBG_STUB_INVOKE__ });
+
+    plugin->onWindowOpened(testWindowId);
+
+    EXPECT_TRUE(addSideBarCalled);
+    EXPECT_TRUE(installSideBarCalled);
+    EXPECT_TRUE(updateVisiableCalled);
+}
+
+TEST_F(UT_SideBar, OnWindowClosed_LastWindow)
+{
+    bool removeSideBarCalled = false;
+    bool saveStateCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [testWindowId](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << testWindowId;
+                   });
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::saveStateWhenClose,
+                   [&saveStateCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       saveStateCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::removeSideBar,
+                   [&removeSideBarCalled](quint64) {
+                       __DBG_STUB_INVOKE__
+                       removeSideBarCalled = true;
+                   });
+
+    plugin->onWindowClosed(testWindowId);
+
+    EXPECT_TRUE(saveStateCalled);
+    EXPECT_TRUE(removeSideBarCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnWindowClosed_NotLastWindow)
+{
+    bool removeSideBarCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << 1 << 2;   // Multiple windows
+                   });
+
+    stub.set_lamda(&SideBarHelper::removeSideBar,
+                   [&removeSideBarCalled](quint64) {
+                       __DBG_STUB_INVOKE__
+                       removeSideBarCalled = true;
+                   });
+
+    plugin->onWindowClosed(testWindowId);
+
+    EXPECT_TRUE(removeSideBarCalled);
+}
+
+TEST_F(UT_SideBar, OnConfigChanged_VisiableKey)
+{
+    bool updateVisiableCalled = false;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << 1;
+                   });
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    plugin->onConfigChanged(ConfigInfos::kConfName, ConfigInfos::kVisiableKey);
+
+    EXPECT_TRUE(updateVisiableCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnConfigChanged_WrongConfig)
+{
+    bool updateVisiableCalled = false;
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    plugin->onConfigChanged("wrong.config", ConfigInfos::kVisiableKey);
+
+    EXPECT_FALSE(updateVisiableCalled);
+}
+
+TEST_F(UT_SideBar, OnAboutToShowSettingDialog)
+{
+    bool resetPanelCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::resetSettingPanel,
+                   [&resetPanelCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       resetPanelCalled = true;
+                   });
+
+    bool result = plugin->onAboutToShowSettingDialog(testWindowId);
+
+    EXPECT_FALSE(result);   // Always returns false
+    EXPECT_TRUE(resetPanelCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnAboutToShowSettingDialog_InvalidWindow)
+{
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    bool result = plugin->onAboutToShowSettingDialog(99999);
+
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebareventcaller.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebareventcaller.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/sidebareventcaller.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarEventCaller : public testing::Test
+{
+protected:
+    virtual void SetUp() override {}
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarEventCaller, SendItemActived)
+{
+    bool isCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedWindowId, &capturedUrl](EventDispatcherManager *, EventType type,
+                                                       quint64 windowId, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kChangeCurrentUrl) {
+            isCalled = true;
+            capturedWindowId = windowId;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    quint64 testWindowId = 12345;
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+
+    SideBarEventCaller::sendItemActived(testWindowId, testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedWindowId, testWindowId);
+    EXPECT_EQ(capturedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendEject)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl](EventDispatcherManager *, const QString &space,
+                                   const QString &topic, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (space == "dfmplugin_sidebar" && topic == "signal_Item_EjectClicked") {
+            isCalled = true;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    QUrl deviceUrl = QUrl::fromLocalFile("/dev/sdb1");
+    SideBarEventCaller::sendEject(deviceUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, deviceUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenWindow_NewWindow)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+    bool capturedIsNew = false;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, QUrl, const bool &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl, &capturedIsNew](EventDispatcherManager *, EventType type,
+                                                    const QUrl &url, bool isNew) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewWindow) {
+            isCalled = true;
+            capturedUrl = url;
+            capturedIsNew = isNew;
+        }
+        return true;
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/newwindow");
+    SideBarEventCaller::sendOpenWindow(testUrl, true);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_TRUE(capturedIsNew);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenWindow_ExistingWindow)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+    bool capturedIsNew = true;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, QUrl, const bool &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl, &capturedIsNew](EventDispatcherManager *, EventType type,
+                                                    const QUrl &url, bool isNew) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewWindow) {
+            isCalled = true;
+            capturedUrl = url;
+            capturedIsNew = isNew;
+        }
+        return true;
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/existing");
+    SideBarEventCaller::sendOpenWindow(testUrl, false);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_FALSE(capturedIsNew);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenTab)
+{
+    bool isCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedWindowId, &capturedUrl](EventDispatcherManager *, EventType type,
+                                                       quint64 windowId, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewTab) {
+            isCalled = true;
+            capturedWindowId = windowId;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    quint64 testWindowId = 54321;
+    QUrl testUrl = QUrl::fromLocalFile("/home/newtab");
+
+    SideBarEventCaller::sendOpenTab(testWindowId, testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedWindowId, testWindowId);
+    EXPECT_EQ(capturedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendShowFilePropertyDialog)
+{
+    bool isCalled = false;
+    QList<QUrl> capturedUrls;
+
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &,
+                                                       QList<QUrl>, QVariantHash &&);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [&isCalled, &capturedUrls](EventChannelManager *, const QString &space,
+                                     const QString &topic, QList<QUrl> urls, QVariantHash) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (space == "dfmplugin_propertydialog" && topic == "slot_PropertyDialog_Show") {
+            isCalled = true;
+            capturedUrls = urls;
+        }
+        return QVariant();
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/properties");
+    SideBarEventCaller::sendShowFilePropertyDialog(testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrls.size(), 1);
+    EXPECT_EQ(capturedUrls[0], testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendCheckTabAddable_True)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [](EventChannelManager *, const QString &, const QString &, quint64) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    bool result = SideBarEventCaller::sendCheckTabAddable(99999);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarEventCaller, SendCheckTabAddable_False)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [](EventChannelManager *, const QString &, const QString &, quint64) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    bool result = SideBarEventCaller::sendCheckTabAddable(88888);
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebareventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebareventreceiver.cpp
@@ -1,0 +1,420 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/sidebareventreceiver.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "utils/sidebarhelper.h"
+#include "utils/sidebarinfocachemananger.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        receiver = SideBarEventReceiver::instance();
+        ASSERT_NE(receiver, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarEventReceiver, Instance)
+{
+    auto ins1 = SideBarEventReceiver::instance();
+    auto ins2 = SideBarEventReceiver::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarEventReceiver, BindEvents)
+{
+    EXPECT_NO_THROW(receiver->bindEvents());
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSetContextMenuEnable_True)
+{
+    SideBarHelper::contextMenuEnabled = false;
+
+    receiver->handleSetContextMenuEnable(true);
+
+    EXPECT_TRUE(SideBarHelper::contextMenuEnabled);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSetContextMenuEnable_False)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    receiver->handleSetContextMenuEnable(false);
+
+    EXPECT_FALSE(SideBarHelper::contextMenuEnabled);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemHidden)
+{
+    bool setVisiableCalled = false;
+    QUrl capturedUrl;
+    bool capturedVisible = false;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::setItemVisiable,
+                   [&setVisiableCalled, &capturedUrl, &capturedVisible](SideBarWidget *, const QUrl &url, bool visible) {
+                       __DBG_STUB_INVOKE__
+                       setVisiableCalled = true;
+                       capturedUrl = url;
+                       capturedVisible = visible;
+                   });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    receiver->handleItemHidden(testUrl, true);
+
+    EXPECT_TRUE(setVisiableCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_TRUE(capturedVisible);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemTriggerEdit)
+{
+    bool editCalled = false;
+    QUrl capturedUrl;
+
+    quint64 testWindowId = 12345;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [testWindowId](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    stub.set_lamda(&SideBarWidget::editItem,
+                   [&editCalled, &capturedUrl](SideBarWidget *, const QUrl &url) {
+                       __DBG_STUB_INVOKE__
+                       editCalled = true;
+                       capturedUrl = url;
+                   });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/edit");
+    receiver->handleItemTriggerEdit(testWindowId, testUrl);
+
+    EXPECT_TRUE(editCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSidebarUpdateSelection)
+{
+    bool updateCalled = false;
+
+    quint64 testWindowId = 54321;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [testWindowId](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    stub.set_lamda(&SideBarWidget::updateSelection,
+                   [&updateCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       updateCalled = true;
+                   });
+
+    receiver->handleSidebarUpdateSelection(testWindowId);
+
+    EXPECT_TRUE(updateCalled);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_AlreadyExists)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/exists");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;   // Item already exists
+                   });
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_InvalidItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/invalid");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;   // Failed to create item
+    });
+
+    QVariantMap properties;
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_Success)
+{
+    bool addCacheCalled = false;
+    bool addItemCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/newadd");
+
+    SideBarItem *mockItem = new SideBarItem(testUrl);
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [mockItem](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return mockItem;
+    });
+
+    stub.set_lamda(&SideBarItem::group, []() -> QString {
+        __DBG_STUB_INVOKE__
+        return DefaultGroup::kCommon;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::addItemInfoCache,
+                   [&addCacheCalled](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addCacheCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::addItem,
+                   [&addItemCalled](SideBarWidget *, SideBarItem *, bool) -> int {
+                       __DBG_STUB_INVOKE__
+                       addItemCalled = true;
+                       return 0;   // Success
+                   });
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(VADDR(SideBarWidget, currentUrl), []() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addCacheCalled);
+    EXPECT_TRUE(addItemCalled);
+
+    delete mockWidget;
+    // mockItem will be managed by widget, don't delete
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemRemove_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleItemRemove(testUrl);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemRemove_Success)
+{
+    bool removeCacheCalled = false;
+    bool removeRowCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &)>(&SideBarInfoCacheMananger::removeItemInfoCache),
+                   [&removeCacheCalled](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeCacheCalled = true;
+                       return true;
+                   });
+
+    // Mock kSidebarModelIns to be non-null
+    SideBarModel mockModel;
+    SideBarWidget::kSidebarModelIns = QSharedPointer<SideBarModel>(&mockModel, [](SideBarModel *) {});
+
+    stub.set_lamda(&SideBarModel::removeRow,
+                   [&removeRowCalled](SideBarModel *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeRowCalled = true;
+                       return true;
+                   });
+
+    bool result = receiver->handleItemRemove(testUrl);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(removeCacheCalled);
+    EXPECT_TRUE(removeRowCalled);
+
+    // Cleanup
+    SideBarWidget::kSidebarModelIns.reset();
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemUpdate_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/updatenotfound");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QVariantMap properties;
+    bool result = receiver->handleItemUpdate(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemInsert_Success)
+{
+    bool insertCacheCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/insert");
+
+    SideBarItem *mockItem = new SideBarItem(testUrl);
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [mockItem](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return mockItem;
+    });
+
+    stub.set_lamda(&SideBarItem::group, []() -> QString {
+        __DBG_STUB_INVOKE__
+        return DefaultGroup::kCommon;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::insertItemInfoCache,
+                   [&insertCacheCalled](SideBarInfoCacheMananger *, int, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       insertCacheCalled = true;
+                       return true;
+                   });
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::insertItem,
+                   [](SideBarWidget *, int, SideBarItem *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;   // Success
+                   });
+    stub.set_lamda(&SideBarWidget::insertItem, [] {__DBG_STUB_INVOKE__ return true;});
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemInsert(0, testUrl, properties);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(insertCacheCalled);
+
+    delete mockWidget;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarhelper.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarhelper.cpp
@@ -1,0 +1,803 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarhelper.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "treeviews/sidebaritem.h"
+#include "treeviews/sidebarwidget.h"
+#include "events/sidebareventcaller.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/settingdialog/customsettingitemregister.h>
+#include <dfm-base/base/configs/settingbackend.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/utils/networkutils.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QIcon>
+#include <QMutex>
+#include <QMenu>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Clear static map before each test
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    Application app;
+};
+
+TEST_F(UT_SideBarHelper, AllSideBar_Empty)
+{
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    QList<SideBarWidget *> list = SideBarHelper::allSideBar();
+
+    // May be empty or contain widgets
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, AddSideBar)
+{
+    quint64 windowId = 12345;
+    SideBarWidget *widget = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, AddSideBar_Duplicate)
+{
+    quint64 windowId = 54321;
+    SideBarWidget *widget1 = new SideBarWidget();
+    SideBarWidget *widget2 = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget1);
+    SideBarHelper::addSideBar(windowId, widget2);   // Should not add duplicate
+
+    EXPECT_TRUE(true);
+
+    delete widget1;
+    delete widget2;
+}
+
+TEST_F(UT_SideBarHelper, RemoveSideBar)
+{
+    quint64 windowId = 99999;
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::removeSideBar(windowId);
+
+    // Should not crash even if not exists
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RemoveSideBar_Existing)
+{
+    quint64 windowId = 88888;
+    SideBarWidget *widget = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget);
+    SideBarHelper::removeSideBar(windowId);
+
+    EXPECT_TRUE(true);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, WindowId)
+{
+    QWidget *widget = new QWidget();
+    quint64 testWindowId = 77777;
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowId,
+                   [testWindowId](FileManagerWindowsManager *, const QWidget *) -> quint64 {
+                       __DBG_STUB_INVOKE__
+                       return testWindowId;
+                   });
+
+    quint64 result = SideBarHelper::windowId(widget);
+
+    EXPECT_EQ(result, testWindowId);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, PreDefineItemProperties_Empty)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObjs,
+                   [](std::function<bool(PluginMetaObjectPointer)>) -> QList<PluginMetaObjectPointer> {
+                       __DBG_STUB_INVOKE__
+                       return QList<PluginMetaObjectPointer>();
+                   });
+
+    QMap<QUrl, QPair<int, QVariantMap>> properties = SideBarHelper::preDefineItemProperties();
+
+    EXPECT_TRUE(properties.isEmpty());
+}
+
+TEST_F(UT_SideBarHelper, CreateItemByInfo_Basic)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.displayName = "TestItem";
+    info.group = DefaultGroup::kCommon;
+    info.icon = QIcon::fromTheme("folder");
+    info.flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    info.isEjectable = false;
+
+    SideBarItem *item = SideBarHelper::createItemByInfo(info);
+
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), info.displayName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarHelper, CreateItemByInfo_WithEjectable)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/media/usb");
+    info.displayName = "USB Drive";
+    info.group = DefaultGroup::kDevice;
+    info.icon = QIcon::fromTheme("drive-removable-media");
+    info.flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    info.isEjectable = true;
+
+    stub.set_lamda(&SideBarEventCaller::sendEject, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    SideBarItem *item = SideBarHelper::createItemByInfo(info);
+
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), info.displayName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Tag)
+{
+    QString group = DefaultGroup::kTag;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsEnabled);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsDropEnabled);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Common)
+{
+    QString group = DefaultGroup::kCommon;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsEnabled);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsDropEnabled);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Device)
+{
+    QString group = DefaultGroup::kDevice;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_EQ(separator->flags(), Qt::NoItemFlags);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, MakeItemIdentifier)
+{
+    QString group = DefaultGroup::kCommon;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+
+    QString identifier = SideBarHelper::makeItemIdentifier(group, url);
+
+    EXPECT_FALSE(identifier.isEmpty());
+    EXPECT_TRUE(identifier.contains(group));
+    EXPECT_TRUE(identifier.contains(url.url()));
+}
+
+TEST_F(UT_SideBarHelper, DefaultCdAction_ValidUrl)
+{
+    quint64 windowId = 12345;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendItemActived,
+                   [&sendCalled](quint64, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                   });
+
+    SideBarHelper::defaultCdAction(windowId, url);
+
+    EXPECT_TRUE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, DefaultCdAction_EmptyUrl)
+{
+    quint64 windowId = 12345;
+    QUrl emptyUrl;
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendItemActived,
+                   [&sendCalled](quint64, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                   });
+
+    SideBarHelper::defaultCdAction(windowId, emptyUrl);
+
+    EXPECT_FALSE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, DefaultContextMenu)
+{
+    quint64 windowId = 12345;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+    QPoint globalPos(100, 100);
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenWindow, [](const QUrl &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenTab, [](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendCheckTabAddable, [](quint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendShowFilePropertyDialog, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&NetworkUtils::checkFtpOrSmbBusy, [](NetworkUtils *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    using ExecFunc = QAction *(QMenu::*)(const QPoint &, QAction *);
+    stub.set_lamda(static_cast<ExecFunc>(&QMenu::exec), [] {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    // Should create and show menu without crashing
+    SideBarHelper::defaultContextMenu(windowId, url, globalPos);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, BindSetting)
+{
+    QString itemVisiableSettingKey = "test.setting.key";
+    QString itemVisiableControlKey = "test.control.key";
+
+    stub.set_lamda(&SettingBackend::instance, []() -> SettingBackend * {
+        __DBG_STUB_INVOKE__
+        static SettingBackend backend;
+        return &backend;
+    });
+
+    typedef void (SettingBackend::*Func)(const QString &, SettingBackend::GetOptFunc, SettingBackend::SaveOptFunc);
+    stub.set_lamda(static_cast<Func>(&SettingBackend::addSettingAccessor),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["test.control.key"] = true;
+        return map;
+    });
+
+    SideBarHelper::bindSetting(itemVisiableSettingKey, itemVisiableControlKey);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RemovebindingSetting)
+{
+    QString itemVisiableSettingKey = "test.remove.key";
+
+    stub.set_lamda(&SettingBackend::instance, []() -> SettingBackend * {
+        __DBG_STUB_INVOKE__
+        static SettingBackend backend;
+        return &backend;
+    });
+
+    stub.set_lamda(&SettingBackend::removeSettingAccessor,
+                   [](SettingBackend *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::removebindingSetting(itemVisiableSettingKey);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, InitDefaultSettingPanel)
+{
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::addGroup,
+                   [](SettingJsonGenerator *, const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::initDefaultSettingPanel();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_QuickAccess)
+{
+    QString group = DefaultGroup::kCommon;
+    QString key = "test.quick.key";
+    QString value = "Quick Access Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Device)
+{
+    QString group = DefaultGroup::kDevice;
+    QString key = "test.device.key";
+    QString value = "Device Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Network)
+{
+    QString group = DefaultGroup::kNetwork;
+    QString key = "test.network.key";
+    QString value = "Network Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Tag)
+{
+    QString group = DefaultGroup::kTag;
+    QString key = "test.tag.key";
+    QString value = "Tag Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, RemoveItemFromSetting)
+{
+    QString key = "test.remove.setting.key";
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::removeConfig,
+                   [](SettingJsonGenerator *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::removeItemFromSetting(key);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RegistCustomSettingItem)
+{
+    stub.set_lamda(&CustomSettingItemRegister::instance, []() -> CustomSettingItemRegister * {
+        __DBG_STUB_INVOKE__
+        static CustomSettingItemRegister reg;
+        return &reg;
+    });
+
+    stub.set_lamda(&CustomSettingItemRegister::registCustomSettingItemType,
+                   [](CustomSettingItemRegister *, const QString &, std::function<QPair<QWidget *, QWidget *>(QObject *)>) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::registCustomSettingItem();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, HiddenRules)
+{
+    QVariantMap mockRules;
+    mockRules["key1"] = false;
+    mockRules["key2"] = true;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [mockRules](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(mockRules);
+                   });
+
+    QVariantMap rules = SideBarHelper::hiddenRules();
+
+    EXPECT_EQ(rules.size(), mockRules.size());
+}
+
+TEST_F(UT_SideBarHelper, GroupExpandRules)
+{
+    QVariantMap mockRules;
+    mockRules[DefaultGroup::kCommon] = true;
+    mockRules[DefaultGroup::kDevice] = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [mockRules](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(mockRules);
+                   });
+
+    QVariantMap rules = SideBarHelper::groupExpandRules();
+
+    EXPECT_EQ(rules.size(), mockRules.size());
+}
+
+TEST_F(UT_SideBarHelper, SaveGroupsStateToConfig)
+{
+    QVariantMap inputVar;
+    inputVar[DefaultGroup::kCommon] = true;
+    inputVar[DefaultGroup::kDevice] = false;
+
+    bool setValueCalled = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(QVariantMap());
+                   });
+
+    stub.set_lamda(&DConfigManager::setValue,
+                   [&setValueCalled](DConfigManager *, const QString &, const QString &, const QVariant &) {
+                       __DBG_STUB_INVOKE__
+                       setValueCalled = true;
+                   });
+
+    SideBarHelper::saveGroupsStateToConfig(inputVar);
+
+    EXPECT_TRUE(setValueCalled);
+}
+
+TEST_F(UT_SideBarHelper, OpenFolderInASeparateProcess)
+{
+    QUrl url = QUrl::fromLocalFile("/home/separate");
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenWindow,
+                   [&sendCalled](const QUrl &, bool isNew) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                       EXPECT_FALSE(isNew);
+                   });
+
+    SideBarHelper::openFolderInASeparateProcess(url);
+
+    EXPECT_TRUE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, ContextMenuEnabled_Static)
+{
+    // Test static variable
+    SideBarHelper::contextMenuEnabled = true;
+    EXPECT_TRUE(SideBarHelper::contextMenuEnabled);
+
+    SideBarHelper::contextMenuEnabled = false;
+    EXPECT_FALSE(SideBarHelper::contextMenuEnabled);
+
+    // Restore default
+    SideBarHelper::contextMenuEnabled = true;
+}
+
+TEST_F(UT_SideBarHelper, Mutex)
+{
+    QMutex &m1 = SideBarHelper::mutex();
+    QMutex &m2 = SideBarHelper::mutex();
+
+    // Should return same mutex instance
+    EXPECT_EQ(&m1, &m2);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarinfocachemananger.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarinfocachemananger.cpp
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+
+class UT_SideBarInfoCacheMananger : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = SideBarInfoCacheMananger::instance();
+        ASSERT_NE(manager, nullptr);
+
+        // Clear any existing cache for clean test state
+        manager->clearLastSettingKey();
+        manager->clearLastSettingBindingKey();
+        manager->cacheInfoMap.clear();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarInfoCacheMananger *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarInfoCacheMananger, Instance)
+{
+    auto ins1 = SideBarInfoCacheMananger::instance();
+    auto ins2 = SideBarInfoCacheMananger::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AddItemInfoCache_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "Test";
+
+    bool result = manager->addItemInfoCache(info);
+    EXPECT_TRUE(result);
+
+    EXPECT_TRUE(manager->contains(info));
+    EXPECT_TRUE(manager->contains(info.url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AddItemInfoCache_Duplicate)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/duplicate");
+    info.group = DefaultGroup::kDevice;
+    info.displayName = "Duplicate";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_TRUE(manager->addItemInfoCache(info));
+
+    // Adding same item again should fail
+    bool result = manager->addItemInfoCache(info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_Success)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/first");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "First";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/second");
+    info2.group = DefaultGroup::kCommon;
+    info2.displayName = "Second";
+
+    manager->addItemInfoCache(info1);
+
+    // Insert at index 0
+    bool result = manager->insertItemInfoCache(0, info2);
+    EXPECT_TRUE(result);
+
+    auto cacheList = manager->indexCacheList(DefaultGroup::kCommon);
+    EXPECT_EQ(cacheList.size(), 2);
+    EXPECT_EQ(cacheList[0].url, info2.url);
+    EXPECT_EQ(cacheList[1].url, info1.url);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_InvalidIndex)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.group = DefaultGroup::kNetwork;
+    info.displayName = "Test";
+
+    // Insert at out-of-range index should append
+    bool result = manager->insertItemInfoCache(999, info);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_NegativeIndex)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/negative");
+    info.group = DefaultGroup::kTag;
+    info.displayName = "Negative";
+
+    // Insert at negative index should append
+    bool result = manager->insertItemInfoCache(-1, info);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByGroupAndUrl_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/remove");
+    info.group = DefaultGroup::kOther;
+    info.displayName = "Remove";
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(info.url));
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->removeItemInfoCache(info.group, info.url);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(manager->contains(info.url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByGroupAndUrl_NotFound)
+{
+    QUrl nonExistentUrl = QUrl::fromLocalFile("/non/existent");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = manager->removeItemInfoCache(DefaultGroup::kCommon, nonExistentUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByUrl_Success)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/multi1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Multi1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/multi1");
+    info2.group = DefaultGroup::kDevice;
+    info2.displayName = "Multi2";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1.path() == url2.path();
+    });
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    // Remove by URL should remove from all groups
+    bool result = manager->removeItemInfoCache(info1.url);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByGroupAndUrl_Success)
+{
+    ItemInfo oldInfo;
+    oldInfo.url = QUrl::fromLocalFile("/home/update");
+    oldInfo.group = DefaultGroup::kCommon;
+    oldInfo.displayName = "OldName";
+
+    manager->addItemInfoCache(oldInfo);
+
+    ItemInfo newInfo = oldInfo;
+    newInfo.displayName = "NewName";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->updateItemInfoCache(oldInfo.group, oldInfo.url, newInfo);
+    EXPECT_TRUE(result);
+
+    ItemInfo retrieved = manager->itemInfo(oldInfo.url);
+    EXPECT_EQ(retrieved.displayName, QString("NewName"));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByGroupAndUrl_NotFound)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/non/existent");
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "Test";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = manager->updateItemInfoCache(info.group, info.url, info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByUrl_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/updateall");
+    info.group = DefaultGroup::kNetwork;
+    info.displayName = "OldDisplay";
+
+    manager->addItemInfoCache(info);
+
+    ItemInfo newInfo = info;
+    newInfo.displayName = "NewDisplay";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->updateItemInfoCache(info.url, newInfo);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Contains_ItemInfo)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/contains");
+    info.group = DefaultGroup::kTag;
+    info.displayName = "Contains";
+
+    EXPECT_FALSE(manager->contains(info));
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Contains_Url)
+{
+    QUrl url = QUrl::fromLocalFile("/home/urltest");
+
+    ItemInfo info;
+    info.url = url;
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "UrlTest";
+
+    EXPECT_FALSE(manager->contains(url));
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Groups)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/group1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Group1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/group2");
+    info2.group = DefaultGroup::kDevice;
+    info2.displayName = "Group2";
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    QStringList groups = manager->groups();
+    EXPECT_TRUE(groups.contains(DefaultGroup::kCommon));
+    EXPECT_TRUE(groups.contains(DefaultGroup::kDevice));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, IndexCacheList)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/cache1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Cache1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/cache2");
+    info2.group = DefaultGroup::kCommon;
+    info2.displayName = "Cache2";
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    auto cacheList = manager->indexCacheList(DefaultGroup::kCommon);
+    EXPECT_GE(cacheList.size(), 2);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ItemInfo)
+{
+    QUrl url = QUrl::fromLocalFile("/home/iteminfo");
+
+    ItemInfo info;
+    info.url = url;
+    info.group = DefaultGroup::kOther;
+    info.displayName = "ItemInfoTest";
+
+    manager->addItemInfoCache(info);
+
+    ItemInfo retrieved = manager->itemInfo(url);
+    EXPECT_EQ(retrieved.url, info.url);
+    EXPECT_EQ(retrieved.displayName, info.displayName);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, GetLastSettingKeys)
+{
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_TRUE(keys.isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingKey)
+{
+    QString key1 = "setting.key1";
+    QString key2 = "setting.key2";
+
+    manager->appendLastSettingKey(key1);
+    manager->appendLastSettingKey(key2);
+
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_EQ(keys.size(), 2);
+    EXPECT_TRUE(keys.contains(key1));
+    EXPECT_TRUE(keys.contains(key2));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingKey_Duplicate)
+{
+    QString key = "duplicate.key";
+
+    manager->appendLastSettingKey(key);
+    manager->appendLastSettingKey(key);
+
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_EQ(keys.size(), 1);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ClearLastSettingKey)
+{
+    manager->appendLastSettingKey("key1");
+    manager->appendLastSettingKey("key2");
+
+    EXPECT_FALSE(manager->getLastSettingKeys().isEmpty());
+
+    manager->clearLastSettingKey();
+    EXPECT_TRUE(manager->getLastSettingKeys().isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, GetLastSettingBindingKeys)
+{
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_TRUE(keys.isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingBindingKey)
+{
+    QString key1 = "binding.key1";
+    QString key2 = "binding.key2";
+
+    manager->appendLastSettingBindingKey(key1);
+    manager->appendLastSettingBindingKey(key2);
+
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_EQ(keys.size(), 2);
+    EXPECT_TRUE(keys.contains(key1));
+    EXPECT_TRUE(keys.contains(key2));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingBindingKey_Duplicate)
+{
+    QString key = "duplicate.binding";
+
+    manager->appendLastSettingBindingKey(key);
+    manager->appendLastSettingBindingKey(key);
+
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_EQ(keys.size(), 1);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ClearLastSettingBindingKey)
+{
+    manager->appendLastSettingBindingKey("binding1");
+    manager->appendLastSettingBindingKey("binding2");
+
+    EXPECT_FALSE(manager->getLastSettingBindingKeys().isEmpty());
+
+    manager->clearLastSettingBindingKey();
+    EXPECT_TRUE(manager->getLastSettingBindingKeys().isEmpty());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarmanager.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarmanager.cpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarmanager.h"
+#include "utils/sidebarhelper.h"
+#include "treeviews/sidebaritem.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <QUrl>
+#include <QPoint>
+
+using namespace dfmplugin_sidebar;
+
+class UT_SideBarManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = SideBarManager::instance();
+        ASSERT_NE(manager, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarManager *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarManager, Instance)
+{
+    auto ins1 = SideBarManager::instance();
+    auto ins2 = SideBarManager::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarManager, RunCd_NullItem)
+{
+    // Should not crash with null item
+    manager->runCd(nullptr, 123);
+
+    // Test passes if no crash occurs
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunCd_WithClickedCallback)
+{
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    // Mock item->url()
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    // Mock item->itemInfo() to return ItemInfo with callback
+    stub.set_lamda(&SideBarItem::itemInfo, [&callbackInvoked, &capturedWindowId, &capturedUrl]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.clickedCb = [&callbackInvoked, &capturedWindowId, &capturedUrl](quint64 winId, const QUrl &url) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+        };
+        return info;
+    });
+
+    manager->runCd(item, 12345);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 12345u);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunCd_WithoutCallback_UseDefault)
+{
+    bool defaultActionCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/default");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.clickedCb = nullptr;
+        return info;
+    });
+
+    stub.set_lamda(&SideBarHelper::defaultCdAction,
+        [&defaultActionCalled, &capturedWindowId, &capturedUrl](quint64 winId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        defaultActionCalled = true;
+        capturedWindowId = winId;
+        capturedUrl = url;
+    });
+
+    manager->runCd(item, 54321);
+
+    EXPECT_TRUE(defaultActionCalled);
+    EXPECT_EQ(capturedWindowId, 54321u);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_ContextMenuDisabled)
+{
+    SideBarHelper::contextMenuEnabled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    // Should return early without calling any menu functions
+    manager->runContextMenu(item, 123, QPoint(0, 0));
+
+    // Test passes if no crash
+    EXPECT_TRUE(true);
+
+    delete item;
+
+    // Restore default state
+    SideBarHelper::contextMenuEnabled = true;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_NullItem)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    // Should not crash with null item
+    manager->runContextMenu(nullptr, 123, QPoint(0, 0));
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_SeparatorItem)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    // Should not show context menu for separator items
+    manager->runContextMenu(separator, 123, QPoint(0, 0));
+
+    EXPECT_TRUE(true);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_InvalidUrl)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    QUrl invalidUrl;  // Invalid URL
+    SideBarItem *item = new SideBarItem(invalidUrl);
+
+    stub.set_lamda(&SideBarItem::url, [invalidUrl]() {
+        __DBG_STUB_INVOKE__
+        return invalidUrl;
+    });
+
+    // Should return early with invalid URL
+    manager->runContextMenu(item, 123, QPoint(10, 20));
+
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_WithCallback)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QPoint capturedPos;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/context");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo,
+        [&callbackInvoked, &capturedWindowId, &capturedUrl, &capturedPos]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.contextMenuCb = [&](quint64 winId, const QUrl &url, const QPoint &pos) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+            capturedPos = pos;
+        };
+        return info;
+    });
+
+    QPoint menuPos(100, 200);
+    manager->runContextMenu(item, 99999, menuPos);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 99999u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedPos, menuPos);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_WithoutCallback_UseDefault)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    bool defaultMenuCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QPoint capturedPos;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/defaultmenu");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.contextMenuCb = nullptr;
+        return info;
+    });
+
+    stub.set_lamda(&SideBarHelper::defaultContextMenu,
+        [&defaultMenuCalled, &capturedWindowId, &capturedUrl, &capturedPos]
+        (quint64 winId, const QUrl &url, const QPoint &pos) {
+        __DBG_STUB_INVOKE__
+        defaultMenuCalled = true;
+        capturedWindowId = winId;
+        capturedUrl = url;
+        capturedPos = pos;
+    });
+
+    QPoint menuPos(50, 75);
+    manager->runContextMenu(item, 11111, menuPos);
+
+    EXPECT_TRUE(defaultMenuCalled);
+    EXPECT_EQ(capturedWindowId, 11111u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedPos, menuPos);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunRename_NullItem)
+{
+    // Should not crash with null item
+    manager->runRename(nullptr, 123, "NewName");
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunRename_WithCallback)
+{
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QString capturedName;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/rename");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo,
+        [&callbackInvoked, &capturedWindowId, &capturedUrl, &capturedName]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.renameCb = [&](quint64 winId, const QUrl &url, const QString &name) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+            capturedName = name;
+        };
+        return info;
+    });
+
+    QString newName = "RenamedItem";
+    manager->runRename(item, 77777, newName);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 77777u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedName, newName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunRename_WithoutCallback)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/norename");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.renameCb = nullptr;
+        return info;
+    });
+
+    // Should log warning but not crash
+    manager->runRename(item, 88888, "SomeName");
+
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, OpenFolderInASeparateProcess)
+{
+    bool helperCalled = false;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/separate");
+
+    stub.set_lamda(&SideBarHelper::openFolderInASeparateProcess,
+        [&helperCalled, &capturedUrl](const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        helperCalled = true;
+        capturedUrl = url;
+    });
+
+    manager->openFolderInASeparateProcess(testUrl);
+
+    EXPECT_TRUE(helperCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+}


### PR DESCRIPTION
Part 1/2 of dfmplugin-sidebar unit tests, split by module for easier review:
侧边栏核心管理与事件.

This part carries the final CMakeLists.txt and main.cpp; test files
of the other parts land in separate PRs. The test binary is wired
into the build by the registration PR (merged last).

dfmplugin-sidebar 单元测试第 1/2 部分（按模块拆分以便评审）：侧边栏核心管理与事件。

本部分包含最终版 CMakeLists.txt 与 main.cpp，其余测试文件由独立
PR 提交；测试二进制由注册 PR（最后合入）接入构建。

Log: 新增 dfmplugin-sidebar 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add core unit tests for dfmplugin-sidebar management, event handling, helper utilities, and cached sidebar state.

Build:
- Add CMake configuration and a GoogleTest entry point for the dfmplugin-sidebar unit-test target.

Tests:
- Add unit coverage for sidebar lifecycle and window/configuration event handling.
- Add unit coverage for sidebar event publishing and event receiver behavior.
- Add unit coverage for sidebar item management, helper utilities, cache management, and callback-driven actions.
- Exercise real sidebar event binding during initialization to verify production event connections do not crash.