### PR TITLE
test: add unit tests for dfmplugin-tag (part 1/2: backend)

### DIFF
--- a/autotests/plugins/dfmplugin-tag/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-tag/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-tag" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-tag") 

--- a/autotests/plugins/dfmplugin-tag/main.cpp
+++ b/autotests/plugins/dfmplugin-tag/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_tag)

--- a/autotests/plugins/dfmplugin-tag/test_anythingmonitorfilter.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_anythingmonitorfilter.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/anythingmonitorfilter.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QFile>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_AnythingMonitorFilter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = &AnythingMonitorFilter::instance();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+    AnythingMonitorFilter *ins;
+};
+
+TEST_F(UT_AnythingMonitorFilter, whetherFilterCurrentPath)
+{
+    EXPECT_TRUE(ins->whetherFilterCurrentPath("/media"));
+    EXPECT_TRUE(!ins->whetherFilterCurrentPath("~/.local/share/Trash"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_filetagcache.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_filetagcache.cpp
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/utils/private/filetagcache_p.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QVariantMap>
+
+using namespace dfmplugin_tag;
+
+class UT_FileTagCacheController : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub QThread operations to avoid thread issues in tests
+        stub.set_lamda(ADDR(QThread, start), [](QThread*, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+            // Prevent thread from starting
+        });
+
+        stub.set_lamda(ADDR(QThread, quit), [](QThread*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(static_cast<bool (QThread::*)(QDeadlineTimer)>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        controller = &FileTagCacheController::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    FileTagCacheController *controller = nullptr;
+};
+
+TEST_F(UT_FileTagCacheController, instance)
+{
+    // Test singleton instance
+    FileTagCacheController *instance1 = &FileTagCacheController::instance();
+    FileTagCacheController *instance2 = &FileTagCacheController::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFile_Empty)
+{
+    // Test getting tags for empty file path
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    QStringList tags = controller->getTagsByFile("");
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFile_ValidFile)
+{
+    // Test getting tags for valid file
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1" << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFile("/home/user/test.txt");
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_Empty)
+{
+    // Test getting tags for empty file list
+    QStringList paths;
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_MultipleFiles)
+{
+    // Test getting tags for multiple files
+    QStringList paths;
+    paths << "/home/user/file1.txt" << "/home/user/file2.txt";
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1" << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_Empty)
+{
+    // Test getting colors for empty tag list
+    QStringList tags;
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        return QMap<QString, QColor>();
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_TRUE(colors.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_ValidTags)
+{
+    // Test getting colors for valid tags
+    QStringList tags;
+    tags << "Tag1" << "Tag2";
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> colors;
+        colors["Tag1"] = QColor("#ffa503");
+        colors["Tag2"] = QColor("#ff1c49");
+        return colors;
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_EQ(colors.size(), 2);
+    EXPECT_TRUE(colors.contains("Tag1"));
+    EXPECT_TRUE(colors.contains("Tag2"));
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_Empty)
+{
+    // Test finding children for empty path
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        return QHash<QString, QStringList>();
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("");
+
+    EXPECT_TRUE(children.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_ValidPath)
+{
+    // Test finding children for valid path
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        QHash<QString, QStringList> children;
+        QStringList tags;
+        tags << "Tag1";
+        children["/home/user/subdir/file.txt"] = tags;
+        return children;
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("/home/user");
+
+    EXPECT_FALSE(children.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_SingleFile)
+{
+    // Test getting tags for a single file (common tags scenario)
+    QStringList paths;
+    paths << "/home/user/test.txt";
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Important" << "Work";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_FALSE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_MixedColors)
+{
+    // Test getting colors with different color formats
+    QStringList tags;
+    tags << "Orange" << "Red" << "Blue";
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> colors;
+        colors["Orange"] = QColor("#ffa503");
+        colors["Red"] = QColor("#ff1c49");
+        colors["Blue"] = QColor("#0000ff");
+        return colors;
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_EQ(colors.size(), 3);
+    EXPECT_TRUE(colors["Orange"].isValid());
+    EXPECT_TRUE(colors["Red"].isValid());
+    EXPECT_TRUE(colors["Blue"].isValid());
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_NestedPaths)
+{
+    // Test finding children in nested directory structure
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        QHash<QString, QStringList> children;
+        children["/home/user/dir1/file1.txt"] = QStringList() << "Tag1";
+        children["/home/user/dir2/file2.txt"] = QStringList() << "Tag2";
+        children["/home/user/dir1/subdir/file3.txt"] = QStringList() << "Tag1" << "Tag2";
+        return children;
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("/home/user");
+
+    EXPECT_EQ(children.size(), 3);
+}

--- a/autotests/plugins/dfmplugin-tag/test_filetagcache_impl.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_filetagcache_impl.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/utils/private/filetagcache_p.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QVariantMap>
+#include <QThread>
+
+using namespace dfmplugin_tag;
+
+class FileTagCacheImpl : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Prevent the FileTagCacheController update thread from actually running;
+        // otherwise the unit-test process may hang or crash because the worker
+        // lives in a thread without an event loop.
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+        });
+        stub.set_lamda(ADDR(QThread, quit), [](QThread *) {
+            __DBG_STUB_INVOKE__
+        });
+        stub.set_lamda(static_cast<bool (QThread::*)(QDeadlineTimer)>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        // Make sure the controller singleton is materialized under the stubs above.
+        controller = &FileTagCacheController::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    FileTagCacheController *controller = nullptr;
+};
+
+TEST_F(FileTagCacheImpl, controller_singleton)
+{
+    EXPECT_NE(controller, nullptr);
+    EXPECT_EQ(controller, &FileTagCacheController::instance());
+}
+
+TEST_F(FileTagCacheImpl, load_file_tags_from_database)
+{
+    stub.set_lamda(&TagProxyHandle::getAllFileWithTags, [](TagProxyHandle *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash.insert("/tmp/ftc_impl/file1.txt", QStringList() << "ImplTag1");
+        return hash;
+    });
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("ImplTag1", "#ff0000");
+        return map;
+    });
+    stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, [](TagProxyHandle *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash.insert("/tmp/ftc_impl/trash:42", QStringList() << "ImplTrashTag");
+        return hash;
+    });
+
+    FileTagCacheWorker worker;
+    worker.loadFileTagsFromDatabase();
+
+    EXPECT_EQ(controller->getTagsByFile("/tmp/ftc_impl/file1.txt"), QStringList({ "ImplTag1" }));
+
+    auto colors = controller->getCacheTagsColor({ "ImplTag1" });
+    EXPECT_EQ(colors.size(), 1);
+    EXPECT_EQ(colors.value("ImplTag1").name().toLower(), QString("#ff0000"));
+
+    auto trashTags = controller->getTrashFileTags("/tmp/ftc_impl/trash", 42);
+    EXPECT_EQ(trashTags, QStringList({ "ImplTrashTag" }));
+}
+
+TEST_F(FileTagCacheImpl, add_and_delete_tags)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplTagAdd", "#00ff00");
+    worker.onTagAdded(tags);
+
+    auto colors = controller->getCacheTagsColor({ "ImplTagAdd" });
+    EXPECT_EQ(colors.size(), 1);
+    EXPECT_EQ(colors.value("ImplTagAdd").name().toLower(), QString("#00ff00"));
+
+    worker.onTagDeleted(QVariant(QStringList({ "ImplTagAdd" })));
+    colors = controller->getCacheTagsColor({ "ImplTagAdd" });
+    EXPECT_TRUE(colors.isEmpty());
+}
+
+TEST_F(FileTagCacheImpl, tag_and_untag_files)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplTagFile", "#0000ff");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/ftc_impl/file2.txt", QStringList({ "ImplTagFile" }));
+    worker.onFilesTagged(fileTags);
+
+    EXPECT_EQ(controller->getTagsByFile("/tmp/ftc_impl/file2.txt"), QStringList({ "ImplTagFile" }));
+
+    worker.onFilesUntagged(fileTags);
+    EXPECT_TRUE(controller->getTagsByFile("/tmp/ftc_impl/file2.txt").isEmpty());
+}
+
+TEST_F(FileTagCacheImpl, change_tag_color)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplTagColor", "#123456");
+    worker.onTagAdded(tags);
+
+    QVariantMap colorMap;
+    colorMap.insert("ImplTagColor", "#654321");
+    worker.onTagsColorChanged(colorMap);
+
+    auto colors = controller->getCacheTagsColor({ "ImplTagColor" });
+    EXPECT_EQ(colors.size(), 1);
+    EXPECT_EQ(colors.value("ImplTagColor").name().toLower(), QString("#654321"));
+}
+
+TEST_F(FileTagCacheImpl, change_tag_name)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplTagOldName", "#abcdef");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/ftc_impl/file3.txt", QStringList({ "ImplTagOldName" }));
+    worker.onFilesTagged(fileTags);
+
+    QVariantMap nameMap;
+    nameMap.insert("ImplTagOldName", "ImplTagNewName");
+    worker.onTagsNameChanged(nameMap);
+
+    auto fileTagsResult = controller->getTagsByFile("/tmp/ftc_impl/file3.txt");
+    EXPECT_TRUE(fileTagsResult.contains("ImplTagNewName"));
+    EXPECT_FALSE(fileTagsResult.contains("ImplTagOldName"));
+
+    auto colors = controller->getCacheTagsColor({ "ImplTagNewName" });
+    EXPECT_EQ(colors.size(), 1);
+    EXPECT_EQ(colors.value("ImplTagNewName").name().toLower(), QString("#abcdef"));
+}
+
+TEST_F(FileTagCacheImpl, get_tags_by_files_intersection)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplCommon", "#ff0000");
+    tags.insert("ImplOnlyA", "#00ff00");
+    tags.insert("ImplOnlyB", "#0000ff");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/ftc_impl/fileA.txt", QStringList({ "ImplCommon", "ImplOnlyA" }));
+    fileTags.insert("/tmp/ftc_impl/fileB.txt", QStringList({ "ImplCommon", "ImplOnlyB" }));
+    worker.onFilesTagged(fileTags);
+
+    auto result = controller->getTagsByFiles({ "/tmp/ftc_impl/fileA.txt", "/tmp/ftc_impl/fileB.txt" });
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(result.contains("ImplCommon"));
+}
+
+TEST_F(FileTagCacheImpl, get_tags_by_files_empty_paths)
+{
+    auto result = controller->getTagsByFiles(QStringList());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(FileTagCacheImpl, find_children)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplChildTag", "#ffaa00");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/ftc_impl/dir/file1.txt", QStringList({ "ImplChildTag" }));
+    fileTags.insert("/tmp/ftc_impl/dir/sub/file2.txt", QStringList({ "ImplChildTag" }));
+    fileTags.insert("/tmp/ftc_impl/other/file3.txt", QStringList({ "ImplChildTag" }));
+    worker.onFilesTagged(fileTags);
+
+    auto children = controller->findChildren("/tmp/ftc_impl/dir");
+    EXPECT_EQ(children.size(), 2);
+    EXPECT_TRUE(children.contains("/tmp/ftc_impl/dir/file1.txt"));
+    EXPECT_TRUE(children.contains("/tmp/ftc_impl/dir/sub/file2.txt"));
+    EXPECT_FALSE(children.contains("/tmp/ftc_impl/other/file3.txt"));
+}
+
+TEST_F(FileTagCacheImpl, get_tags_color_ignores_unknown_tags)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplKnownTag", "#112233");
+    worker.onTagAdded(tags);
+
+    auto colors = controller->getCacheTagsColor({ "ImplKnownTag", "ImplUnknownTag" });
+    EXPECT_EQ(colors.size(), 1);
+    EXPECT_TRUE(colors.contains("ImplKnownTag"));
+    EXPECT_FALSE(colors.contains("ImplUnknownTag"));
+}
+
+TEST_F(FileTagCacheImpl, reload_trash_file_tags)
+{
+    stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, [](TagProxyHandle *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash.insert("/tmp/ftc_impl/trash2:99", QStringList() << "ImplTrashTag2");
+        return hash;
+    });
+
+    FileTagCacheWorker worker;
+    worker.onTrashFileTagsChanged();
+
+    auto trashTags = controller->getTrashFileTags("/tmp/ftc_impl/trash2", 99);
+    EXPECT_EQ(trashTags, QStringList({ "ImplTrashTag2" }));
+}
+
+TEST_F(FileTagCacheImpl, delete_tag_removes_it_from_files)
+{
+    FileTagCacheWorker worker;
+
+    QVariantMap tags;
+    tags.insert("ImplTagToDelete", "#deadbeef");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/ftc_impl/delete_me.txt", QStringList({ "ImplTagToDelete" }));
+    worker.onFilesTagged(fileTags);
+
+    EXPECT_FALSE(controller->getTagsByFile("/tmp/ftc_impl/delete_me.txt").isEmpty());
+
+    worker.onTagDeleted(QVariant(QStringList({ "ImplTagToDelete" })));
+
+    EXPECT_TRUE(controller->getTagsByFile("/tmp/ftc_impl/delete_me.txt").isEmpty());
+    EXPECT_TRUE(controller->getCacheTagsColor({ "ImplTagToDelete" }).isEmpty());
+}

