### PR TITLE
test: add unit tests for dfmplugin-sidebar (part 2/2: view and widgets)

### DIFF
--- a/autotests/plugins/dfmplugin-sidebar/test_fileoperatorhelper.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_fileoperatorhelper.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/fileoperatorhelper.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_FileOperatorHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_FileOperatorHelper, Instance)
+{
+    auto ins1 = FileOperatorHelper::instance();
+    auto ins2 = FileOperatorHelper::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_MoveAction)
+{
+    bool isCallCut { false };
+    quint64 capturedWindowId { 0 };
+    QList<QUrl> capturedSrcUrls;
+    QUrl capturedTargetUrl;
+    AbstractJobHandler::JobFlag capturedFlag;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, unsigned long long,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, unsigned long long windowId,
+                       const QList<QUrl> &srcUrls, const QUrl &targetUrl,
+                       AbstractJobHandler::JobFlag flag, std::nullptr_t) {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCutFile) {
+                           isCallCut = true;
+                           capturedWindowId = windowId;
+                           capturedSrcUrls = srcUrls;
+                           capturedTargetUrl = targetUrl;
+                           capturedFlag = flag;
+                       }
+                       return true;
+                   });
+
+    quint64 windowId = 12345;
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/tmp/test1.txt"),
+                            QUrl::fromLocalFile("/tmp/test2.txt") };
+    QUrl targetUrl = QUrl::fromLocalFile("/tmp/target");
+
+    FileOperatorHelper::instance()->pasteFiles(windowId, srcUrls, targetUrl, Qt::MoveAction);
+
+    EXPECT_TRUE(isCallCut);
+    EXPECT_EQ(capturedWindowId, windowId);
+    EXPECT_EQ(capturedSrcUrls, srcUrls);
+    EXPECT_EQ(capturedTargetUrl, targetUrl);
+    EXPECT_EQ(capturedFlag, AbstractJobHandler::JobFlag::kNoHint);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_CopyAction)
+{
+    bool isCallCopy { false };
+    quint64 capturedWindowId { 0 };
+    QList<QUrl> capturedSrcUrls;
+    QUrl capturedTargetUrl;
+    AbstractJobHandler::JobFlag capturedFlag;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, quint64 windowId,
+                       const QList<QUrl> &srcUrls, const QUrl &targetUrl,
+                       AbstractJobHandler::JobFlag flag, std::nullptr_t) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCopy) {
+                           isCallCopy = true;
+                           capturedWindowId = windowId;
+                           capturedSrcUrls = srcUrls;
+                           capturedTargetUrl = targetUrl;
+                           capturedFlag = flag;
+                       }
+                       return true;
+                   });
+
+    quint64 windowId = 54321;
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/tmp/copy1.txt") };
+    QUrl targetUrl = QUrl::fromLocalFile("/tmp/copy_target");
+
+    FileOperatorHelper::instance()->pasteFiles(windowId, srcUrls, targetUrl, Qt::CopyAction);
+
+    EXPECT_TRUE(isCallCopy);
+    EXPECT_EQ(capturedWindowId, windowId);
+    EXPECT_EQ(capturedSrcUrls, srcUrls);
+    EXPECT_EQ(capturedTargetUrl, targetUrl);
+    EXPECT_EQ(capturedFlag, AbstractJobHandler::JobFlag::kNoHint);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_DefaultActionIsCopy)
+{
+    bool isCallCopy { false };
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, quint64,
+                       const QList<QUrl> &, const QUrl &,
+                       AbstractJobHandler::JobFlag, std::nullptr_t) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCopy) {
+                           isCallCopy = true;
+                       }
+                       return true;
+                   });
+
+    // Use any action other than MoveAction, should default to copy
+    FileOperatorHelper::instance()->pasteFiles(1, { QUrl() }, QUrl(), Qt::LinkAction);
+
+    EXPECT_TRUE(isCallCopy);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebaritem.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebaritem.cpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebaritem.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <DDciIcon>
+
+#include <QUrl>
+#include <QIcon>
+
+using namespace dfmplugin_sidebar;
+DGUI_USE_NAMESPACE
+
+class UT_SideBarItem : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl = QUrl::fromLocalFile("/home/test");
+        testGroup = DefaultGroup::kCommon;
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    QUrl testUrl;
+    QString testGroup;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItem, Constructor_WithUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->url(), testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Constructor_WithFullParameters)
+{
+    QIcon testIcon = QIcon::fromTheme("folder");
+    QString testText = "TestItem";
+
+    SideBarItem *item = new SideBarItem(testIcon, testText, testGroup, testUrl);
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->url(), testUrl);
+    EXPECT_EQ(item->text(), testText);
+    EXPECT_EQ(item->group(), testGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Constructor_CopyConstructor)
+{
+    QIcon testIcon = QIcon::fromTheme("folder");
+    QString testText = "Original";
+
+    SideBarItem *original = new SideBarItem(testIcon, testText, testGroup, testUrl);
+    SideBarItem *copy = new SideBarItem(*original);
+
+    EXPECT_NE(copy, nullptr);
+    EXPECT_EQ(copy->url(), original->url());
+    EXPECT_EQ(copy->text(), original->text());
+    EXPECT_EQ(copy->group(), original->group());
+
+    delete original;
+    delete copy;
+}
+
+TEST_F(UT_SideBarItem, Url_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QUrl newUrl = QUrl::fromLocalFile("/home/newurl");
+    item->setUrl(newUrl);
+
+    EXPECT_EQ(item->url(), newUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, TargetUrl_WithoutFinalUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::itemInfo, [this]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.url = testUrl;
+        info.finalUrl = QUrl();   // Empty final URL
+        return info;
+    });
+
+    QUrl targetUrl = item->targetUrl();
+    EXPECT_EQ(targetUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, TargetUrl_WithFinalUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QUrl finalUrl = QUrl::fromLocalFile("/home/final");
+
+    stub.set_lamda(&SideBarItem::itemInfo, [this, finalUrl]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.url = testUrl;
+        info.finalUrl = finalUrl;
+        return info;
+    });
+
+    QUrl targetUrl = item->targetUrl();
+    EXPECT_EQ(targetUrl, finalUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SetIcon_DciIcon)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QIcon icon = QIcon::fromTheme("folder");
+
+    stub.set_lamda(static_cast<DDciIcon (*)(const QString &)>(&DDciIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        DDciIcon dciIcon;
+        return dciIcon;
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, []() {
+        __DBG_STUB_INVOKE__
+        return false;   // DCI icon is valid
+    });
+
+    bool dciIconSet = false;
+    using SetDciIconFunc = void (DStandardItem::*)(const DDciIcon &);
+    stub.set_lamda(static_cast<SetDciIconFunc>(&DStandardItem::setDciIcon),
+                   [&dciIconSet](DStandardItem *, const DDciIcon &) {
+                       __DBG_STUB_INVOKE__
+                       dciIconSet = true;
+                   });
+
+    item->setIcon(icon);
+
+    EXPECT_TRUE(dciIconSet);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SetIcon_RegularIcon)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QIcon icon;
+
+    stub.set_lamda(static_cast<DDciIcon (*)(const QString &)>(&DDciIcon::fromTheme), [](const QString &) {
+        __DBG_STUB_INVOKE__
+        DDciIcon dciIcon;
+        return dciIcon;
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, []() {
+        __DBG_STUB_INVOKE__
+        return true;   // DCI icon is null, use regular icon
+    });
+
+    item->setIcon(icon);
+
+    // Verify icon is set through data (Qt::DecorationRole)
+    EXPECT_TRUE(item->icon().isNull());
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Group_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    item->setGroup(testGroup);
+    EXPECT_EQ(item->group(), testGroup);
+
+    QString newGroup = DefaultGroup::kDevice;
+    item->setGroup(newGroup);
+    EXPECT_EQ(item->group(), newGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SubGroup)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QString testSubGroup = "SubGroup1";
+
+    stub.set_lamda(&SideBarItem::itemInfo, [testSubGroup]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.subGroup = testSubGroup;
+        return info;
+    });
+
+    EXPECT_EQ(item->subGourp(), testSubGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Hidden_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    item->setHiiden(true);
+    // Note: isHidden() reads from kItemGroupRole which is a bug in original code
+    // We test the actual implementation
+
+    item->setHiiden(false);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, ItemInfo)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    ItemInfo mockInfo;
+    mockInfo.url = testUrl;
+    mockInfo.group = testGroup;
+    mockInfo.displayName = "MockInfo";
+
+    // SideBarItem::itemInfo() calls the two-argument overload
+    // itemInfo(group, url); stub that exact instance.
+    using ItemInfoFunc = ItemInfo (SideBarInfoCacheMananger::*)(const QString &, const QUrl &);
+    stub.set_lamda(static_cast<ItemInfoFunc>(&SideBarInfoCacheMananger::itemInfo),
+                   [mockInfo](SideBarInfoCacheMananger *, const QString &, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       return mockInfo;
+                   });
+
+    ItemInfo info = item->itemInfo();
+    EXPECT_EQ(info.url, mockInfo.url);
+    EXPECT_EQ(info.group, mockInfo.group);
+    EXPECT_EQ(info.displayName, mockInfo.displayName);
+
+    delete item;
+}
+
+// Tests for SideBarItemSeparator
+class UT_SideBarItemSeparator : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testGroup = DefaultGroup::kCommon;
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    QString testGroup;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItemSeparator, Constructor)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), testGroup);
+    EXPECT_EQ(separator->text(), testGroup);
+    EXPECT_TRUE(separator->isExpanded());
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, Expanded_GetSet)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_TRUE(separator->isExpanded());
+
+    separator->setExpanded(false);
+    EXPECT_FALSE(separator->isExpanded());
+
+    separator->setExpanded(true);
+    EXPECT_TRUE(separator->isExpanded());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, Visible_GetSet)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_TRUE(separator->isVisible());
+
+    separator->setVisible(false);
+    EXPECT_FALSE(separator->isVisible());
+
+    separator->setVisible(true);
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, DefaultValues)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator();
+
+    // Test default constructor behavior
+    EXPECT_TRUE(separator->isExpanded());
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, MultipleToggles)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    // Toggle expanded multiple times
+    for (int i = 0; i < 5; ++i) {
+        bool state = (i % 2 == 0);
+        separator->setExpanded(state);
+        EXPECT_EQ(separator->isExpanded(), state);
+    }
+
+    // Toggle visible multiple times
+    for (int i = 0; i < 5; ++i) {
+        bool state = (i % 2 == 0);
+        separator->setVisible(state);
+        EXPECT_EQ(separator->isVisible(), state);
+    }
+
+    delete separator;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebaritemdelegate.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebaritemdelegate.cpp
@@ -1,0 +1,1022 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treemodels/sidebarmodel.h"
+#include "treeviews/sidebaritemdelegate.h"
+#include "treeviews/sidebaritem.h"
+#include "treeviews/sidebarview.h"
+#include "events/sidebareventcaller.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/device/devicealiasmanager.h>
+
+#include <QPainter>
+#include <QStyleOptionViewItem>
+#include <QAbstractItemView>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QHelpEvent>
+#include <QToolTip>
+
+using namespace dfmplugin_sidebar;
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_SideBarItemDelegate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub GUI operations
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        view = new SideBarView();
+        delegate = new SideBarItemDelegate(view);
+        ASSERT_NE(delegate, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete delegate;
+        delegate = nullptr;
+        delete view;
+        view = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarItemDelegate *delegate { nullptr };
+    SideBarView *view { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItemDelegate, Constructor)
+{
+    EXPECT_NE(delegate, nullptr);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    // Create a mock painter
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, paint),
+                   [](DStyledItemDelegate *, QPainter *, const QStyleOptionViewItem &, const QModelIndex &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should not crash even with invalid index
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SizeHint)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, sizeHint),
+                   [](const DStyledItemDelegate *, const QStyleOptionViewItem &, const QModelIndex &) -> QSize {
+                       __DBG_STUB_INVOKE__
+                       return QSize(100, 30);
+                   });
+
+    QSize size = delegate->sizeHint(option, index);
+
+    EXPECT_GT(size.width(), 0);
+    EXPECT_GT(size.height(), 0);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QWidget *editor = delegate->createEditor(&parent, option, index);
+
+    // Should return nullptr for invalid index
+    EXPECT_EQ(editor, nullptr);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor_ValidIndex)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(Qt::ItemIsEditable);
+    });
+
+    QWidget *editor = delegate->createEditor(&parent, option, index);
+
+    // Editor may or may not be created depending on item type
+    if (editor) {
+        delete editor;
+    }
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData)
+{
+    QLineEdit editor;
+    QModelIndex index;
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant("TestText");
+    });
+
+    delegate->setEditorData(&editor, index);
+
+    // Editor should be populated
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+
+    QAbstractItemModel *model = nullptr;
+    QModelIndex index;
+
+    // Should not crash with null model
+    delegate->setModelData(&editor, model, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, UpdateEditorGeometry)
+{
+    QLineEdit editor;
+    QStyleOptionViewItem option;
+    option.rect = QRect(10, 10, 100, 30);
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, updateEditorGeometry), [] { __DBG_STUB_INVOKE__ });
+
+    delegate->updateEditorGeometry(&editor, option, index);
+
+    // Editor geometry should be updated
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_NullEvent)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] { __DBG_STUB_INVOKE__ return false; });
+
+    bool result = delegate->editorEvent(nullptr, model, option, index);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MousePress)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 100, 30);
+    QModelIndex index;
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress,
+                                         QPointF(10, 10),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = delegate->editorEvent(event, model, option, index);
+
+    delete event;
+
+    // Result depends on implementation
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MouseRelease)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 100, 30);
+    QModelIndex index;
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease,
+                                         QPointF(10, 10),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = delegate->editorEvent(event, model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_ToolTip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    QModelIndex index;
+    SideBarModel model;
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, helpEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    typedef QAbstractItemModel *(*fun_type)();
+    stub.set_lamda((fun_type)(&QModelIndex::model), [&] { __DBG_STUB_INVOKE__ return &model; });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Result depends on whether tooltip should be shown
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged)
+{
+    QString newText = "ChangedText";
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::setText, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    delegate->onEditorTextChanged(newText, item);
+
+    // Should update item text
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged_NullItem)
+{
+    QString newText = "ChangedText";
+
+    // Should not crash with null item
+    delegate->onEditorTextChanged(newText, nullptr);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_WithValidData)
+{
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled;
+
+    QModelIndex index;
+
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int role) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (role == Qt::DisplayRole)
+            return QVariant("TestItem");
+        return QVariant();
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, paint),
+                   [](DStyledItemDelegate *, QPainter *, const QStyleOptionViewItem &, const QModelIndex &) {
+                       __DBG_STUB_INVOKE__
+                   });
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint successfully
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SizeHint_Separator)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int role) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (role == SideBarItem::kItemTypeRole)
+            return QVariant(SideBarItem::kSeparator);
+        return QVariant();
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, sizeHint),
+                   [](const DStyledItemDelegate *, const QStyleOptionViewItem &, const QModelIndex &) -> QSize {
+                       __DBG_STUB_INVOKE__
+                       return QSize(100, 30);
+                   });
+
+    QSize size = delegate->sizeHint(option, index);
+
+    // Separator might have different size
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_SelectedState)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_Selected;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///test");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with selected background
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_HoverState)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_MouseOver;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with hover background
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_SeparatorItem)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_MouseOver;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    separator->setExpanded(true);
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint separator with expand button
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_EjectableItem)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled;
+    option.widget = &widget;
+    option.features = QStyleOptionViewItem::HasDecoration;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with eject icon
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_ExpandButton_Click)
+{
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    separator->setExpanded(false);
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    // Click on expand button area (right side)
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress,
+                                         QPointF(170, 20),   // Position in expand button area
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(&SideBarView::isExpanded, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool expandSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::changeExpandState,
+                     [&expandSignalEmitted](const QModelIndex &, bool expand) {
+                         expandSignalEmitted = true;
+                         EXPECT_TRUE(expand);
+                     });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(expandSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_EjectButton_Click)
+{
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    info.url = QUrl("file:///media/usb");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    // Click on eject button area (bottom right)
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease,
+                                         QPointF(180, 25),   // Position in eject button area
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    bool ejectCalled = false;
+    stub.set_lamda(&SideBarEventCaller::sendEject, [&ejectCalled](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ejectCalled = true;
+    });
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(ejectCalled);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MouseMove_Separator)
+{
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseMove,
+                                         QPointF(100, 20),
+                                         Qt::NoButton,
+                                         Qt::NoButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update), [](SideBarView *, const QModelIndex &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    // Should update view on mouse move over separator
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_ShortText_NoTooltip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    item->setText("Short");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(&QToolTip::hideText, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Short text should hide tooltip
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_LongText_ShowTooltip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    item->setText("This is a very long text that should trigger tooltip display because it exceeds the available width");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    bool tooltipShown = false;
+    stub.set_lamda(&QToolTip::showText, [&tooltipShown] {
+        __DBG_STUB_INVOKE__
+        tooltipShown = true;
+    });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(tooltipShown);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_EjectableItem)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    item->setText("USB Drive with Very Long Name");
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(&QToolTip::showText, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QToolTip::hideText, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Ejectable items have less space for text
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData_ValidItem)
+{
+    QLineEdit editor;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    ItemInfo info = item->itemInfo();
+    info.displayName = "DisplayName";
+    info.editDisplayText = "EditText";
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    delegate->setEditorData(&editor, index);
+
+    // Should set edit text if available, otherwise display name
+    EXPECT_EQ(editor.text(), QString("EditText"));
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData_NoEditText)
+{
+    QLineEdit editor;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    ItemInfo info = item->itemInfo();
+    info.displayName = "DisplayName";
+    info.editDisplayText = "";   // Empty edit text
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    delegate->setEditorData(&editor, index);
+
+    // Should use display name when edit text is empty
+    EXPECT_EQ(editor.text(), QString("DisplayName"));
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData_ModifiedEditor)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+    editor.setModified(true);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    bool renameSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::rename,
+                     [&renameSignalEmitted](const QModelIndex &, const QString &text) {
+                         renameSignalEmitted = true;
+                         EXPECT_EQ(text, QString("NewName"));
+                     });
+
+    delegate->setModelData(&editor, &model, index);
+
+    EXPECT_TRUE(renameSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData_UnmodifiedEditor)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+    editor.setModified(false);   // Not modified
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    bool renameSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::rename,
+                     [&renameSignalEmitted](const QModelIndex &, const QString &) {
+                         renameSignalEmitted = true;
+                     });
+
+    delegate->setModelData(&editor, &model, index);
+
+    // Should not emit signal for unmodified editor
+    EXPECT_FALSE(renameSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged_LongText)
+{
+    SideBarItem *item = new SideBarItem(QUrl::fromLocalFile("/home/test"));
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, exists), [](const FileInfo *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, extraProperties), [](const FileInfo *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash["filesystem"] = "ext4";
+        return hash;
+    });
+
+    stub.set_lamda(&FileUtils::supportedMaxLength, [](const QString &) -> int {
+        __DBG_STUB_INVOKE__
+        return 255;
+    });
+
+    stub.set_lamda(&FileUtils::processLength, [](const QString &, int, int, bool, QString &out, int &) {
+        __DBG_STUB_INVOKE__
+        out = "Truncated";
+        return true;
+    });
+
+    // Simulate text change
+    QString veryLongText = QString("a").repeated(300);
+    delegate->onEditorTextChanged(veryLongText, item);
+
+    delete item;
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor_WithValidator)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+
+    SideBarModel model;
+    QLineEdit edit;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, createEditor),
+                   [&] {
+                       __DBG_STUB_INVOKE__
+                       return &edit;
+                   });
+
+    stub.set_lamda(&NPDeviceAliasManager::canSetAlias, [](NPDeviceAliasManager *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_THROW(delegate->createEditor(&parent, option, index));
+}
+
+TEST_F(UT_SideBarItemDelegate, UpdateEditorGeometry_AdjustedWidth)
+{
+    QLineEdit editor;
+    QStyleOptionViewItem option;
+    option.rect = QRect(10, 10, 100, 30);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, updateEditorGeometry), [] { __DBG_STUB_INVOKE__ });
+
+    stub.set_lamda(&SideBarView::width, [] {
+        __DBG_STUB_INVOKE__
+        return 200;
+    });
+
+    EXPECT_NO_THROW(delegate->updateEditorGeometry(&editor, option, index));
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_DoubleClick)
+{
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonDblClick,
+                                         QPointF(100, 20),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    // Double click should be handled
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_InactiveWindow)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_Selected;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&QWidget::isActiveWindow, [](const QWidget *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;   // Inactive window
+    });
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///test");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with reduced opacity when window is inactive
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarmodel.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarmodel.cpp
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treemodels/sidebarmodel.h"
+#include "treeviews/sidebaritem.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-framework/event/event.h>
+
+#include <QMimeData>
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarModel : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        model = new SideBarModel();
+        ASSERT_NE(model, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete model;
+        model = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarModel *model { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarModel, Constructor)
+{
+    EXPECT_NE(model, nullptr);
+    EXPECT_EQ(model->rowCount(), 0);
+}
+
+TEST_F(UT_SideBarModel, ItemFromIndex_ValidIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    SideBarItem *item = new SideBarItem(testUrl);
+    separator->appendRow(item);
+
+    QModelIndex index = model->index(0, 0);
+    SideBarItem *retrievedItem = model->itemFromIndex(index);
+
+    EXPECT_NE(retrievedItem, nullptr);
+    EXPECT_EQ(retrievedItem, separator);
+}
+
+TEST_F(UT_SideBarModel, ItemFromIndex_ByRow)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    SideBarItem *retrievedItem = model->itemFromIndex(0);
+
+    EXPECT_NE(retrievedItem, nullptr);
+    EXPECT_EQ(retrievedItem, separator);
+}
+
+TEST_F(UT_SideBarModel, GroupItems)
+{
+    SideBarItemSeparator *separator1 = new SideBarItemSeparator(DefaultGroup::kCommon);
+    SideBarItemSeparator *separator2 = new SideBarItemSeparator(DefaultGroup::kDevice);
+
+    model->appendRow(separator1);
+    model->appendRow(separator2);
+
+    QList<SideBarItemSeparator *> groups = model->groupItems();
+
+    EXPECT_EQ(groups.size(), 2);
+    EXPECT_TRUE(groups.contains(separator1));
+    EXPECT_TRUE(groups.contains(separator2));
+}
+
+TEST_F(UT_SideBarModel, SubItems_All)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl url1 = QUrl::fromLocalFile("/home/test1");
+    QUrl url2 = QUrl::fromLocalFile("/home/test2");
+
+    SideBarItem *item1 = new SideBarItem(url1);
+    SideBarItem *item2 = new SideBarItem(url2);
+    item1->setGroup(DefaultGroup::kCommon);
+    item2->setGroup(DefaultGroup::kCommon);
+
+    separator->appendRow(item1);
+    separator->appendRow(item2);
+
+    QList<SideBarItem *> items = model->subItems();
+
+    EXPECT_EQ(items.size(), 2);
+}
+
+TEST_F(UT_SideBarModel, SubItems_ByGroup)
+{
+    SideBarItemSeparator *separatorCommon = new SideBarItemSeparator(DefaultGroup::kCommon);
+    SideBarItemSeparator *separatorDevice = new SideBarItemSeparator(DefaultGroup::kDevice);
+
+    model->appendRow(separatorCommon);
+    model->appendRow(separatorDevice);
+
+    QUrl url1 = QUrl::fromLocalFile("/home/common1");
+    QUrl url2 = QUrl::fromLocalFile("/dev/device1");
+
+    SideBarItem *item1 = new SideBarItem(url1);
+    SideBarItem *item2 = new SideBarItem(url2);
+    item1->setGroup(DefaultGroup::kCommon);
+    item2->setGroup(DefaultGroup::kDevice);
+
+    separatorCommon->appendRow(item1);
+    separatorDevice->appendRow(item2);
+
+    QList<SideBarItem *> commonItems = model->subItems(DefaultGroup::kCommon);
+
+    EXPECT_EQ(commonItems.size(), 1);
+    EXPECT_EQ(commonItems.first(), item1);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_NullItem)
+{
+    bool result = model->insertRow(0, nullptr);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_InvalidRowIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/invalid");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    bool result = model->insertRow(-5, item);
+    EXPECT_FALSE(result);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarModel, InsertRow_Separator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    bool result = model->insertRow(0, separator);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_SubItem)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/subitem");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    bool result = model->insertRow(0, item);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_NullItem)
+{
+    int result = model->appendRow(nullptr);
+    EXPECT_EQ(result, -1);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_AlreadyExists)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/exists");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        index.r = 5;
+        index.c = 0;
+        // Simulate found at row 5
+        return index;
+    });
+
+    int result = model->appendRow(item);
+    EXPECT_EQ(result, 5);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarModel, AppendRow_Separator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        return index;   // Not found, row() returns -1
+    });
+
+    int result = model->appendRow(separator);
+
+    EXPECT_GE(result, 0);
+    EXPECT_EQ(model->rowCount(), 1);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_SubItem_WithGroup)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/append");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    int result = model->appendRow(item, true);
+
+    EXPECT_GE(result, 0);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_InvalidUrl)
+{
+    QUrl invalidUrl;
+    bool result = model->removeRow(invalidUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = model->removeRow(testUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = model->removeRow(testUrl);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, UpdateRow_InvalidUrl)
+{
+    QUrl invalidUrl;
+    ItemInfo info;
+
+    // Should return early without crashing
+    model->updateRow(invalidUrl, info);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarModel, UpdateRow_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/update");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() -> ItemInfo {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.findMeCb = nullptr;
+        return info;
+    });
+
+    ItemInfo newInfo;
+    newInfo.url = testUrl;
+    newInfo.displayName = "Updated Name";
+    newInfo.icon = QIcon::fromTheme("folder");
+    newInfo.flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    newInfo.group = DefaultGroup::kCommon;
+    newInfo.isEditable = true;
+
+    model->updateRow(testUrl, newInfo);
+
+    // Test passes if no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarModel, FindRowByUrl_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notexist");
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QModelIndex index = model->findRowByUrl(testUrl);
+    EXPECT_FALSE(index.isValid());
+}
+
+TEST_F(UT_SideBarModel, FindRowByUrl_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/find");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QModelIndex index = model->findRowByUrl(testUrl);
+    EXPECT_TRUE(index.isValid());
+}
+
+TEST_F(UT_SideBarModel, AddEmptyItem)
+{
+    int initialCount = model->rowCount();
+
+    model->addEmptyItem();
+
+    EXPECT_EQ(model->rowCount(), initialCount + 1);
+
+    // Adding again should not add another empty item
+    model->addEmptyItem();
+    EXPECT_EQ(model->rowCount(), initialCount + 1);
+}
+
+TEST_F(UT_SideBarModel, CanDropMimeData_InvalidParameters)
+{
+    QMimeData *data = new QMimeData();
+
+    // Invalid row/column
+    bool canDrop = model->canDropMimeData(data, Qt::MoveAction, -1, -1, QModelIndex());
+    EXPECT_FALSE(canDrop);
+
+    // Null data
+    canDrop = model->canDropMimeData(nullptr, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(canDrop);
+
+    delete data;
+}
+
+TEST_F(UT_SideBarModel, CanDropMimeData_OnSeparator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QMimeData *data = new QMimeData();
+
+    stub.set_lamda(static_cast<SideBarItem *(SideBarModel::*)(int, const QModelIndex &) const>(&SideBarModel::itemFromIndex),
+                   [separator](const SideBarModel *, int, const QModelIndex &) -> SideBarItem * {
+                       __DBG_STUB_INVOKE__
+                       return separator;
+                   });
+
+    bool canDrop = model->canDropMimeData(data, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(canDrop);   // Cannot drop on separator
+
+    delete data;
+}
+
+TEST_F(UT_SideBarModel, MimeData)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/mime");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    QModelIndex itemIndex = item->index();
+    QModelIndexList indexes;
+    indexes << itemIndex;
+
+    stub.set_lamda(VADDR(QStandardItemModel, mimeData),
+                   [](const QStandardItemModel *, const QModelIndexList &) -> QMimeData * {
+                       __DBG_STUB_INVOKE__
+                       return new QMimeData();
+                   });
+
+    QMimeData *mimeData = model->mimeData(indexes);
+
+    EXPECT_NE(mimeData, nullptr);
+
+    delete mimeData;
+}
+
+TEST_F(UT_SideBarModel, DropMimeData_CannotDrop)
+{
+    QMimeData *data = new QMimeData();
+
+    stub.set_lamda(VADDR(SideBarModel, canDropMimeData),
+                   [](const SideBarModel *, const QMimeData *, Qt::DropAction, int, int, const QModelIndex &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = model->dropMimeData(data, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(result);
+
+    delete data;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarview.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarview.cpp
@@ -1,0 +1,1131 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebarview.h"
+#include "treeviews/private/sidebarview_p.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "utils/sidebarhelper.h"
+#include "utils/fileoperatorhelper.h"
+
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QMouseEvent>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QDrag>
+#include <QMimeData>
+#include <QUrl>
+#include <QTimer>
+#include <thread>
+#include <chrono>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_sidebar;
+
+class UT_SidebarView : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        model = new SideBarModel;
+        SideBarItem *item1 = createGroupItem(QString("group1"));
+        SideBarItem *item2 = createGroupItem(QString("group2"));
+        model->appendRow(item1);
+        model->appendRow(item2);   // two groups added.
+
+        SideBarItem *group1_item1 = createSubItem("item1", QUrl("test/url3"), QString("group1"));
+        SideBarItem *group1_item2 = createSubItem("item2", QUrl("test/url4"), QString("group1"));
+
+        model->appendRow(group1_item1);
+        model->appendRow(group1_item2);   // two items under group1
+
+        view = new SideBarView;
+        view->setModel(model);
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (model) {
+            model->clear();
+            delete model;
+        }
+        if (view)
+            delete view;
+    }
+    SideBarItem *createGroupItem(const QString &group)
+    {
+        SideBarItem *item = new SideBarItemSeparator(group);
+        return item;
+    }
+    SideBarItem *createSubItem(const QString &name, const QUrl &url, const QString &group)
+    {
+        QString iconName { SystemPathUtil::instance()->systemPathIconName(name) };
+        QString text { name };
+        if (!iconName.contains("-symbolic"))
+            iconName.append("-symbolic");
+
+        SideBarItem *item = new SideBarItem(QIcon::fromTheme(iconName),
+                                            text,
+                                            group,
+                                            url);
+        return item;
+    }
+    SideBarModel *model = nullptr;
+    SideBarView *view = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SidebarView, FindItemIndex)
+{
+    QModelIndex index1 = view->findItemIndex(QUrl("test/url3"));
+    EXPECT_TRUE(index1.row() == 0);
+
+    QModelIndex index2 = view->findItemIndex(QUrl("test/url4"));
+    EXPECT_TRUE(index2.row() == 1);
+}
+
+TEST_F(UT_SidebarView, testDragEnterEvent)
+{
+    bool isCall { false };
+    stub.set_lamda(&QDropEvent::setDropAction, []() {
+        return;
+    });
+
+    stub.set_lamda(&QDropEvent::ignore, [&]() {
+        isCall = true;
+        return;
+    });
+
+    QDragEnterEvent event(QPoint(10, 10), Qt::IgnoreAction, nullptr, Qt::LeftButton, Qt::NoModifier);
+
+    // action1
+    stub.set_lamda(&QMimeData::urls, []() -> QList<QUrl> {
+        return {};
+    });
+
+    QMimeData data;
+    data.setData(DFMGLOBAL_NAMESPACE::Mime::kDFMTreeUrlsKey, "file:///home");
+    stub.set_lamda(&QDropEvent::mimeData, [&] {
+        return &data;
+    });
+
+    view->dragEnterEvent(&event);
+    EXPECT_FALSE(isCall);
+
+    // action2
+    isCall = false;
+    stub.set_lamda(&QMimeData::urls, []() -> QList<QUrl> {
+        return { QUrl("/home/uos") };
+    });
+
+    stub.set_lamda(&FileUtils::isContainProhibitPath, []() -> bool {
+        return true;
+    });
+
+    view->dragEnterEvent(&event);
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_SidebarView, testDragLeaveEvent)
+{
+    bool isCall { false };
+    stub.set_lamda(&QAbstractItemView::setCurrentIndex, []() {
+        return;
+    });
+    stub.set_lamda(&QAbstractItemView::setState, []() {
+        return;
+    });
+
+    auto upDate = static_cast<void (QWidget::*)()>(&QWidget::update);
+    stub.set_lamda(upDate, [&]() {
+        __DBG_STUB_INVOKE__
+        isCall = true;
+        return;
+    });
+
+    QDragLeaveEvent event;
+
+    view->dragLeaveEvent(&event);
+    // Product now refreshes the viewport while clearing hover/drag state on
+    // drag leave, so QWidget::update() is expected to be called.
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_SidebarView, MousePressEvent_RightButton)
+{
+    stub.set_lamda(&SideBarView::urlAt, [](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///home/test");
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPoint(10, 10), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+
+    // Right click should be accepted and not trigger parent handler
+    view->mousePressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+}
+
+TEST_F(UT_SidebarView, MousePressEvent_LeftButton)
+{
+    QUrl testUrl("file:///home/test");
+    QString testGroup("Common");
+
+    stub.set_lamda(&SideBarView::urlAt, [testUrl](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    SideBarItem *testItem = createSubItem("test", testUrl, testGroup);
+    stub.set_lamda(&SideBarView::itemAt, [testItem](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return testItem;
+    });
+
+    stub.set_lamda(VADDR(DTreeView, mousePressEvent), [](DTreeView *, QMouseEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&event);
+
+    delete testItem;
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, MouseReleaseEvent_ValidItem)
+{
+    bool reportCalled = false;
+    QUrl testUrl("file:///home/test");
+
+    SideBarItem *testItem = createSubItem("TestItem", testUrl, "Common");
+    model->appendRow(testItem);
+
+    stub.set_lamda(&SideBarView::itemAt, [testItem](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return testItem;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [testItem, this](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return testItem->index();
+    });
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(const QString &, const QString &, QString, QVariantMap &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&reportCalled](EventDispatcherManager *, const QString &, const QString &, QString, QVariantMap) {
+                       __DBG_STUB_INVOKE__
+                       reportCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(DTreeView, mouseReleaseEvent), [](DTreeView *, QMouseEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMouseEvent event(QEvent::MouseButtonRelease, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    EXPECT_TRUE(reportCalled);
+}
+
+TEST_F(UT_SidebarView, ItemAt_ValidPoint)
+{
+    SideBarItem *item = createSubItem("item", QUrl("file:///test"), "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item, this](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    SideBarItem *result = view->itemAt(QPoint(10, 10));
+    EXPECT_NE(result, nullptr);
+    if (result) {
+        EXPECT_EQ(result->url(), QUrl("file:///test"));
+    }
+}
+
+TEST_F(UT_SidebarView, ItemAt_InvalidPoint)
+{
+    stub.set_lamda(VADDR(SideBarView, indexAt), [](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    SideBarItem *result = view->itemAt(QPoint(10, 10));
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_SidebarView, UrlAt_ValidItem)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("item", testUrl, "group1");
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    QUrl result = view->urlAt(QPoint(10, 10));
+    EXPECT_EQ(result, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, UrlAt_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QUrl result = view->urlAt(QPoint(10, 10));
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_ValidUrl)
+{
+    QUrl testUrl("test/url3");
+
+    stub.set_lamda(&QAbstractItemView::setCurrentIndex, [](QAbstractItemView *, const QModelIndex &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_EQ(view->currentUrl(), testUrl);
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_InvalidUrl)
+{
+    QUrl invalidUrl("file:///nonexistent");
+
+    stub.set_lamda(&QAbstractItemView::clearSelection, [](QAbstractItemView *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->setCurrentUrl(invalidUrl);
+
+    // Should handle invalid URL gracefully
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_CollapsedGroup)
+{
+    QUrl testUrl("test/url3");
+
+    SideBarItem *item = model->itemFromIndex(model->index(0, 0));
+    SideBarItemSeparator *separator = dynamic_cast<SideBarItemSeparator *>(item);
+    if (separator) {
+        separator->setExpanded(false);
+    }
+
+    // Should not set current index when group is collapsed
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, CurrentUrl)
+{
+    QUrl testUrl("file:///home/test");
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_EQ(view->currentUrl(), testUrl);
+}
+
+TEST_F(UT_SidebarView, SaveStateWhenClose_WithExpandRules)
+{
+    bool saveConfigCalled = false;
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        map["group2"] = false;
+        return map;
+    });
+
+    stub.set_lamda(&SideBarHelper::saveGroupsStateToConfig, [&saveConfigCalled] {
+        __DBG_STUB_INVOKE__
+        saveConfigCalled = true;
+    });
+
+    view->saveStateWhenClose();
+
+    EXPECT_TRUE(saveConfigCalled);
+}
+
+TEST_F(UT_SidebarView, SaveStateWhenClose_EmptyRules)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    // Should return early when no expand rules
+    view->saveStateWhenClose();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, UpdateSeparatorVisibleState_AllChildrenHidden)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    stub.set_lamda(&QTreeView::isRowHidden, [](const QTreeView *, int, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;   // All children are hidden
+    });
+
+    stub.set_lamda(&QTreeView::setRowHidden, [](QTreeView *, int, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->updateSeparatorVisibleState();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, UpdateSeparatorVisibleState_SomeChildrenVisible)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    stub.set_lamda(&QTreeView::isRowHidden, [](const QTreeView *, int row, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return row > 0;   // First child visible, others hidden
+    });
+
+    stub.set_lamda(&QTreeView::setRowHidden, [](QTreeView *, int, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->updateSeparatorVisibleState();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_ExpandGroup)
+{
+    SideBarItem *groupItem = model->itemFromIndex(model->index(0, 0));
+    ASSERT_NE(groupItem, nullptr);
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool expand) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(expand);
+    });
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    auto updateFunc = static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update);
+    stub.set_lamda(updateFunc, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->onChangeExpandState(groupItem->index(), true);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_CollapseGroup)
+{
+    SideBarItem *groupItem = model->itemFromIndex(model->index(0, 0));
+    ASSERT_NE(groupItem, nullptr);
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool expand) {
+        __DBG_STUB_INVOKE__
+        EXPECT_FALSE(expand);
+    });
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    auto updateFunc = static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update);
+    stub.set_lamda(updateFunc, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->onChangeExpandState(groupItem->index(), false);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_NullItem)
+{
+    QModelIndex invalidIndex;
+
+    // Should handle null item gracefully
+    view->onChangeExpandState(invalidIndex, true);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, PreviousIndex)
+{
+    QModelIndex testIndex = model->index(0, 0);
+    view->setPreviousIndex(testIndex);
+
+    EXPECT_EQ(view->previousIndex(), testIndex);
+}
+
+TEST_F(UT_SidebarView, IsDropTarget_True)
+{
+    QModelIndex testIndex = model->index(0, 0);
+
+    // Simulate drag event to set current hover index
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [testIndex](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return testIndex;
+    });
+
+    QMimeData mimeData;
+    QDragMoveEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    view->dragMoveEvent(&event);
+
+    bool result = view->isDropTarget(testIndex);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, IsSideBarItemDragged_False)
+{
+    bool result = view->isSideBarItemDragged();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SidebarView, StartDrag_ValidUrl)
+{
+    QUrl dragUrl("file:///home/test");
+
+    // mousePressEvent() throttles ops within 200ms of view construction
+    // (checkOpTime()); wait out the window so the press is processed.
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+    stub.set_lamda(&SideBarView::urlAt, [dragUrl](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return dragUrl;
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    // Give startDrag() a valid, drag-enabled source index. Note: inside
+    // SideBarView::mousePressEvent the call to indexAt() is devirtualized, so
+    // the vtable stub only affects calls from Qt's view machinery; also stub
+    // the non-virtual currentIndex() as startDrag()'s fallback.
+    stub.set_lamda(VADDR(SideBarView, indexAt), [this](SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return model->index(0, 0, model->index(0, 0));
+    });
+
+    stub.set_lamda(&QAbstractItemView::currentIndex, [this](QAbstractItemView *) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return model->index(0, 0, model->index(0, 0));
+    });
+
+    // QDrag::exec() spins a nested event loop; stub it to return immediately
+    using ExecFunc = Qt::DropAction (QDrag::*)(Qt::DropActions, Qt::DropAction);
+    auto exec = static_cast<ExecFunc>(&QDrag::exec);
+    bool execCalled = false;
+    stub.set_lamda(exec, [&execCalled](QDrag *, Qt::DropActions, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+        execCalled = true;
+        return Qt::IgnoreAction;
+    });
+
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&pressEvent);
+
+    view->startDrag(Qt::CopyAction | Qt::MoveAction);
+
+    // The drag pipeline ran through exec(); the product clears the dragged
+    // flag after the drag finishes, so it must be false again here.
+    EXPECT_TRUE(execCalled);
+    EXPECT_FALSE(view->isSideBarItemDragged());
+}
+
+TEST_F(UT_SidebarView, StartDrag_InvalidUrl)
+{
+    stub.set_lamda(&SideBarView::urlAt, [](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&pressEvent);
+
+    // Should return early without calling parent
+    view->startDrag(Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, GroupExpandState)
+{
+    QVariantMap state = view->groupExpandState();
+    // Initially should be empty
+    EXPECT_TRUE(state.isEmpty());
+}
+
+TEST_F(UT_SidebarView, DragMoveEvent_ValidItem)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("test", testUrl, "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    auto updateFunc = static_cast<void (QWidget::*)()>(&QWidget::update);
+    stub.set_lamda(updateFunc, [](QWidget *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source") });
+    QDragMoveEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    // Should not ignore the event
+    view->dragMoveEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, DragMoveEvent_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source") });
+    QDragMoveEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::ignore, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->dragMoveEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, DropEvent_ValidDrop)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    stub.set_lamda(VADDR(SideBarView, visualRect), [] {
+        __DBG_STUB_INVOKE__
+        return QRect(0, 0, 100, 30);
+    });
+
+    stub.set_lamda(&SideBarView::onDropData, [](const SideBarView *, QList<QUrl>, QUrl, Qt::DropAction) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QWidget::activateWindow, [](QWidget *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::accept, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+    QDropEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->dropEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnDropData_CopyAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    typedef void (*Func)(int, const QObject *, const std::function<void()> &);
+    stub.set_lamda(static_cast<Func>(&QTimer::singleShot), [](int, const QObject *, std::function<void()> func) {
+        __DBG_STUB_INVOKE__
+        func();   // Execute the lambda
+    });
+
+    stub.set_lamda(&FileOperatorHelper::pasteFiles, [](FileOperatorHelper *, quint64, const QList<QUrl> &, const QUrl &, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return 12345;
+    });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return false; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::CopyAction);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, OnDropData_MoveAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    bool pasteCalled = false;
+
+    stub.set_lamda(&FileOperatorHelper::pasteFiles, [&pasteCalled](FileOperatorHelper *, quint64, const QList<QUrl> &, const QUrl &, Qt::DropAction action) {
+        __DBG_STUB_INVOKE__
+        pasteCalled = true;
+        EXPECT_EQ(action, Qt::MoveAction);
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return 12345;
+    });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return false; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::MoveAction);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(pasteCalled);
+}
+
+TEST_F(UT_SidebarView, OnDropData_IgnoreAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return true; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::IgnoreAction);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_IgnoreAction_EmptyUrls)
+{
+    SideBarItem *item = createSubItem("test", QUrl("file:///test"), "group1");
+
+    QMimeData mimeData;
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_IgnoreAction_InvalidTargetUrl)
+{
+    SideBarItem *item = createSubItem("test", QUrl(), "group1");
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///source") });
+
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_CopyAction)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isSameDevice, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    EXPECT_NO_THROW(view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction));
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_MoveAction_SameDevice)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isSameDevice, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UrlRoute::urlParent, [](const QUrl &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    EXPECT_NO_THROW(view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction));
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_TrashFile_DifferentUser)
+{
+    QUrl targetUrl("file:///home/.local/share/Trash/files");
+    SideBarItem *item = createSubItem("trash", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SysInfoUtils::isSameUser, [](const QMimeData *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UrlRoute::urlParent, [](const QUrl &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, IsAccepteDragEvent_Accept)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(&SideBarView::canDropMimeData, [](const SideBarView *, SideBarItem *, const QMimeData *, Qt::DropActions) -> Qt::DropAction {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::accept, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+    QDropEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    bool result = view->isAccepteDragEvent(&event);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, IsAccepteDragEvent_Reject_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMimeData mimeData;
+    QDropEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    bool result = view->isAccepteDragEvent(&event);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SidebarView, FindItemIndex_WithCallback)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("test", testUrl, "group1");
+
+    ItemInfo info = item->itemInfo();
+    info.findMeCb = [](const QUrl &, const QUrl &) -> bool {
+        return true;
+    };
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    model->appendRow(item);
+
+    QModelIndex result = view->findItemIndex(QUrl("file:///other"));
+
+    EXPECT_TRUE(result.isValid());
+}
+
+TEST_F(UT_SidebarView, FindItemIndex_NotFound)
+{
+    QModelIndex result = view->findItemIndex(QUrl("file:///nonexistent"));
+
+    EXPECT_FALSE(result.isValid());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarwidget.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarwidget.cpp
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebarview.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <DBlurEffectWidget>
+#include <DConfig>
+
+#include <QUrl>
+#include <QEvent>
+#include <QListView>
+
+using namespace dfmplugin_sidebar;
+DWIDGET_USE_NAMESPACE
+
+class UT_SideBarWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub GUI operations
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(static_cast<void (QWidget::*)()>(&QWidget::update), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        widget = new SideBarWidget();
+        ASSERT_NE(widget, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarWidget, Constructor)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_SideBarWidget, View)
+{
+    QAbstractItemView *view = widget->view();
+
+    // Should return the sidebar view
+    EXPECT_NE(view, nullptr);
+}
+
+TEST_F(UT_SideBarWidget, SetCurrentUrl)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->setCurrentUrl(testUrl);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, CurrentUrl)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/current");
+
+    stub.set_lamda(&SideBarView::currentUrl, [testUrl]() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    QUrl retrievedUrl = widget->currentUrl();
+
+    EXPECT_EQ(retrievedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarWidget, AddItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/add");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::appendRow, [](SideBarModel *, SideBarItem *, bool) -> int {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+
+    int result = widget->addItem(item, true);
+
+    EXPECT_GE(result, -1);
+}
+
+TEST_F(UT_SideBarWidget, InsertItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/insert");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::insertRow, [](SideBarModel *, int, SideBarItem *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = widget->insertItem(0, item);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarWidget, RemoveItem_InvalidUrl)
+{
+    QUrl invalidUrl;
+
+    bool result = widget->removeItem(invalidUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarWidget, RemoveItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+
+    stub.set_lamda(&SideBarModel::removeRow, [](SideBarModel *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = widget->removeItem(testUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/update");
+
+    ItemInfo newInfo;
+    newInfo.url = testUrl;
+    newInfo.displayName = "Updated";
+
+    stub.set_lamda(&SideBarModel::updateRow, [](SideBarModel *, const QUrl &, const ItemInfo &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->updateItem(testUrl, newInfo);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, FindItem_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    int result = widget->findItem(testUrl);
+    EXPECT_EQ(result, -1);
+}
+
+TEST_F(UT_SideBarWidget, FindItemIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/find");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        return index;
+    });
+
+    QModelIndex index = widget->findItemIndex(testUrl);
+
+    // Just verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, EditItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/edit");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    stub.set_lamda(static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::edit), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->editItem(testUrl);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, SetItemVisiable)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/visible");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    stub.set_lamda(&QListView::setRowHidden, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->setItemVisiable(testUrl, true);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItemVisiable_EmptyMap)
+{
+    QVariantMap emptyStates;
+
+    widget->updateItemVisiable(emptyStates);
+
+    // Should not crash with empty map
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItemVisiable_WithStates)
+{
+    QVariantMap states;
+    states["key1"] = false;
+    states["key2"] = true;
+
+    stub.set_lamda(&SideBarWidget::findItemUrlsByVisibleControlKey,
+                   [](const SideBarWidget *, const QString &) -> QList<QUrl> {
+                       __DBG_STUB_INVOKE__
+                       return QList<QUrl>();
+                   });
+
+    widget->updateItemVisiable(states);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, FindItemUrlsByVisibleControlKey)
+{
+    QString key = "test_key";
+
+    stub.set_lamda(static_cast<QList<SideBarItem *> (SideBarModel::*)() const>(&SideBarModel::subItems),
+                   [](const SideBarModel *) -> QList<SideBarItem *> {
+                       __DBG_STUB_INVOKE__
+                       return QList<SideBarItem *>();
+                   });
+
+    QList<QUrl> urls = widget->findItemUrlsByVisibleControlKey(key);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateSelection)
+{
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->updateSelection();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, SaveStateWhenClose)
+{
+    stub.set_lamda(&SideBarView::saveStateWhenClose, [](SideBarView *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->saveStateWhenClose();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, ResetSettingPanel)
+{
+    stub.set_lamda(&SideBarModel::groupItems,
+                   [](const SideBarModel *) -> QList<SideBarItemSeparator *> {
+                       __DBG_STUB_INVOKE__
+                       return QList<SideBarItemSeparator *>();
+                   });
+
+    widget->resetSettingPanel();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, ChangeEvent_PaletteChange)
+{
+    QPalette oldPalette;
+    QPalette newPalette;
+
+    QEvent *event = new QEvent(QEvent::PaletteChange);
+
+    stub.set_lamda(VADDR(QWidget, changeEvent), [](QWidget *, QEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    // Protected method, tested through public API
+    widget->changeEvent(event);
+
+    delete event;
+
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
Part 2/2 of dfmplugin-sidebar unit tests, split by module for easier review:
视图、模型与组件.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-sidebar 单元测试第 2/2 部分（按模块拆分以便评审）：视图、模型与组件。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-sidebar 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Tests:
- Add unit test coverage for sidebar file operations, items, separators, model behavior, delegate interactions, view events, drag-and-drop handling, and widget APIs.