--- a/autotests/plugins/dfmplugin-tag/test_tag.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tag.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "tag.h"
+#include "utils/tagmanager.h"
+#include "utils/taghelper.h"
+#include "utils/filetagcache.h"
+#include "widgets/tagwidget.h"
+#include "widgets/private/tagwidget_p.h"
+#include "data/tagproxyhandle.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+#include "qdbusabstractinterface.h"
+#include <QDBusPendingCall>
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_tag;
+using namespace dpf;
+using namespace QDBus;
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+
+class TagTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagManager::getAllTags, []() {
+            __DBG_STUB_INVOKE__
+            return QMap<QString, QColor>();
+        });
+        stub.set_lamda(&QDBusAbstractInterface::asyncCallWithArgumentList, []() {
+            return QDBusPendingCall::fromError(QDBusError());
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+protected:
+    stub_ext::StubExt stub;
+    Tag ins;
+};
+
+TEST_F(TagTest, Start)
+{
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, CustomViewExtensionView, int &);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, CustomViewExtensionView, QString &, int &);
+    typedef QVariant (EventChannelManager::*Push3)(const QString &, const QString &, QString, QStringList &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    auto push3 = static_cast<Push3>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(&FileTagCacheController::initLoadTagInfos, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_TRUE(ins.start());
+}
+
+TEST_F(TagTest, createTagWidget)
+{
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::getTagsByUrls, []() {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+    EXPECT_TRUE(ins.createTagWidgetForPropertyDialog(QUrl("file://hello/world")));
+}
+
+TEST_F(TagTest, initialize)
+{
+    bool isRegister = false;
+    stub.set_lamda(&TagProxyHandle::connectToService, [&isRegister]() {
+        __DBG_STUB_INVOKE__
+        isRegister = true;
+        return true;
+    });
+    ins.initialize();
+    EXPECT_TRUE(isRegister);
+}
+
+TEST_F(TagTest, onWindowOpened)
+{
+    bool isRun = false;
+    FileManagerWindow w(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&w, &isRun] {
+        isRun = true;
+        return &w;
+    });
+    stub.set_lamda(&Tag::installToSideBar, [] {});
+    ins.onWindowOpened(1);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, onAllPluginsStarted)
+{
+    bool isRun = false;
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [&isRun] {
+        isRun = true;
+        return QVariant();
+    });
+
+    ins.onAllPluginsStarted();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, installToSideBar)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::getAllTags, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        QMap<QString, QColor> map;
+        map.insert("red", QColor("red"));
+        return map;
+    });
+
+    stub.set_lamda(&TagHelper::createSidebarItemInfo, []() { return QVariantMap(); });
+    ins.installToSideBar();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, onMenuSceneAdded)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() {
+        __DBG_STUB_INVOKE__
+        return QMap<QString, QColor>();
+    });
+    ins.menuScenes.insert("TagMenu");
+    ins.onMenuSceneAdded("TagMenu");
+    EXPECT_TRUE(!ins.subscribedEvent);
+}
+
+TEST_F(TagTest, regTagCrumbToTitleBar)
+{
+    bool isCall { false };
+
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, QVariantMap &&);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    ins.regTagCrumbToTitleBar();
+
+    EXPECT_TRUE(isCall);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagdiriterator.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagdiriterator.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "files/tagdiriterator.h"
+#include "files/private/tagdiriterator_p.h"
+#include "utils/tagmanager.h"
+#include "utils/taghelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QDir>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class TagDirIteratorTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+
+        stub.set_lamda(&TagManager::getFilesByTag, []() {
+            __DBG_STUB_INVOKE__
+            return QStringList() << QString("红色");
+        });
+        iter = new TagDirIterator(QUrl::fromLocalFile("/home/"), {}, QDir::AllEntries);
+        d = iter->d.data();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete iter;
+        iter = nullptr;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagDirIterator *iter { nullptr };
+    TagDirIteratorPrivate *d { nullptr };
+};
+
+TEST_F(TagDirIteratorTest, Next)
+{
+    EXPECT_FALSE(iter->next().isValid());
+}
+
+TEST_F(TagDirIteratorTest, HasNext)
+{
+    EXPECT_FALSE(iter->hasNext());
+}
+
+TEST_F(TagDirIteratorTest, FileName)
+{
+    EXPECT_TRUE(iter->fileName() == "");
+}
+
+TEST_F(TagDirIteratorTest, FileUrl)
+{
+    EXPECT_FALSE(iter->fileUrl().isValid());
+}
+
+TEST_F(TagDirIteratorTest, FileInfo)
+{
+    EXPECT_TRUE(iter->fileInfo() == nullptr);
+}
+
+TEST_F(TagDirIteratorTest, Url)
+{
+    EXPECT_TRUE(iter->url().isValid());
+}
+
+TEST_F(TagDirIteratorTest, loadTagsUrls)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> map;
+        map.insert("红色", QColor("red"));
+        return map;
+    });
+    d->loadTagsUrls(TagHelper::rootUrl());
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageventcaller.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageventcaller.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QRect>
+
+using namespace dfmplugin_tag;
+DPF_USE_NAMESPACE
+
+Q_DECLARE_METATYPE(QRectF *)
+Q_DECLARE_METATYPE(QPoint *)
+
+TEST(UT_TagEventCaller, sendOpenWindow)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, QUrl);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenWindow(QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendOpenTab)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenTab(0, QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendCheckTabAddable)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return true;
+    });
+    TagEventCaller::sendCheckTabAddable(0);
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionView)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+
+    TagEventCaller::getCollectionView("");
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendOpenFiles)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, quint64, const QList<QUrl> &);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenFiles(0, QList<QUrl>() << QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionVisualRect)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, const QUrl &);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+    TagEventCaller::getCollectionVisualRect("", QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionIconRect)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, QRect &);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+    TagEventCaller::getCollectionIconRect("", QRect());
+
+    EXPECT_TRUE(isCall);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageventreceiver.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/events/tageventreceiver.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/event/event.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QPainter>
+#include <QPixmap>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_tag;
+Q_DECLARE_METATYPE(QDir::Filters);
+class TagEventReceiverTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+    }
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TagEventReceiverTest, handleFileCutResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    TagEventReceiver::instance()->handleFileCutResult(QList<QUrl>() << QUrl("/"), QList<QUrl>(), true, QString());
+    TagEventReceiver::instance()->handleFileCutResult(QList<QUrl>() << QUrl("/"), QList<QUrl>() << QUrl("/"), true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleHideFilesResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::hideFiles, []() {});
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+    TagEventReceiver::instance()->handleHideFilesResult(1, QList<QUrl>() << QUrl("/"), true);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleFileRemoveResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    TagEventReceiver::instance()->handleWindowUrlChanged(1, QUrl("tag:/"));
+    TagEventReceiver::instance()->handleFileRemoveResult(QList<QUrl>() << QUrl("/"), true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleFileRenameResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    QMap<QUrl, QUrl> map;
+    map.insert(QUrl("/"), QUrl("/"));
+    TagEventReceiver::instance()->handleFileRenameResult(1, map, true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleGetTags)
+{
+    stub.set_lamda(&TagManager::getTagsByUrls, []() {
+        __DBG_STUB_INVOKE__
+        return QStringList() << "red";
+    });
+    EXPECT_TRUE(!TagEventReceiver::instance()->handleGetTags(QUrl("/")).isEmpty());
+}
+
+TEST_F(TagEventReceiverTest, handleSidebarOrderChanged)
+{
+    EXPECT_NO_THROW(TagEventReceiver::instance()->handleSidebarOrderChanged(1, QString("Group_Tag"), QList<QUrl>()));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfilehelper.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfilehelper.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "utils/tagfilehelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QRect>
+
+using namespace dfmplugin_tag;
+
+class TagFileHelperTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = TagFileHelper::instance();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagFileHelper *ins;
+};
+
+TEST_F(TagFileHelperTest, openFileInPlugin)
+{
+    EXPECT_TRUE(!ins->openFileInPlugin(1, QList<QUrl>() << QUrl("file:/test")));
+    EXPECT_TRUE(!ins->openFileInPlugin(1, QList<QUrl>()));
+    EXPECT_TRUE(ins->openFileInPlugin(1, QList<QUrl>() << QUrl("tag:/test")));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfilewatcher.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfilewatcher.cpp
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/files/tagfilewatcher.h"
+#include "plugins/common/dfmplugin-tag/files/private/tagfilewatcher_p.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <dfm-base/utils/universalutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagFileWatcher : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl.setScheme("tag");
+        testUrl.setPath("/TestTag");
+
+        // Stub initialization methods
+        stub.set_lamda(&TagFileWatcherPrivate::initFileWatcher, [](TagFileWatcherPrivate*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TagFileWatcherPrivate::initConnect, [](TagFileWatcherPrivate*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        watcher = new TagFileWatcher(testUrl);
+    }
+
+    virtual void TearDown() override
+    {
+        delete watcher;
+        watcher = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagFileWatcher *watcher = nullptr;
+    QUrl testUrl;
+};
+
+TEST_F(UT_TagFileWatcher, constructor)
+{
+    // Test constructor
+    EXPECT_NE(watcher, nullptr);
+}
+
+TEST_F(UT_TagFileWatcher, setEnabledSubfileWatcher)
+{
+    // Test setEnabledSubfileWatcher (currently does nothing)
+    QUrl subfileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    EXPECT_NO_THROW(watcher->setEnabledSubfileWatcher(subfileUrl, true));
+    EXPECT_NO_THROW(watcher->setEnabledSubfileWatcher(subfileUrl, false));
+}
+
+TEST_F(UT_TagFileWatcher, onTagRemoved_MatchingTag)
+{
+    // Test when the removed tag matches the watcher's tag
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/TestTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return true; // URLs match
+    });
+
+    watcher->onTagRemoved("TestTag");
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onTagRemoved_DifferentTag)
+{
+    // Test when the removed tag doesn't match
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/OtherTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // URLs don't match
+    });
+
+    watcher->onTagRemoved("OtherTag");
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_SingleFile)
+{
+    // Test when a single file is tagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_MultipleFiles)
+{
+    // Test when multiple files are tagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/file1.txt"] = tags;
+    fileAndTags["/home/user/file2.txt"] = tags;
+    fileAndTags["/home/user/file3.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 3);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_DifferentTag)
+{
+    // Test when files are tagged with different tag
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "OtherTag"; // Different tag
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesUntagged_SingleFile)
+{
+    // Test when a single file is untagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesUntagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesUntagged_MultipleFiles)
+{
+    // Test when multiple files are untagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/file1.txt"] = tags;
+    fileAndTags["/home/user/file2.txt"] = tags;
+
+    watcher->onFilesUntagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesHidden_SingleFile)
+{
+    // Test when a single file is hidden
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesHidden(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesHidden_DifferentTag)
+{
+    // Test when files with different tags are hidden
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "OtherTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesHidden(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_EmptyMap)
+{
+    // Test with empty file and tags map
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags; // Empty map
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, signals)
+{
+    // Test that all signals can be emitted without crashing
+    QSignalSpy subfileCreatedSpy(watcher, &AbstractFileWatcher::subfileCreated);
+    QSignalSpy fileDeletedSpy(watcher, &AbstractFileWatcher::fileDeleted);
+    QSignalSpy fileAttributeChangedSpy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/TestTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    // Trigger different signals
+    watcher->onFilesTagged(fileAndTags);
+    watcher->onFilesUntagged(fileAndTags);
+    watcher->onFilesHidden(fileAndTags);
+    watcher->onTagRemoved("TestTag");
+
+    EXPECT_GT(subfileCreatedSpy.count() + fileDeletedSpy.count() + fileAttributeChangedSpy.count(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_taghelper.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_taghelper.cpp
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/widgets/tageditor.h"
+
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <QPainter>
+#include <QPixmap>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        helper = TagHelper::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagHelper *helper = nullptr;
+};
+
+TEST_F(UT_TagHelper, instance)
+{
+    // Test singleton instance
+    TagHelper *instance1 = TagHelper::instance();
+    TagHelper *instance2 = TagHelper::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagHelper, scheme)
+{
+    // Test scheme method
+    EXPECT_EQ(TagHelper::scheme(), "tag");
+}
+
+TEST_F(UT_TagHelper, rootUrl)
+{
+    // Test rootUrl static method
+    QUrl root = TagHelper::rootUrl();
+
+    EXPECT_EQ(root.scheme(), "tag");
+    EXPECT_EQ(root.path(), "/");
+}
+
+TEST_F(UT_TagHelper, commonUrls_Empty)
+{
+    // Test with empty URL list
+    QList<QUrl> urls;
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_TagHelper, commonUrls_NoTransform)
+{
+    // Test when URLs don't need transformation
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/home/user/test.txt");
+
+    // Stub bindUrlTransform to return the same URL
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), urls.first());
+}
+
+TEST_F(UT_TagHelper, commonUrls_WithTransform)
+{
+    // Test when URLs need transformation
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/mount/test.txt");
+
+    QUrl transformedUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    // Stub bindUrlTransform to return a different URL
+    stub.set_lamda(&FileUtils::bindUrlTransform, [transformedUrl](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return transformedUrl;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;   // URLs are different
+    });
+
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), transformedUrl);
+}
+
+TEST_F(UT_TagHelper, defaultColors)
+{
+    // Test default colors list
+    QList<QColor> colors = helper->defaultColors();
+
+    // Should have 8 default colors based on initTagColorDefines
+    EXPECT_EQ(colors.size(), 8);
+
+    // Verify at least one color is valid
+    EXPECT_TRUE(colors.first().isValid());
+}
+
+TEST_F(UT_TagHelper, queryColorByColorName_Valid)
+{
+    // Test querying color by valid color name
+    QColor color = helper->queryColorByColorName("Orange");
+
+    EXPECT_TRUE(color.isValid());
+    EXPECT_EQ(color.name().toLower(), "#ffa503");
+}
+
+TEST_F(UT_TagHelper, queryColorByColorName_Invalid)
+{
+    // Test querying color by invalid color name
+    QColor color = helper->queryColorByColorName("InvalidColor");
+
+    EXPECT_FALSE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, queryColorByDisplayName_Valid)
+{
+    // Test querying color by valid display name
+    QColor color = helper->queryColorByDisplayName(QObject::tr("Orange"));
+
+    EXPECT_TRUE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, queryColorByDisplayName_Invalid)
+{
+    // Test querying color by invalid display name
+    QColor color = helper->queryColorByDisplayName("InvalidDisplayName");
+
+    EXPECT_FALSE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, queryColorNameByColor_Valid)
+{
+    // Test querying color name by valid color
+    QColor color("#ffa503");
+    QString colorName = helper->queryColorNameByColor(color);
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, queryColorNameByColor_Invalid)
+{
+    // Test querying color name by invalid color
+    QColor color("#123456");   // Non-existent color
+    QString colorName = helper->queryColorNameByColor(color);
+
+    EXPECT_TRUE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, queryIconNameByColorName_Valid)
+{
+    // Test querying icon name by valid color name
+    QString iconName = helper->queryIconNameByColorName("Orange");
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagHelper, queryIconNameByColorName_Invalid)
+{
+    // Test querying icon name by invalid color name
+    QString iconName = helper->queryIconNameByColorName("InvalidColor");
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, queryIconNameByColor_Valid)
+{
+    // Test querying icon name by valid color
+    QColor color("#ffa503");
+    QString iconName = helper->queryIconNameByColor(color);
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagHelper, queryIconNameByColor_Invalid)
+{
+    // Test querying icon name by invalid color
+    QColor color("#123456");
+    QString iconName = helper->queryIconNameByColor(color);
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, queryDisplayNameByColor_Valid)
+{
+    // Test querying display name by valid color
+    QColor color("#ffa503");
+    QString displayName = helper->queryDisplayNameByColor(color);
+
+    EXPECT_EQ(displayName, QObject::tr("Orange"));
+}
+
+TEST_F(UT_TagHelper, queryDisplayNameByColor_Invalid)
+{
+    // Test querying display name by invalid color
+    QColor color("#123456");
+    QString displayName = helper->queryDisplayNameByColor(color);
+
+    EXPECT_TRUE(displayName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, queryColorNameByDisplayName_Valid)
+{
+    // Test querying color name by valid display name
+    QString colorName = helper->queryColorNameByDisplayName(QObject::tr("Orange"));
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, queryColorNameByDisplayName_Invalid)
+{
+    // Test querying color name by invalid display name
+    QString colorName = helper->queryColorNameByDisplayName("InvalidDisplayName");
+
+    EXPECT_TRUE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, getTagNameFromUrl_Valid)
+{
+    // Test extracting tag name from valid tag URL
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/MyTag");
+
+    QString tagName = helper->getTagNameFromUrl(tagUrl);
+
+    EXPECT_EQ(tagName, "MyTag");
+}
+
+TEST_F(UT_TagHelper, getTagNameFromUrl_Invalid)
+{
+    // Test extracting tag name from non-tag URL
+    QUrl fileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    QString tagName = helper->getTagNameFromUrl(fileUrl);
+
+    EXPECT_TRUE(tagName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, makeTagUrlByTagName)
+{
+    // Test creating tag URL from tag name
+    QString tagName = "MyTag";
+    QUrl tagUrl = helper->makeTagUrlByTagName(tagName);
+
+    EXPECT_EQ(tagUrl.scheme(), "tag");
+    EXPECT_EQ(tagUrl.path(), "/MyTag");
+}
+
+TEST_F(UT_TagHelper, getColorNameByTag_DefaultTag)
+{
+    // Test getting color name for default tag
+    QString colorName = helper->getColorNameByTag(QObject::tr("Orange"));
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, getColorNameByTag_CustomTag)
+{
+    // Test getting color name for custom tag (should return random color)
+    QString colorName = helper->getColorNameByTag("CustomTag");
+
+    // Should return one of the default color names
+    EXPECT_FALSE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, isDefaultTag_DefaultTag)
+{
+    // Test checking if tag is default tag
+    bool isDefault = helper->isDefaultTag(QObject::tr("Orange"));
+
+    EXPECT_TRUE(isDefault);
+}
+
+TEST_F(UT_TagHelper, isDefaultTag_CustomTag)
+{
+    // Test checking if custom tag is default tag
+    bool isDefault = helper->isDefaultTag("CustomTag");
+
+    EXPECT_FALSE(isDefault);
+}
+
+TEST_F(UT_TagHelper, paintTags)
+{
+    // Test painting tags
+    QPixmap pixmap(100, 100);
+    QPainter painter(&pixmap);
+    QRectF rect(0, 0, 100, 100);
+    QList<QColor> colors;
+    colors << QColor("#ffa503") << QColor("#ff1c49");
+
+    EXPECT_NO_THROW(helper->paintTags(&painter, rect, colors));
+
+    // Rect should be modified (right side moved left)
+    EXPECT_LT(rect.right(), 100);
+}
+
+TEST_F(UT_TagHelper, createSidebarItemInfo)
+{
+    // Test creating sidebar item info
+    QString tagName = "TestTag";
+
+    // Stub TagManager::instance to avoid initialization issues
+    stub.set_lamda(&TagManager::instance, []() -> TagManager * {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getTagIconName, [](TagManager *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    QVariantMap infoMap = helper->createSidebarItemInfo(tagName);
+
+    EXPECT_FALSE(infoMap.isEmpty());
+    EXPECT_TRUE(infoMap.contains("Property_Key_Url"));
+    EXPECT_TRUE(infoMap.contains("Property_Key_DisplayName"));
+    EXPECT_EQ(infoMap["Property_Key_DisplayName"].toString(), tagName);
+}
+
+TEST_F(UT_TagHelper, showTagEdit)
+{
+    typedef void (*fptr)(TagEditor *, int x, int y);
+    fptr p = (fptr)(&TagEditor::show);
+
+    bool flag = false;
+    stub.set_lamda(&TagManager::getTagsByUrls, []() { __DBG_STUB_INVOKE__ return QStringList(); });
+    stub.set_lamda(p, [&flag]() {
+        __DBG_STUB_INVOKE__
+        flag = true;
+    });
+
+    helper->showTagEdit(QRectF(), QRectF(), QList<QUrl>() << QUrl("tag:/test"), true);
+    EXPECT_TRUE(flag);
+}
+
+TEST_F(UT_TagHelper, crumbEditInputFilter_NullEdit)
+{
+    // Test crumb edit input filter with null pointer
+    EXPECT_NO_THROW(helper->crumbEditInputFilter(nullptr));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmanager.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmanager.cpp
@@ -1,0 +1,596 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/utils/anythingmonitorfilter.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+
+#include <QUrl>
+#include <QColor>
+#include <QPainter>
+#include <QPixmap>
+#include <QMenu>
+#include <QDBusVariant>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = TagManager::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagManager *ins = nullptr;
+};
+
+TEST_F(UT_TagManager, instance)
+{
+    // Test singleton instance
+    TagManager *instance1 = TagManager::instance();
+    TagManager *instance2 = TagManager::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagManager, scheme)
+{
+    // Test scheme method
+    EXPECT_EQ(TagManager::scheme(), "tag");
+}
+
+TEST_F(UT_TagManager, rootUrl)
+{
+    // Test rootUrl static method
+    QUrl root = TagManager::rootUrl();
+
+    EXPECT_EQ(root.scheme(), "tag");
+    EXPECT_EQ(root.path(), "/");
+}
+
+TEST_F(UT_TagManager, canTagFile)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+    stub.set_lamda(&TagManager::localFileCanTagFilter, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->canTagFile(QUrl()));
+    EXPECT_TRUE(ins->canTagFile(QUrl("file:/hello/world")));
+    EXPECT_FALSE(ins->canTagFile(FileInfoPointer()));
+    EXPECT_TRUE(ins->canTagFile(info));
+}
+
+TEST_F(UT_TagManager, registerTagColor_NewTag)
+{
+    // Test registering new tag color
+    QString tagName = "NewTestTag";
+    QString color = "#123456";
+
+    bool result = ins->registerTagColor(tagName, color);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, registerTagColor_ExistingTag)
+{
+    // Test registering existing tag color
+    QString tagName = "ExistingTag";
+    QString color1 = "#123456";
+    QString color2 = "#654321";
+
+    ins->registerTagColor(tagName, color1);
+    bool result = ins->registerTagColor(tagName, color2);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, getTagIconName_EmptyTag)
+{
+    // Test with empty tag name
+    QString iconName = ins->getTagIconName("");
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagIconName_ValidTag)
+{
+    // Test with valid tag name
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["TestTag"] = QVariant("#ffa503");
+        return map;
+    });
+
+    stub.set_lamda(&TagHelper::queryIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    QString iconName = ins->getTagIconName("TestTag");
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagManager, getAllTags)
+{
+    // Test getting all tags
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["Tag1"] = QVariant(QColor("#ffa503"));
+        map["Tag2"] = QVariant(QColor("#ff1c49"));
+        return map;
+    });
+
+    TagManager::TagColorMap tags = ins->getAllTags();
+
+    EXPECT_EQ(tags.size(), 2);
+    EXPECT_TRUE(tags.contains("Tag1"));
+    EXPECT_TRUE(tags.contains("Tag2"));
+}
+
+TEST_F(UT_TagManager, getTagsColor_Empty)
+{
+    // Test with empty tag list
+    QStringList tags;
+    TagManager::TagColorMap result = ins->getTagsColor(tags);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagsColor_ValidTags)
+{
+    // Test with valid tags
+    QStringList tags;
+    tags << "Tag1"
+         << "Tag2";
+
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["Tag1"] = QVariant("#ffa503");
+        map["Tag2"] = QVariant("#ff1c49");
+        return map;
+    });
+
+    TagManager::TagColorMap result = ins->getTagsColor(tags);
+
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_TRUE(result.contains("Tag1"));
+    EXPECT_EQ(result["Tag1"].name().toLower(), "#ffa503");
+}
+
+TEST_F(UT_TagManager, getTagsByUrls_Empty)
+{
+    // Test with empty URL list
+    QList<QUrl> urls;
+    QStringList tags = ins->getTagsByUrls(urls);
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagsByUrls_ValidUrls)
+{
+    // Test with valid URLs
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/home/user/test.txt");
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [&urls](const QList<QUrl> &, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    stub.set_lamda(&FileTagCacheController::getTagsByFiles, [](FileTagCacheController *, const QStringList &) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1"
+             << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = ins->getTagsByUrls(urls);
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_TagManager, getFilesByTag_EmptyTag)
+{
+    // Test with empty tag
+    QStringList files = ins->getFilesByTag("");
+
+    EXPECT_TRUE(files.isEmpty());
+}
+
+TEST_F(UT_TagManager, getFilesByTag_ValidTag)
+{
+    // Test with valid tag
+    stub.set_lamda(&TagProxyHandle::getFilesThroughTag, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        QStringList files;
+        files << "/home/user/file1.txt"
+              << "/home/user/file2.txt";
+        map["TestTag"] = QVariant(files);
+        return map;
+    });
+
+    QStringList files = ins->getFilesByTag("TestTag");
+
+    EXPECT_EQ(files.size(), 2);
+}
+
+TEST_F(UT_TagManager, setTagsForFiles_EmptyFiles)
+{
+    // Test with empty file list
+    QStringList tags;
+    tags << "Tag1";
+    QList<QUrl> files;
+
+    bool result = ins->setTagsForFiles(tags, files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, addTagsForFiles)
+{
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, []() { __DBG_STUB_INVOKE__ return QColor("red"); });
+    stub.set_lamda(&TagProxyHandle::addTags, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return false; });
+
+    EXPECT_FALSE(ins->addTagsForFiles(QStringList(), QList<QUrl>()));
+    EXPECT_FALSE(ins->addTagsForFiles(QStringList() << QString("test"), QList<QUrl>() << QUrl("file:///test")));
+
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ins->addTagsForFiles(QStringList() << QString("test"), QList<QUrl>() << QUrl("file:///test")));
+}
+
+TEST_F(UT_TagManager, removeTagsOfFiles_EmptyTags)
+{
+    // Test with empty tag list
+    QList<QString> tags;
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test.txt");
+
+    bool result = ins->removeTagsOfFiles(tags, files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, removeTagsOfFiles_ValidData)
+{
+    // Test with valid tags and files
+    QList<QString> tags;
+    tags << "Tag1";
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test.txt");
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [&files](const QList<QUrl> &, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = files;
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QMap<QString, QVariant> &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->removeTagsOfFiles(tags, files);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, pasteHandle_TagScheme_CutAction)
+{
+    // Test paste with cut action - should return true without processing
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    stub.set_lamda(&ClipBoard::instance, []() -> ClipBoard * {
+        __DBG_STUB_INVOKE__
+        static ClipBoard clipboard;
+        return &clipboard;
+    });
+
+    stub.set_lamda(&ClipBoard::clipboardAction, [](ClipBoard *) -> ClipBoard::ClipboardAction {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCutAction;
+    });
+
+    bool result = ins->pasteHandle(0, QList<QUrl>(), tagUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, pasteHandle)
+{
+    EXPECT_FALSE(ins->pasteHandle(1, QList<QUrl>(), QUrl("file:///test")));
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ClipBoard::clipboardAction, []() { __DBG_STUB_INVOKE__ return ClipBoard::kCutAction; });
+
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+
+    stub.set_lamda(&ClipBoard::clipboardAction, []() { __DBG_STUB_INVOKE__ return ClipBoard::kCopyAction; });
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+}
+
+TEST_F(UT_TagManager, fileDropHandle)
+{
+    stub.set_lamda(static_cast<TagFileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<TagFileInfo>), []() {
+        return nullptr;
+    });
+    EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::setTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
+    EXPECT_FALSE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), QUrl("file:///test")));
+}
+
+TEST_F(UT_TagManager, fileDropHandleWithAction)
+{
+    // Test file drop with action
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    QList<QUrl> fromUrls;
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(&TagManager::fileDropHandle, [](TagManager *, const QList<QUrl> &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->fileDropHandleWithAction(fromUrls, tagUrl, &action);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(action, Qt::IgnoreAction);
+}
+
+TEST_F(UT_TagManager, sepateTitlebarCrumb_TagUrl)
+{
+    // Test separate titlebar crumb with tag URL
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    QList<QVariantMap> mapGroup;
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    stub.set_lamda(&TagManager::getTagIconName, [](const TagManager *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    bool result = ins->sepateTitlebarCrumb(tagUrl, &mapGroup);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+}
+
+TEST_F(UT_TagManager, sepateTitlebarCrumb_NonTagUrl)
+{
+    // Test separate titlebar crumb with non-tag URL
+    QUrl fileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+    QList<QVariantMap> mapGroup;
+
+    bool result = ins->sepateTitlebarCrumb(fileUrl, &mapGroup);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(mapGroup.isEmpty());
+}
+
+TEST_F(UT_TagManager, deleteTags)
+{
+    stub.set_lamda(&TagManager::deleteTagData, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, []() { __DBG_STUB_INVOKE__ return QUrl(); });
+
+    EXPECT_NO_THROW(ins->deleteTags(QStringList() << QString("test")));
+}
+
+TEST_F(UT_TagManager, changeTagColor_EmptyTag)
+{
+    // Test changing color with empty tag name
+    bool result = ins->changeTagColor("", "#123456");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, changeTagColor_ValidTag)
+{
+    // Test changing color with valid tag
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ffa503");
+    });
+
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->changeTagColor("TestTag", "Orange");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, changeTagName)
+{
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::getAllTags, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_FALSE(ins->changeTagName(QString(), QString()));
+    EXPECT_TRUE(ins->changeTagName(QString("test"), QString("red")));
+}
+
+TEST_F(UT_TagManager, changeTagName_ValidTag)
+{
+    // Test changing tag name
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager *) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return TagManager::TagColorMap();
+    });
+
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->changeTagName("OldTag", "NewTag");
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, hideFiles)
+{
+    QSignalSpy isCallSpy(ins, &TagManager::filesHidden);
+    ins->hideFiles(QList<QString>() << "red", QList<QUrl>() << QUrl("/test"));
+    EXPECT_EQ(isCallSpy.count(), 1);
+}
+
+TEST_F(UT_TagManager, paintListTagsHandle)
+{
+    DFMGLOBAL_USE_NAMESPACE
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    QPainter painter;
+    QRectF rect;
+    // overload func
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ins->paintListTagsHandle(1, info, &painter, &rect));
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->paintListTagsHandle(1, info, &painter, &rect));
+    EXPECT_FALSE(ins->paintListTagsHandle(kItemFileDisplayNameRole, info, &painter, &rect));
+}
+
+TEST_F(UT_TagManager, paintListTagsHandle2)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ins->addIconTagsHandle(info, nullptr));
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->addIconTagsHandle(info, nullptr));
+}
+
+TEST_F(UT_TagManager, assignColorToTags)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagManager::getTagsColor, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagManager::registerTagColor, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagHelper::queryColorByColorName, []() { __DBG_STUB_INVOKE__ return QColor("red"); });
+    stub.set_lamda(&TagHelper::getColorNameByTag, []() { __DBG_STUB_INVOKE__ return QString("test"); });
+
+    EXPECT_TRUE(ins->assignColorToTags(QStringList() << QString("test")).contains("test"));
+}
+
+TEST_F(UT_TagManager, contenxtMenuHandle)
+{
+    // Test context menu handle - stub to prevent actual menu display
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+    QPoint globalPos(100, 100);
+
+    stub.set_lamda(&TagEventCaller::sendCheckTabAddable, [](quint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    bool isCall = false;
+    stub.set_lamda((QAction * (QMenu::*)(const QPoint &, QAction *)) ADDR(QMenu, exec), [&]() {
+        isCall = true;
+        return nullptr;
+    });
+
+    // Note: This method creates and shows a menu, which involves GUI
+    // In actual unit tests, we would stub DMenu::exec to prevent showing
+    // For now, we just verify the method can be called
+    EXPECT_NO_THROW(TagManager::contenxtMenuHandle(0, tagUrl, globalPos));
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_TagManager, renameHandle)
+{
+    // Test rename handle
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/OldTag");
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "OldTag";
+    });
+
+    stub.set_lamda(&TagManager::changeTagName, [](TagManager *, const QString &, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(TagManager::renameHandle(0, tagUrl, "NewTag"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmanager_impl.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmanager_impl.cpp
@@ -1,0 +1,796 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/dfmplugin_tag_global.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/utils/anythingmonitorfilter.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+
+#include <QUrl>
+#include <QSet>
+#include <QColor>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class TagManagerImpl : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // The controller singleton is pulled in by TagManager::instance().
+        // Stub the update thread before it gets created.
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+        });
+        stub.set_lamda(ADDR(QThread, quit), [](QThread *) {
+            __DBG_STUB_INVOKE__
+        });
+        stub.set_lamda(static_cast<bool (QThread::*)(QDeadlineTimer)>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        // Harmless stubs so that FileTagCache signals routed to TagManager slots
+        // do not need a fully running framework / sidebar.
+        stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper *, const QString &tag) -> QUrl {
+            __DBG_STUB_INVOKE__
+            return QUrl(QString("tag:///%1").arg(tag));
+        });
+        stub.set_lamda(&TagHelper::createSidebarItemInfo, [](const TagHelper *, const QString &tag) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            QVariantMap map;
+            map["tag"] = tag;
+            return map;
+        });
+        stub.set_lamda(&TagHelper::queryIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+            __DBG_STUB_INVOKE__
+            return QString("dfm_tag_icon");
+        });
+        stub.set_lamda(&TagEventCaller::sendFileUpdate, [](const QString &) {
+            __DBG_STUB_INVOKE__
+        });
+
+        // UrlRoute::urlToPath() requires the scheme to be registered,
+        // otherwise it returns an empty string.
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+
+        manager = TagManager::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    void resetFileTagCache()
+    {
+        stub.set_lamda(&TagProxyHandle::getAllFileWithTags, [](TagProxyHandle *) -> QVariantHash {
+            __DBG_STUB_INVOKE__
+            return QVariantHash();
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            return QVariantMap();
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, [](TagProxyHandle *) -> QVariantHash {
+            __DBG_STUB_INVOKE__
+            return QVariantHash();
+        });
+        FileTagCacheWorker worker;
+        worker.loadFileTagsFromDatabase();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagManager *manager = nullptr;
+};
+
+TEST_F(TagManagerImpl, instance_and_scheme_and_root_url)
+{
+    EXPECT_NE(manager, nullptr);
+    EXPECT_EQ(TagManager::instance(), manager);
+    EXPECT_EQ(TagManager::scheme(), QString("tag"));
+
+    QUrl root = TagManager::rootUrl();
+    EXPECT_EQ(root.scheme(), QString("tag"));
+    EXPECT_EQ(root.path(), QString("/"));
+}
+
+TEST_F(TagManagerImpl, can_tag_file_by_url_real_logic)
+{
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return FileInfoPointer(new FileInfo(QUrl("file:///tmp/tm_impl/can_tag.txt")));
+                   });
+    stub.set_lamda(&AnythingMonitorFilter::instance, []() -> AnythingMonitorFilter & {
+        __DBG_STUB_INVOKE__
+        static AnythingMonitorFilter filter;
+        return filter;
+    });
+    stub.set_lamda(&AnythingMonitorFilter::whetherFilterCurrentPath, [](AnythingMonitorFilter *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&SystemPathUtil::instance, []() -> SystemPathUtil * {
+        __DBG_STUB_INVOKE__
+        static SystemPathUtil util;
+        return &util;
+    });
+    stub.set_lamda(&SystemPathUtil::isSystemPath, [](SystemPathUtil *, QString) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&FileUtils::isDesktopFileSuffix, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_TRUE(manager->canTagFile(QUrl("file:///tmp/tm_impl/can_tag.txt")));
+}
+
+TEST_F(TagManagerImpl, can_tag_file_by_url_transforms_to_local)
+{
+    // Transform the remote url into a local file:// url, as the real
+    // UniversalUtils does for reachable remote shares.
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        for (const QUrl &url : urls)
+            realUrls->append(QUrl(QString("file://%1").arg(url.path())));
+        return true;
+    });
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return FileInfoPointer(new FileInfo(QUrl("file:///tmp/tm_impl/can_tag2.txt")));
+                   });
+    stub.set_lamda(&AnythingMonitorFilter::instance, []() -> AnythingMonitorFilter & {
+        static AnythingMonitorFilter filter;
+        return filter;
+    });
+    stub.set_lamda(&AnythingMonitorFilter::whetherFilterCurrentPath, [](AnythingMonitorFilter *, const QString &) -> bool {
+        return true;
+    });
+    stub.set_lamda(&SystemPathUtil::instance, []() -> SystemPathUtil * {
+        static SystemPathUtil util;
+        return &util;
+    });
+    stub.set_lamda(&SystemPathUtil::isSystemPath, [](SystemPathUtil *, QString) -> bool {
+        return false;
+    });
+    stub.set_lamda(&FileUtils::isDesktopFileSuffix, [](const QUrl &) -> bool { return false; });
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [](const QUrl &) -> bool { return false; });
+
+    EXPECT_TRUE(manager->canTagFile(QUrl("smb://share/tmp/tm_impl/can_tag2.txt")));
+}
+
+TEST_F(TagManagerImpl, can_tag_file_by_info_real_logic)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///tmp/tm_impl/can_tag3.txt")));
+
+    stub.set_lamda(&AnythingMonitorFilter::instance, []() -> AnythingMonitorFilter & {
+        static AnythingMonitorFilter filter;
+        return filter;
+    });
+    stub.set_lamda(&AnythingMonitorFilter::whetherFilterCurrentPath, [](AnythingMonitorFilter *, const QString &) -> bool {
+        return true;
+    });
+    stub.set_lamda(&SystemPathUtil::instance, []() -> SystemPathUtil * {
+        static SystemPathUtil util;
+        return &util;
+    });
+    stub.set_lamda(&SystemPathUtil::isSystemPath, [](SystemPathUtil *, QString) -> bool { return false; });
+    stub.set_lamda(&FileUtils::isDesktopFileSuffix, [](const QUrl &) -> bool { return false; });
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [](const QUrl &) -> bool { return false; });
+
+    EXPECT_TRUE(manager->canTagFile(info));
+}
+
+TEST_F(TagManagerImpl, get_tags_by_urls_uses_cache)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    QVariantMap tags;
+    tags.insert("TmUrlTag", "#ff0000");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/tm_impl/url_file.txt", QStringList({ "TmUrlTag" }));
+    worker.onFilesTagged(fileTags);
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+
+    auto result = manager->getTagsByUrls({ QUrl("file:///tmp/tm_impl/url_file.txt") });
+    EXPECT_EQ(result, QStringList({ "TmUrlTag" }));
+}
+
+TEST_F(TagManagerImpl, find_children_real_logic)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    QVariantMap tags;
+    tags.insert("TmChildTag", "#00ff00");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/tm_impl/dir/file1.txt", QStringList({ "TmChildTag" }));
+    fileTags.insert("/tmp/tm_impl/dir/sub/file2.txt", QStringList({ "TmChildTag" }));
+    fileTags.insert("/tmp/tm_impl/other/file3.txt", QStringList({ "TmChildTag" }));
+    worker.onFilesTagged(fileTags);
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    auto children = manager->findChildren("/tmp/tm_impl/dir");
+    EXPECT_EQ(children.size(), 2);
+    EXPECT_TRUE(children.contains("/tmp/tm_impl/dir/file1.txt"));
+    EXPECT_TRUE(children.contains("/tmp/tm_impl/dir/sub/file2.txt"));
+}
+
+TEST_F(TagManagerImpl, set_tags_for_files_orchestrates_add_and_remove)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    // existing tags on the file -> setTagsForFiles must remove old tags not in the new list
+    stub.set_lamda(&FileTagCacheController::getTagsByFiles, [](FileTagCacheController *, const QStringList &) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList({ "OldTag" });
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/tm_impl/set_tag.txt"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/tm_impl/set_tag.txt"));
+        return true;
+    });
+
+    QList<QUrl> files = { QUrl("file:///tmp/tm_impl/set_tag.txt") };
+    bool result = manager->setTagsForFiles({ "NewTag" }, files);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerImpl, add_tags_for_files_builds_request)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("TmNewTag"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/tm_impl/add_tag.txt"));
+        return true;
+    });
+
+    bool result = manager->addTagsForFiles({ "TmNewTag" }, { QUrl("file:///tmp/tm_impl/add_tag.txt") });
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerImpl, remove_tags_of_files_builds_request)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/tm_impl/remove_tag.txt"));
+        auto tags = map.value("/tmp/tm_impl/remove_tag.txt").toStringList();
+        EXPECT_TRUE(tags.contains("TmRemoveTag"));
+        return true;
+    });
+
+    bool result = manager->removeTagsOfFiles({ "TmRemoveTag" }, { QUrl("file:///tmp/tm_impl/remove_tag.txt") });
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerImpl, remove_children_real_logic)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    QVariantMap tags;
+    tags.insert("TmChildRemoveTag", "#ff0000");
+    worker.onTagAdded(tags);
+
+    QVariantMap fileTags;
+    fileTags.insert("/tmp/tm_impl/children/file1.txt", QStringList({ "TmChildRemoveTag" }));
+    fileTags.insert("/tmp/tm_impl/children/file2.txt", QStringList({ "TmChildRemoveTag" }));
+    worker.onFilesTagged(fileTags);
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+    QSet<QString> removedPaths;
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [&](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        // removeChildren() removes tags file by file, one entry per call.
+        EXPECT_EQ(map.size(), 1);
+        for (auto it = map.begin(); it != map.end(); ++it)
+            removedPaths.insert(it.key());
+        return true;
+    });
+
+    bool result = manager->removeChildren("/tmp/tm_impl/children");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(removedPaths.size(), 2);
+    EXPECT_TRUE(removedPaths.contains("/tmp/tm_impl/children/file1.txt"));
+    EXPECT_TRUE(removedPaths.contains("/tmp/tm_impl/children/file2.txt"));
+}
+
+TEST_F(TagManagerImpl, get_all_tags_real_logic)
+{
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("TmAllTag", QVariant(QColor("#aabbcc")));
+        return map;
+    });
+
+    auto result = manager->getAllTags();
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(result.contains("TmAllTag"));
+    EXPECT_EQ(result.value("TmAllTag").name().toLower(), QString("#aabbcc"));
+}
+
+TEST_F(TagManagerImpl, get_tags_color_real_logic)
+{
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("TmColorTag1", QVariant("#112233"));
+        return map;
+    });
+
+    auto result = manager->getTagsColor({ "TmColorTag1", "TmUnknown" });
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(result.contains("TmColorTag1"));
+    EXPECT_EQ(result.value("TmColorTag1").name().toLower(), QString("#112233"));
+}
+
+TEST_F(TagManagerImpl, get_files_by_tag)
+{
+    stub.set_lamda(&TagProxyHandle::getFilesThroughTag, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("TmSearchTag", QVariant(QStringList({ "/tmp/tm_impl/file1.txt", "/tmp/tm_impl/file2.txt" })));
+        return map;
+    });
+
+    auto result = manager->getFilesByTag("TmSearchTag");
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(TagManagerImpl, get_tag_icon_name)
+{
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("TmIconTag", QVariant("#ff0000"));
+        return map;
+    });
+    stub.set_lamda(&TagHelper::queryIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("dfm_tag_red");
+    });
+
+    auto iconName = manager->getTagIconName("TmIconTag");
+    EXPECT_EQ(iconName, QString("dfm_tag_red"));
+}
+
+TEST_F(TagManagerImpl, register_tag_color)
+{
+    EXPECT_TRUE(manager->registerTagColor("TmRegTag", "#ff0000"));
+    EXPECT_FALSE(manager->registerTagColor("TmRegTag", "#00ff00"));
+}
+
+TEST_F(TagManagerImpl, change_tag_color_default_sync)
+{
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(&TagHelper::queryDisplayNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("Red");
+    });
+    stub.set_lamda(&TagHelper::isDefaultTag, [](const TagHelper *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(static_cast<TagManager::TagColorMap (TagManager::*)()>(&TagManager::getAllTags), []() -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("OldDefaultTag"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("OldDefaultTag"));
+        EXPECT_EQ(map.value("OldDefaultTag").toString(), QString("Red"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    bool result = manager->changeTagColor("OldDefaultTag", "Red");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, change_tag_color_normal_path)
+{
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#00ff00");
+    });
+    stub.set_lamda(&TagHelper::queryDisplayNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("Green");
+    });
+    stub.set_lamda(&TagHelper::isDefaultTag, [](const TagHelper *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("TmColorTag"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    bool result = manager->changeTagColor("TmColorTag", "Green");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, change_tag_name_default_color_sync)
+{
+    stub.set_lamda(static_cast<TagManager::TagColorMap (TagManager::*)()>(&TagManager::getAllTags), []() -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#0000ff");
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("TmNameOld"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("TmNameOld"));
+        EXPECT_EQ(map.value("TmNameOld").toString(), QString("Blue"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    bool result = manager->changeTagName("TmNameOld", "Blue");
+    EXPECT_TRUE(result);
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, assign_color_to_tags)
+{
+    stub.set_lamda(static_cast<TagManager::TagColorMap (TagManager::*)()>(&TagManager::getAllTags), []() -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    // Avoid touching the daemon DBus interface (null in the test environment).
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    stub.set_lamda(&TagHelper::getColorNameByTag, [](const TagHelper *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("TmColorName");
+    });
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#123456");
+    });
+
+    auto result = manager->assignColorToTags({ "TmAssignTag" });
+    EXPECT_TRUE(result.contains("TmAssignTag"));
+    EXPECT_EQ(result.value("TmAssignTag").name().toLower(), QString("#123456"));
+}
+
+TEST_F(TagManagerImpl, sepate_titlebar_crumb)
+{
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("TmCrumbTag");
+    });
+    stub.set_lamda(static_cast<QString (TagManager::*)(const QString &) const>(&TagManager::getTagIconName), [](const TagManager *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("dfm_tag_icon");
+    });
+
+    QList<QVariantMap> group;
+    bool result = manager->sepateTitlebarCrumb(QUrl("tag:///TmCrumbTag"), &group);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(group.size(), 1);
+    EXPECT_EQ(group[0].value("CrumbData_Key_IconName"), QString("dfm_tag_icon"));
+}
+
+TEST_F(TagManagerImpl, delete_tags_emits_signal)
+{
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QStringList &, const DeleteOpts &)>(&TagManager::deleteTagData), [](TagManager *, const QStringList &, const DeleteOpts &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    manager->deleteTags({ "TmDeleteTag" });
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, hide_files_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesHidden);
+
+    manager->hideFiles({ "TmHideTag" }, { QUrl("file:///tmp/tm_impl/hide.txt") });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, paste_handle_copy_action)
+{
+    stub.set_lamda(&ClipBoard::clipboardAction, [](ClipBoard *) -> ClipBoard::ClipboardAction {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCopyAction;
+    });
+    stub.set_lamda(&ClipBoard::clipboardFileUrlList, [](ClipBoard *) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return { QUrl("file:///tmp/tm_impl/source.txt") };
+    });
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile), [](const TagManager *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    TagFileInfoPointer tagInfo(new TagFileInfo(QUrl("tag:///TmPasteTag")));
+    stub.set_lamda(static_cast<TagFileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<TagFileInfo>),
+                   [tagInfo](const QUrl &, Global::CreateFileInfoType, QString *) -> TagFileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return tagInfo;
+                   });
+
+    bool result = manager->pasteHandle(0, {}, QUrl("tag:///TmPasteTag"));
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerImpl, file_drop_handle_real_logic)
+{
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile), [](const TagManager *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QStringList &, const QList<QUrl> &)>(&TagManager::setTagsForFiles), [](TagManager *, const QStringList &, const QList<QUrl> &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    TagFileInfoPointer tagInfo(new TagFileInfo(QUrl("tag:///TmDropTag")));
+    stub.set_lamda(static_cast<TagFileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<TagFileInfo>),
+                   [tagInfo](const QUrl &, Global::CreateFileInfoType, QString *) -> TagFileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return tagInfo;
+                   });
+
+    bool result = manager->fileDropHandle({ QUrl("file:///tmp/tm_impl/drop.txt") }, QUrl("tag:///TmDropTag"));
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerImpl, file_drop_handle_with_action)
+{
+    Qt::DropAction action = Qt::CopyAction;
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QList<QUrl> &, const QUrl &)>(&TagManager::fileDropHandle), [](TagManager *, const QList<QUrl> &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->fileDropHandleWithAction({}, QUrl("tag:///TmDropTag"), &action);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(action, Qt::IgnoreAction);
+}
+
+TEST_F(TagManagerImpl, trash_file_tags)
+{
+    stub.set_lamda(&TagProxyHandle::saveTrashFileTags, [](TagProxyHandle *, const QString &, qint64, const QStringList &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::getTrashFileTags, [](TagProxyHandle *, const QString &, qint64) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList({ "TmTrashTag" });
+    });
+    stub.set_lamda(&TagProxyHandle::removeTrashFileTags, [](TagProxyHandle *, const QString &, qint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::clearAllTrashTags, [](TagProxyHandle *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_TRUE(manager->saveTrashFileTags("/tmp/tm_impl/original.txt", 123, { "TmTrashTag" }));
+
+    auto tags = manager->getTrashFileTags("/tmp/tm_impl/original.txt", 123);
+    EXPECT_EQ(tags, QStringList({ "TmTrashTag" }));
+
+    EXPECT_TRUE(manager->removeTrashFileTags("/tmp/tm_impl/original.txt", 123));
+    EXPECT_TRUE(manager->clearAllTrashTags());
+}
+
+TEST_F(TagManagerImpl, get_trash_tags_uses_cache_when_present)
+{
+    resetFileTagCache();
+
+    stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, [](TagProxyHandle *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash.insert("/tmp/tm_impl/trash:777", QStringList({ "TmTrashCached" }));
+        return hash;
+    });
+
+    FileTagCacheWorker worker;
+    worker.onTrashFileTagsChanged();
+
+    auto tags = manager->getTrashFileTags("/tmp/tm_impl/trash", 777);
+    EXPECT_EQ(tags, QStringList({ "TmTrashCached" }));
+}
+
+TEST_F(TagManagerImpl, on_tag_added_does_not_crash)
+{
+    EXPECT_NO_THROW(manager->onTagAdded({ { "TmOnAddedTag", "#ff0000" } }));
+}
+
+TEST_F(TagManagerImpl, on_tag_deleted_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::tagDeleted);
+
+    manager->onTagDeleted({ "TmOnDeletedTag" });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, on_tag_color_changed_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::tagColorChanged);
+
+    manager->onTagColorChanged({ { "TmOnColorTag", "#ff0000" } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, on_tag_name_changed_does_not_crash)
+{
+    EXPECT_NO_THROW(manager->onTagNameChanged({ { "TmOnOldName", "TmOnNewName" } }));
+}
+
+TEST_F(TagManagerImpl, on_files_tagged_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesTagged);
+
+    manager->onFilesTagged({ { "/tmp/tm_impl/tagged.txt", QStringList({ "Tag" }) } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerImpl, on_files_untagged_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesUntagged);
+
+    manager->onFilesUntagged({ { "/tmp/tm_impl/untagged.txt", QStringList({ "Tag" }) } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmanager_real2.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmanager_real2.cpp
@@ -1,0 +1,601 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QUrl>
+#include <QColor>
+
+#include "stubext.h"
+
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class TagManagerReal2 : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        // avoid FileTagCache background thread creation
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(ADDR(QThread, quit), [](QThread *) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(static_cast<bool (QThread::*)(QDeadlineTimer)>(&QThread::wait), [] { __DBG_STUB_INVOKE__ return true; });
+
+        // UrlRoute::urlToPath() requires the scheme to be registered,
+        // otherwise it returns an empty string.
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+
+        // harmless stubs for framework/sidebar interactions
+        stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper *, const QString &tag) -> QUrl {
+            __DBG_STUB_INVOKE__
+            return QUrl(QString("tag:///%1").arg(tag));
+        });
+        stub.set_lamda(&TagHelper::createSidebarItemInfo, [](const TagHelper *, const QString &tag) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            return QVariantMap { { "tag", tag } };
+        });
+        stub.set_lamda(&TagHelper::queryIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+            __DBG_STUB_INVOKE__
+            return QString("dfm_tag_icon");
+        });
+        stub.set_lamda(&TagEventCaller::sendFileUpdate, [](const QString &) { __DBG_STUB_INVOKE__ });
+
+        manager = TagManager::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    void resetFileTagCache()
+    {
+        stub.set_lamda(&TagProxyHandle::getAllFileWithTags, [](TagProxyHandle *) -> QVariantHash {
+            __DBG_STUB_INVOKE__
+            return QVariantHash();
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            return QVariantMap();
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, [](TagProxyHandle *) -> QVariantHash {
+            __DBG_STUB_INVOKE__
+            return QVariantHash();
+        });
+        FileTagCacheWorker worker;
+        worker.loadFileTagsFromDatabase();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TagManager *manager = nullptr;
+};
+
+TEST_F(TagManagerReal2, getAllTags_converts_real_data)
+{
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("Real2Red", QVariant(QColor("#ff0000")));
+        return map;
+    });
+
+    auto result = manager->getAllTags();
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_TRUE(result.contains("Real2Red"));
+    EXPECT_EQ(result.value("Real2Red").name().toLower(), QString("#ff0000"));
+}
+
+TEST_F(TagManagerReal2, getTagsColor_converts_real_data)
+{
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("Real2Blue", QVariant("#0000ff"));
+        return map;
+    });
+
+    auto result = manager->getTagsColor({ "Real2Blue", "Real2Missing" });
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.value("Real2Blue").name().toLower(), QString("#0000ff"));
+}
+
+TEST_F(TagManagerReal2, getTagIconName_real_logic)
+{
+    stub.set_lamda(static_cast<QMap<QString, QString> (TagManager::*)(const QStringList &) const>(&TagManager::getTagsColorName),
+                   [](const TagManager *, const QStringList &) -> QMap<QString, QString> {
+                       __DBG_STUB_INVOKE__
+                       QMap<QString, QString> map;
+                       map.insert("Real2IconTag", "#00ff00");
+                       return map;
+                   });
+    stub.set_lamda(&TagHelper::queryIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("dfm_tag_green");
+    });
+
+    EXPECT_EQ(manager->getTagIconName("Real2IconTag"), QString("dfm_tag_green"));
+    EXPECT_TRUE(manager->getTagIconName("").isEmpty());
+}
+
+TEST_F(TagManagerReal2, getTagsByUrls_uses_real_cache)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    worker.onTagAdded({ { "Real2CacheTag", "#ff0000" } });
+    worker.onFilesTagged({ { "/tmp/real2/cache.txt", QStringList { "Real2CacheTag" } } });
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+
+    auto tags = manager->getTagsByUrls({ QUrl("file:///tmp/real2/cache.txt") });
+    EXPECT_EQ(tags, QStringList({ "Real2CacheTag" }));
+}
+
+TEST_F(TagManagerReal2, getFilesByTag_real_logic)
+{
+    stub.set_lamda(&TagProxyHandle::getFilesThroughTag, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map.insert("Real2FindTag", QVariant(QStringList({ "/tmp/real2/a.txt", "/tmp/real2/b.txt" })));
+        return map;
+    });
+
+    auto files = manager->getFilesByTag("Real2FindTag");
+    EXPECT_EQ(files.size(), 2);
+    EXPECT_TRUE(files.contains("/tmp/real2/a.txt"));
+}
+
+TEST_F(TagManagerReal2, findChildren_real_logic)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    worker.onTagAdded({ { "Real2ChildTag", "#ff0000" } });
+    worker.onFilesTagged({
+        { "/tmp/real2/dir/file1.txt", QStringList { "Real2ChildTag" } },
+        { "/tmp/real2/dir/sub/file2.txt", QStringList { "Real2ChildTag" } },
+        { "/tmp/real2/other/file3.txt", QStringList { "Real2ChildTag" } }
+    });
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    auto children = manager->findChildren("/tmp/real2/dir");
+    EXPECT_EQ(children.size(), 2);
+    EXPECT_TRUE(children.contains("/tmp/real2/dir/file1.txt"));
+    EXPECT_TRUE(children.contains("/tmp/real2/dir/sub/file2.txt"));
+}
+
+TEST_F(TagManagerReal2, setTagsForFiles_real_orchestration)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(static_cast<QStringList (TagManager::*)(const QList<QUrl> &) const>(&TagManager::getTagsByUrls),
+                   [](const TagManager *, const QList<QUrl> &) -> QStringList {
+                       __DBG_STUB_INVOKE__
+                       return QStringList({ "Real2OldTag" });
+                   });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/real2/set.txt"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/real2/set.txt"));
+        return true;
+    });
+
+    bool result = manager->setTagsForFiles({ "Real2NewTag" }, { QUrl("file:///tmp/real2/set.txt") });
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerReal2, addTagsForFiles_real_logic)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#00ff00");
+    });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("Real2AddTag"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/real2/add.txt"));
+        return true;
+    });
+
+    bool result = manager->addTagsForFiles({ "Real2AddTag" }, { QUrl("file:///tmp/real2/add.txt") });
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerReal2, removeTagsOfFiles_real_logic)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("/tmp/real2/remove.txt"));
+        auto tags = map.value("/tmp/real2/remove.txt").toStringList();
+        EXPECT_TRUE(tags.contains("Real2RemoveTag"));
+        return true;
+    });
+
+    bool result = manager->removeTagsOfFiles({ "Real2RemoveTag" }, { QUrl("file:///tmp/real2/remove.txt") });
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TagManagerReal2, changeTagColor_normal_path_real)
+{
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#123456");
+    });
+    stub.set_lamda(&TagHelper::queryDisplayNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("Custom");
+    });
+    stub.set_lamda(&TagHelper::isDefaultTag, [](const TagHelper *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("Real2ColorTag"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    EXPECT_TRUE(manager->changeTagColor("Real2ColorTag", "Custom"));
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, changeTagName_default_color_sync_real)
+{
+    stub.set_lamda(static_cast<TagManager::TagColorMap (TagManager::*)()>(&TagManager::getAllTags), []() -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#abcdef");
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("Real2NameOld"));
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("Real2NameOld"));
+        EXPECT_EQ(map.value("Real2NameOld").toString(), QString("NewName"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    EXPECT_TRUE(manager->changeTagName("Real2NameOld", "NewName"));
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, deleteTags_real_logic)
+{
+    stub.set_lamda(&TagProxyHandle::deleteTags, [](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(map.contains("deleteTagData"));
+        return true;
+    });
+
+    QSignalSpy deletedEmittedSpy(manager, &TagManager::tagDeleted);
+
+    manager->deleteTags({ "Real2DeleteTag" });
+    EXPECT_EQ(deletedEmittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, removeChildren_real_logic)
+{
+    resetFileTagCache();
+
+    FileTagCacheWorker worker;
+    worker.onTagAdded({ { "Real2RemoveChildTag", "#ff0000" } });
+    worker.onFilesTagged({
+        { "/tmp/real2/children/a.txt", QStringList { "Real2RemoveChildTag" } },
+        { "/tmp/real2/children/b.txt", QStringList { "Real2RemoveChildTag" } }
+    });
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+    QSet<QString> removedPaths;
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [&](TagProxyHandle *, const QVariantMap &map) -> bool {
+        __DBG_STUB_INVOKE__
+        // removeChildren() removes tags file by file, one entry per call.
+        EXPECT_EQ(map.size(), 1);
+        for (auto it = map.begin(); it != map.end(); ++it)
+            removedPaths.insert(it.key());
+        return true;
+    });
+
+    EXPECT_TRUE(manager->removeChildren("/tmp/real2/children"));
+    EXPECT_EQ(removedPaths.size(), 2);
+    EXPECT_TRUE(removedPaths.contains("/tmp/real2/children/a.txt"));
+    EXPECT_TRUE(removedPaths.contains("/tmp/real2/children/b.txt"));
+}
+
+TEST_F(TagManagerReal2, hideFiles_emits_filesHidden)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesHidden);
+
+    manager->hideFiles({ "Real2HideTag" }, { QUrl("file:///tmp/real2/hide.txt") });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, pasteHandle_copy_action_real)
+{
+    stub.set_lamda(&ClipBoard::clipboardAction, [](ClipBoard *) -> ClipBoard::ClipboardAction {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCopyAction;
+    });
+    stub.set_lamda(&ClipBoard::clipboardFileUrlList, [](ClipBoard *) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return { QUrl("file:///tmp/real2/source.txt") };
+    });
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile),
+                   [](const TagManager *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &urls, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+    stub.set_lamda(&TagHelper::commonUrls, [](const QList<QUrl> &urls) -> QList<QUrl> {
+        __DBG_STUB_INVOKE__
+        return urls;
+    });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ff0000");
+    });
+    stub.set_lamda(&TagProxyHandle::addTags, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    TagFileInfoPointer tagInfo(new TagFileInfo(QUrl("tag:///Real2PasteTag")));
+    stub.set_lamda(static_cast<TagFileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<TagFileInfo>),
+                   [tagInfo](const QUrl &, Global::CreateFileInfoType, QString *) -> TagFileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return tagInfo;
+                   });
+
+    EXPECT_TRUE(manager->pasteHandle(0, {}, QUrl("tag:///Real2PasteTag")));
+}
+
+TEST_F(TagManagerReal2, fileDropHandle_real_logic)
+{
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile),
+                   [](const TagManager *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QStringList &, const QList<QUrl> &)>(&TagManager::addTagsForFiles),
+                   [](TagManager *, const QStringList &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    TagFileInfoPointer tagInfo(new TagFileInfo(QUrl("tag:///Real2DropTag")));
+    stub.set_lamda(static_cast<TagFileInfoPointer(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<TagFileInfo>),
+                   [tagInfo](const QUrl &, Global::CreateFileInfoType, QString *) -> TagFileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return tagInfo;
+                   });
+
+    EXPECT_TRUE(manager->fileDropHandle({ QUrl("file:///tmp/real2/drop.txt") }, QUrl("tag:///Real2DropTag")));
+}
+
+TEST_F(TagManagerReal2, fileDropHandleWithAction_sets_ignore_action)
+{
+    Qt::DropAction action = Qt::CopyAction;
+    stub.set_lamda(static_cast<bool (TagManager::*)(const QList<QUrl> &, const QUrl &)>(&TagManager::fileDropHandle),
+                   [](TagManager *, const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(manager->fileDropHandleWithAction({}, QUrl("tag:///Real2DropTag"), &action));
+    EXPECT_EQ(action, Qt::IgnoreAction);
+}
+
+TEST_F(TagManagerReal2, trashFileTags_real_logic)
+{
+    stub.set_lamda(&TagProxyHandle::saveTrashFileTags, [](TagProxyHandle *, const QString &, qint64, const QStringList &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::getTrashFileTags, [](TagProxyHandle *, const QString &, qint64) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList({ "Real2TrashTag" });
+    });
+    stub.set_lamda(&TagProxyHandle::removeTrashFileTags, [](TagProxyHandle *, const QString &, qint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagProxyHandle::clearAllTrashTags, [](TagProxyHandle *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_TRUE(manager->saveTrashFileTags("/tmp/real2/original.txt", 123, { "Real2TrashTag" }));
+    EXPECT_EQ(manager->getTrashFileTags("/tmp/real2/original.txt", 123), QStringList({ "Real2TrashTag" }));
+    EXPECT_TRUE(manager->removeTrashFileTags("/tmp/real2/original.txt", 123));
+    EXPECT_TRUE(manager->clearAllTrashTags());
+}
+
+TEST_F(TagManagerReal2, assignColorToTags_real_logic)
+{
+    stub.set_lamda(static_cast<TagManager::TagColorMap (TagManager::*)()>(&TagManager::getAllTags), []() -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    // Avoid touching the daemon DBus interface (null in the test environment).
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return {};
+    });
+    stub.set_lamda(&TagHelper::getColorNameByTag, [](const TagHelper *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("Real2ColorName");
+    });
+    stub.set_lamda(&TagHelper::queryColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#654321");
+    });
+
+    auto result = manager->assignColorToTags({ "Real2AssignTag" });
+    EXPECT_TRUE(result.contains("Real2AssignTag"));
+    EXPECT_EQ(result.value("Real2AssignTag").name().toLower(), QString("#654321"));
+}
+
+TEST_F(TagManagerReal2, sepateTitlebarCrumb_real_logic)
+{
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("Real2CrumbTag");
+    });
+    stub.set_lamda(static_cast<QString (TagManager::*)(const QString &) const>(&TagManager::getTagIconName),
+                   [](const TagManager *, const QString &) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("dfm_tag_icon");
+                   });
+
+    QList<QVariantMap> group;
+    EXPECT_TRUE(manager->sepateTitlebarCrumb(QUrl("tag:///Real2CrumbTag"), &group));
+    EXPECT_EQ(group.size(), 1);
+    EXPECT_EQ(group[0].value("CrumbData_Key_IconName").toString(), QString("dfm_tag_icon"));
+}
+
+TEST_F(TagManagerReal2, registerTagColor_real_logic)
+{
+    EXPECT_TRUE(manager->registerTagColor("Real2RegTag", "#ff0000"));
+    EXPECT_FALSE(manager->registerTagColor("Real2RegTag", "#00ff00"));
+}
+
+TEST_F(TagManagerReal2, onTagAdded_does_not_crash)
+{
+    EXPECT_NO_THROW(manager->onTagAdded({ { "Real2OnAdded", "#ff0000" } }));
+}
+
+TEST_F(TagManagerReal2, onTagDeleted_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::tagDeleted);
+    manager->onTagDeleted({ "Real2OnDeleted" });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, onTagColorChanged_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::tagColorChanged);
+    manager->onTagColorChanged({ { "Real2OnColor", "#ff0000" } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, onTagNameChanged_does_not_crash)
+{
+    EXPECT_NO_THROW(manager->onTagNameChanged({ { "Real2OnOld", "Real2OnNew" } }));
+}
+
+TEST_F(TagManagerReal2, onFilesTagged_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesTagged);
+    manager->onFilesTagged({ { "/tmp/real2/tagged.txt", QStringList({ "Real2Tag" }) } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}
+
+TEST_F(TagManagerReal2, onFilesUntagged_emits_signal)
+{
+    QSignalSpy emittedSpy(manager, &TagManager::filesUntagged);
+    manager->onFilesUntagged({ { "/tmp/real2/untagged.txt", QStringList({ "Real2Tag" }) } });
+    EXPECT_EQ(emittedSpy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagproxyhandle.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagproxyhandle.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+#include "plugins/common/dfmplugin-tag/data/private/tagproxyhandle_p.h"
+
+#include <gtest/gtest.h>
+
+#include <QDBusVariant>
+#include <QDBusReply>
+#include <QDBusPendingReply>
+#include <QVariantMap>
+
+using namespace dfmplugin_tag;
+
+class UT_TagProxyHandle : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        handle = TagProxyHandle::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagProxyHandle *handle = nullptr;
+};
+
+TEST_F(UT_TagProxyHandle, instance)
+{
+    // Test singleton instance
+    TagProxyHandle *instance1 = TagProxyHandle::instance();
+    TagProxyHandle *instance2 = TagProxyHandle::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagProxyHandle, isValid_True)
+{
+    // Test isValid when DBus is running
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = handle->isValid();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagProxyHandle, isValid_False)
+{
+    // Test isValid when DBus is not running
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = handle->isValid();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagProxyHandle, connectToService)
+{
+    // Test connecting to service
+    bool result = false;
+
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(result = handle->connectToService());
+}
+
+TEST_F(UT_TagProxyHandle, getAllTags_Empty)
+{
+    // Test getting all tags when none exist
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // DBus not running
+    });
+
+    QVariantMap tags = handle->getAllTags();
+
+    // Result depends on DBus availability
+    EXPECT_NO_THROW(tags);
+}
+
+TEST_F(UT_TagProxyHandle, getTagsColor_Empty)
+{
+    // Test getting tags color with empty list
+    QStringList emptyTags;
+    QVariantMap result = handle->getTagsColor(emptyTags);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getTagsThroughFile_Empty)
+{
+    // Test getting tags through file with empty file list
+    QStringList emptyFiles;
+    QVariantMap result = handle->getTagsThroughFile(emptyFiles);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getSameTagsOfDiffFiles_Empty)
+{
+    // Test getting same tags of different files with empty list
+    QStringList emptyFiles;
+    QVariant result = handle->getSameTagsOfDiffFiles(emptyFiles);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getFilesThroughTag_Empty)
+{
+    // Test getting files through tag with empty tag list
+    QStringList emptyTags;
+    QVariantMap result = handle->getFilesThroughTag(emptyTags);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getAllFileWithTags)
+{
+    // Test getting all files with tags
+    QVariantHash result;
+
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // DBus not running
+    });
+
+    EXPECT_NO_THROW(result = handle->getAllFileWithTags());
+}
+
+TEST_F(UT_TagProxyHandle, addTags_Empty)
+{
+    // Test adding tags with empty map
+    QVariantMap emptyTags;
+    bool result = handle->addTags(emptyTags);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, addTagsForFiles_Empty)
+{
+    // Test adding tags for files with empty map
+    QVariantMap emptyMap;
+    bool result = handle->addTagsForFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeTagsColor_Empty)
+{
+    // Test changing tags color with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeTagsColor(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeTagNamesWithFiles_Empty)
+{
+    // Test changing tag names with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeTagNamesWithFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeFilePaths_Empty)
+{
+    // Test changing file paths with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeFilePaths(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteTags_Empty)
+{
+    // Test deleting tags with empty map
+    QVariantMap emptyMap;
+    bool result = handle->deleteTags(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteFiles_Empty)
+{
+    // Test deleting files with empty map
+    QVariantMap emptyMap;
+    bool result = handle->deleteFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteFileTags_Empty)
+{
+    // Test deleting file tags with empty map
+    QMap<QString, QVariant> emptyMap;
+    bool result = handle->deleteFileTags(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, signals)
+{
+    // Test that signals can be connected
+    bool filesTaggedEmitted = false;
+    bool filesUntaggedEmitted = false;
+    bool newTagsAddedEmitted = false;
+    bool tagsColorChangedEmitted = false;
+    bool tagsDeletedEmitted = false;
+    bool tagsNameChangedEmitted = false;
+    bool tagServiceRegisteredEmitted = false;
+
+    QObject::connect(handle, &TagProxyHandle::filesTagged,
+        [&filesTaggedEmitted](const QVariantMap&) {
+            filesTaggedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::filesUntagged,
+        [&filesUntaggedEmitted](const QVariantMap&) {
+            filesUntaggedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::newTagsAdded,
+        [&newTagsAddedEmitted](const QVariantMap&) {
+            newTagsAddedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsColorChanged,
+        [&tagsColorChangedEmitted](const QVariantMap&) {
+            tagsColorChangedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsDeleted,
+        [&tagsDeletedEmitted](const QStringList&) {
+            tagsDeletedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsNameChanged,
+        [&tagsNameChangedEmitted](const QVariantMap&) {
+            tagsNameChangedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagServiceRegistered,
+        [&tagServiceRegisteredEmitted]() {
+            tagServiceRegisteredEmitted = true;
+        });
+
+    // Emit signals to test connections
+    emit handle->filesTagged(QVariantMap());
+    emit handle->filesUntagged(QVariantMap());
+    emit handle->newTagsAdded(QVariantMap());
+    emit handle->tagsColorChanged(QVariantMap());
+    emit handle->tagsDeleted(QStringList());
+    emit handle->tagsNameChanged(QVariantMap());
+    emit handle->tagServiceRegistered();
+
+    EXPECT_TRUE(filesTaggedEmitted);
+    EXPECT_TRUE(filesUntaggedEmitted);
+    EXPECT_TRUE(newTagsAddedEmitted);
+    EXPECT_TRUE(tagsColorChangedEmitted);
+    EXPECT_TRUE(tagsDeletedEmitted);
+    EXPECT_TRUE(tagsNameChangedEmitted);
+    EXPECT_TRUE(tagServiceRegisteredEmitted);
+}


### PR DESCRIPTION
Part 1/2 of dfmplugin-tag unit tests, split by module for easier review:
标签管理、缓存与事件后端.

This part carries the final CMakeLists.txt and main.cpp; test files
of the other parts land in separate PRs. The test binary is wired
into the build by the registration PR (merged last).

dfmplugin-tag 单元测试第 1/2 部分（按模块拆分以便评审）：标签管理、缓存与事件后端。

本部分包含最终版 CMakeLists.txt 与 main.cpp，其余测试文件由独立
PR 提交；测试二进制由注册 PR（最后合入）接入构建。

Log: 新增 dfmplugin-tag 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add backend unit-test coverage for dfmplugin-tag and wire the test suite into the autotest build.

Build:
- Add the dfmplugin-tag unit-test target and test entry point to the autotest build configuration.

Tests:
- Add broad GoogleTest coverage for tag management, tag helpers, file-tag caching, tag file iteration and watching, event dispatch and reception, proxy handling, and plugin lifecycle behavior.
- Cover both isolated API behavior and stateful cache/manager workflows, including tag changes, file tagging, trash tags, drag-and-drop, and emitted signals.