### PR TITLE
test: add unit tests for dfmplugin-tag (part 2/2: UI widgets)

### DIFF
--- a/autotests/plugins/dfmplugin-tag/test_tagbutton.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagbutton.cpp
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagbutton.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPixmap>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+
+class UT_TagButton : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        color = QColor("#ffa503");
+        button = new TagButton(color);
+    }
+
+    virtual void TearDown() override
+    {
+        delete button;
+        button = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagButton *button = nullptr;
+    QColor color;
+};
+
+TEST_F(UT_TagButton, constructor)
+{
+    // Test constructor
+    EXPECT_NE(button, nullptr);
+    EXPECT_EQ(button->color(), color);
+}
+
+TEST_F(UT_TagButton, setRadiusF)
+{
+    // Test setting radius as float
+    EXPECT_NO_THROW(button->setRadiusF(20.0));
+}
+
+TEST_F(UT_TagButton, setRadius)
+{
+    // Test setting radius as size_t
+    EXPECT_NO_THROW(button->setRadius(20));
+}
+
+TEST_F(UT_TagButton, setCheckable)
+{
+    // Test setting checkable
+    EXPECT_NO_THROW(button->setCheckable(true));
+    EXPECT_NO_THROW(button->setCheckable(false));
+}
+
+TEST_F(UT_TagButton, setChecked)
+{
+    // Test setting checked state
+    button->setCheckable(true);
+
+    QSignalSpy spy(button, &TagButton::checkedChanged);
+
+    button->setChecked(true);
+    EXPECT_TRUE(button->isChecked());
+    EXPECT_EQ(spy.count(), 1);
+
+    button->setChecked(false);
+    EXPECT_FALSE(button->isChecked());
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(UT_TagButton, setCheckedWhenNotCheckable)
+{
+    // Test setting checked when not checkable
+    button->setCheckable(false);
+
+    button->setChecked(true);
+    EXPECT_FALSE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, isChecked)
+{
+    // Test isChecked
+    button->setCheckable(true);
+
+    EXPECT_FALSE(button->isChecked());
+
+    button->setChecked(true);
+    EXPECT_TRUE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, color)
+{
+    // Test getting color
+    QColor buttonColor = button->color();
+
+    EXPECT_EQ(buttonColor, color);
+}
+
+TEST_F(UT_TagButton, enterEvent)
+{
+    // Test enter event
+    QSignalSpy spy(button, &TagButton::enter);
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    QEvent event(QEvent::Enter);
+#else
+    QEnterEvent event(QPointF(0, 0), QPointF(0, 0), QPointF(0, 0));
+#endif
+
+    EXPECT_NO_THROW(button->enterEvent(&event));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagButton, leaveEvent)
+{
+    // Test leave event
+    QSignalSpy spy(button, &TagButton::leave);
+
+    QEvent event(QEvent::Leave);
+
+    EXPECT_NO_THROW(button->leaveEvent(&event));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagButton, mousePressEvent)
+{
+    // Test mouse press event
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    EXPECT_NO_THROW(button->mousePressEvent(&event));
+}
+
+TEST_F(UT_TagButton, mouseReleaseEvent)
+{
+    // Test mouse release event
+    button->setCheckable(true);
+
+    QSignalSpy clickSpy(button, &TagButton::click);
+
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    EXPECT_NO_THROW(button->mouseReleaseEvent(&event));
+    EXPECT_EQ(clickSpy.count(), 1);
+    EXPECT_TRUE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, paintEvent)
+{
+    // Test paint event
+    button->setRadius(20);
+
+    QPixmap pixmap(100, 100);
+    QPainter painter(&pixmap);
+
+    QPaintEvent event(QRect(0, 0, 100, 100));
+
+    // Paint in normal state
+    EXPECT_NO_THROW(button->paintEvent(&event));
+
+    // Paint in checked state
+    button->setCheckable(true);
+    button->setChecked(true);
+    EXPECT_NO_THROW(button->paintEvent(&event));
+}
+
+TEST_F(UT_TagButton, signals)
+{
+    // Test all signals
+    button->setCheckable(true);
+    button->setRadius(20);
+
+    QSignalSpy clickSpy(button, &TagButton::click);
+    QSignalSpy enterSpy(button, &TagButton::enter);
+    QSignalSpy leaveSpy(button, &TagButton::leave);
+    QSignalSpy checkedSpy(button, &TagButton::checkedChanged);
+
+    // Trigger enter
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    QEvent enterEvent(QEvent::Enter);
+#else
+    QEnterEvent enterEvent(QPointF(0, 0), QPointF(0, 0), QPointF(0, 0));
+#endif
+    button->enterEvent(&enterEvent);
+    EXPECT_EQ(enterSpy.count(), 1);
+
+    // Trigger leave
+    QEvent leaveEvent(QEvent::Leave);
+    button->leaveEvent(&leaveEvent);
+    EXPECT_EQ(leaveSpy.count(), 1);
+
+    // Trigger click
+    QMouseEvent releaseEvent(QEvent::MouseButtonRelease, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    button->mouseReleaseEvent(&releaseEvent);
+    EXPECT_EQ(clickSpy.count(), 1);
+    EXPECT_EQ(checkedSpy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagcolorlistwidget.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagcolorlistwidget.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagbutton.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+
+class TagColorListWidgetTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagHelper::defaultColors, []() {
+            __DBG_STUB_INVOKE__
+            return QList<QColor>() << QColor("red");
+        });
+        ins = new TagColorListWidget();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagColorListWidget *ins;
+};
+
+TEST_F(TagColorListWidgetTest, checkedColorList)
+{
+    stub.set_lamda(&TagButton::isChecked, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    EXPECT_FALSE(ins->checkedColorList().isEmpty());
+}
+
+TEST_F(TagColorListWidgetTest, exclusive)
+{
+    EXPECT_FALSE(ins->exclusive());
+}
+
+TEST_F(TagColorListWidgetTest, ToolTipText)
+{
+    stub.set_lamda(&DLabel::isVisible, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&QLabel::setText, [](QLabel *, QString text) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(text == "tag");
+    });
+    ins->setToolTipText("tag");
+    stub.set_lamda(&QLabel::setText, [](QLabel *, QString text) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(text == " ");
+    });
+    ins->clearToolTipText();
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagcrumbedit.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagcrumbedit.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h"
+
+#include <gtest/gtest.h>
+
+#include <QMouseEvent>
+#include <QTextDocument>
+#include <qabstracttextdocumentlayout.h>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class UT_TagCrumbEdit : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        edit = new TagCrumbEdit();
+    }
+
+    virtual void TearDown() override
+    {
+        delete edit;
+        edit = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagCrumbEdit *edit = nullptr;
+};
+
+TEST_F(UT_TagCrumbEdit, constructor)
+{
+    // Test constructor
+    EXPECT_NE(edit, nullptr);
+}
+
+TEST_F(UT_TagCrumbEdit, isEditing)
+{
+    // Test isEditing - should be false by default
+    bool editing = edit->isEditing();
+
+    EXPECT_FALSE(editing);
+}
+
+TEST_F(UT_TagCrumbEdit, mouseDoubleClickEvent)
+{
+    // Test mouse double click event
+    QMouseEvent event(QEvent::MouseButtonDblClick, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Stub the base class method to prevent actual editing
+    stub.set_lamda(VADDR(DCrumbEdit, mouseDoubleClickEvent), [](DCrumbEdit*, QMouseEvent*) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_THROW(edit->mouseDoubleClickEvent(&event));
+
+    // After double click event completes, isEditing should be false again
+    EXPECT_FALSE(edit->isEditing());
+}
+
+TEST_F(UT_TagCrumbEdit, documentMargins)
+{
+    // Test that document margins are set correctly in constructor
+    QTextDocument *doc = edit->document();
+
+    EXPECT_NE(doc, nullptr);
+    // Document margin should be increased by 5
+    EXPECT_GT(doc->documentMargin(), 0);
+}
+
+TEST_F(UT_TagCrumbEdit, viewportMargins)
+{
+    // Test viewport margins
+    QMargins margins = edit->viewportMargins();
+
+    EXPECT_EQ(margins.left(), 0);
+    EXPECT_EQ(margins.right(), 0);
+    EXPECT_EQ(margins.top(), 0);
+    EXPECT_EQ(margins.bottom(), 0);
+}
+
+TEST_F(UT_TagCrumbEdit, scrollBarPolicy)
+{
+    // Test scroll bar policy
+    Qt::ScrollBarPolicy vPolicy = edit->verticalScrollBarPolicy();
+
+    EXPECT_EQ(vPolicy, Qt::ScrollBarAlwaysOff);
+}
+
+TEST_F(UT_TagCrumbEdit, updateHeight)
+{
+    // Test height update when document size changes
+    stub.set_lamda(&QTextDocument::size, [](const QTextDocument*) -> QSizeF {
+        __DBG_STUB_INVOKE__
+        return QSizeF(100, 50);
+    });
+
+    // Trigger document size change
+    QTextDocument *doc = edit->document();
+    if (doc) {
+        QAbstractTextDocumentLayout *layout = doc->documentLayout();
+        if (layout) {
+            emit layout->documentSizeChanged(QSizeF(100, 50));
+        }
+    }
+
+    // Height should be updated based on document size
+    EXPECT_GT(edit->height(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagdirmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagdirmenuscene.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "menu/tagdirmenuscene.h"
+#include "menu/private/tagdirmenuscene_p.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <gtest/gtest.h>
+
+#include <QMenu>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QProcess>
+#include <DDesktopServices>
+#include <DGuiApplicationHelper>
+#include <dtkwidget_global.h>
+
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagDirMenuSceneTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        auto creator = new TagDirMenuCreator();
+        scene = static_cast<dfmplugin_tag::TagDirMenuScene *>(creator->create());
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TagDirMenuScene *scene { nullptr };
+    TagDirMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(TagDirMenuSceneTest, name)
+{
+    EXPECT_TRUE(scene->name() == "TagDirMenu");
+}
+
+TEST_F(TagDirMenuSceneTest, initialize)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"),
+                       QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_TRUE(scene->initialize({ { "currentDir", true } }));
+    EXPECT_TRUE(scene->initialize({ { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_TRUE(scene->initialize({ { "indexFlags", true } }));
+}
+
+TEST_F(TagDirMenuSceneTest, create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    EXPECT_TRUE(scene->create(&menu));
+}
+
+TEST_F(TagDirMenuSceneTest, triggered)
+{
+    auto act = new QAction("hello");
+    act->setProperty(TagActionId::kOpenFileLocation, "hello");
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+}
+
+TEST_F(TagDirMenuSceneTest, updateMenu)
+{
+    QMenu menu;
+    menu.addSeparator();
+    auto act = menu.addAction("Open file location");
+    act->setProperty(ActionPropertyKey::kActionID, TagActionId::kOpenFileLocation);
+
+    d->isEmptyArea = false;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+
+    d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+}
+
+TEST_F(TagDirMenuSceneTest, updateState)
+{
+    QMenu menu;
+    bool isRun = false;
+    stub.set_lamda(&TagDirMenuScenePrivate::updateMenu, [&isRun] { isRun = true; });
+    scene->updateState(&menu);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagDirMenuSceneTest, scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(),
+                 "dfmplugin_tag::TagDirMenuScene");
+
+    d->predicateAction.clear();
+    scene->scene(act);
+    delete act;
+    act = nullptr;
+}
+
+TEST_F(TagDirMenuSceneTest, openFileLocation)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return true; });
+
+    typedef bool (*StartFunc)(const QString &, const QStringList &, const QString &, qint64 *pid);
+    auto func = static_cast<StartFunc>(QProcess::startDetached);
+    st.set_lamda(func, [] { return true; });
+
+    EXPECT_TRUE(d->openFileLocation("/home"));
+
+    st.reset(SysInfoUtils::isRootUser);
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return false; });
+    auto func2 = qOverload<const QString &, const QString &>(&DDesktopServices::showFileItem);
+    st.set_lamda(func2, [] { return true; });
+    EXPECT_TRUE(d->openFileLocation("/home"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageditor.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageditor.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tageditor.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <dfm-base/utils/windowutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <DCrumbEdit>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class UT_TagEditor : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&dfmbase::WindowUtils::isWayLand, []() -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        stub.set_lamda(&TagManager::getTagsColor, [](TagManager *, const QStringList &) -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["Tag1"] = QColor("#ffa503");
+            return map;
+        });
+
+        stub.set_lamda(&TagManager::assignColorToTags, [](TagManager *, const QStringList &) -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["NewTag"] = QColor("#ffa503");
+            return map;
+        });
+
+        stub.set_lamda(&TagManager::setTagsForFiles, [](TagManager *, const QStringList &, const QList<QUrl> &) -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        editor = new TagEditor();
+    }
+
+    virtual void TearDown() override
+    {
+        if (editor) {
+            editor->deleteLater();
+            editor = nullptr;
+        }
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagEditor *editor = nullptr;
+};
+
+TEST_F(UT_TagEditor, constructor)
+{
+    // Test constructor
+    EXPECT_NE(editor, nullptr);
+}
+
+TEST_F(UT_TagEditor, setFocusOutSelfClosing)
+{
+    // Test setting focus out self closing
+    EXPECT_NO_THROW(editor->setFocusOutSelfClosing(true));
+    EXPECT_NO_THROW(editor->setFocusOutSelfClosing(false));
+}
+
+TEST_F(UT_TagEditor, setFilesForTagging)
+{
+    // Test setting files for tagging
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test1.txt");
+    files << QUrl::fromLocalFile("/home/user/test2.txt");
+
+    EXPECT_NO_THROW(editor->setFilesForTagging(files));
+}
+
+TEST_F(UT_TagEditor, setDefaultCrumbs)
+{
+    // Test setting default crumbs
+    QStringList list;
+    list << "Tag1"
+         << "Tag2";
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    typedef bool (DCrumbEdit::*InsertCrumb)(const DCrumbTextFormat &, int);
+    stub.set_lamda(static_cast<InsertCrumb>(&DCrumbEdit::insertCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(editor->setDefaultCrumbs(list));
+}
+
+TEST_F(UT_TagEditor, onFocusOut)
+{
+    // Test focus out slot
+    editor->setFocusOutSelfClosing(true);
+
+    stub.set_lamda(&DCrumbEdit::toPlainText, [] {
+        __DBG_STUB_INVOKE__
+        return "NewTag";
+    });
+
+    typedef bool (DCrumbEdit::*AppendCrumb)(const QString &);
+    stub.set_lamda(static_cast<AppendCrumb>(&DCrumbEdit::appendCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DCrumbEdit::crumbList, [](const DCrumbEdit *) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList list;
+        list << "NewTag";
+        return list;
+    });
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    typedef bool (DCrumbEdit::*InsertCrumb)(const DCrumbTextFormat &, int);
+    stub.set_lamda(static_cast<InsertCrumb>(&DCrumbEdit::insertCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool closed = false;
+    stub.set_lamda(&TagEditor::close, [&closed] {
+        __DBG_STUB_INVOKE__
+        closed = true;
+        return true;
+    });
+
+    EXPECT_NO_THROW(editor->onFocusOut());
+    EXPECT_TRUE(closed);
+}
+
+TEST_F(UT_TagEditor, filterInput)
+{
+    // Test filter input
+    stub.set_lamda(&TagHelper::crumbEditInputFilter, [](TagHelper *, DCrumbEdit *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_THROW(editor->filterInput());
+}
+
+TEST_F(UT_TagEditor, keyPressEvent)
+{
+    // Test key press event - ESC key
+    stub.set_lamda(&DCrumbEdit::crumbList, [](const DCrumbEdit *) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool closed = false;
+    stub.set_lamda(&TagEditor::close, [&closed] {
+        __DBG_STUB_INVOKE__
+        closed = true;
+        return true;
+    });
+
+    QKeyEvent escEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    EXPECT_NO_THROW(editor->keyPressEvent(&escEvent));
+    EXPECT_TRUE(closed);
+}
+
+TEST_F(UT_TagEditor, constructorWithInTagDir)
+{
+    // Test constructor with inTagDir parameter
+    stub.set_lamda(&dfmbase::WindowUtils::isWayLand, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    TagEditor *tagDirEditor = nullptr;
+    EXPECT_NO_THROW(tagDirEditor = new TagEditor(nullptr, true));
+    EXPECT_NE(tagDirEditor, nullptr);
+
+    if (tagDirEditor) {
+        tagDirEditor->deleteLater();
+    }
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfileinfo.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfileinfo.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo_p.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <QIcon>
+#include <QFile>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagFileInfo : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl.setScheme("tag");
+        testUrl.setPath("/TestTag");
+        fileInfo = new TagFileInfo(testUrl);
+    }
+
+    virtual void TearDown() override
+    {
+        delete fileInfo;
+        fileInfo = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagFileInfo *fileInfo = nullptr;
+    QUrl testUrl;
+};
+
+TEST_F(UT_TagFileInfo, constructor)
+{
+    // Test constructor
+    EXPECT_NE(fileInfo, nullptr);
+}
+
+TEST_F(UT_TagFileInfo, exists_RootUrl)
+{
+    // Test exists for root URL
+    QUrl rootUrl;
+    rootUrl.setScheme("tag");
+
+    TagFileInfo rootInfo(rootUrl);
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [](const FileInfo*, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        return url;
+    });
+
+    bool result = rootInfo.exists();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, exists_TagExists)
+{
+    // Test exists when tag exists in system
+    stub.set_lamda(&TagManager::instance, []() -> TagManager* {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager*) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        TagManager::TagColorMap map;
+        map["TestTag"] = QColor("#ffa503");
+        return map;
+    });
+
+    stub.set_lamda(&TagFileInfo::tagName, [](const TagFileInfo*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    bool result = fileInfo->exists();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, exists_TagNotExists)
+{
+    // Test exists when tag doesn't exist
+    stub.set_lamda(&TagManager::instance, []() -> TagManager* {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager*) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return TagManager::TagColorMap(); // Empty map
+    });
+
+    stub.set_lamda(&TagFileInfo::tagName, [](const TagFileInfo*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "NonExistentTag";
+    });
+
+    bool result = fileInfo->exists();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, permissions)
+{
+    // Test permissions
+    QFile::Permissions perms = fileInfo->permissions();
+
+    // Should have read and write permissions
+    EXPECT_TRUE(perms & QFile::ReadOwner);
+    EXPECT_TRUE(perms & QFile::WriteOwner);
+    EXPECT_TRUE(perms & QFile::ReadUser);
+    EXPECT_TRUE(perms & QFile::WriteUser);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Readable)
+{
+    // Test is readable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsReadable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Writable)
+{
+    // Test is writable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsWritable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Executable)
+{
+    // Test is executable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsExecutable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Default)
+{
+    // Test other attributes fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, isAttributes), [](const ProxyFileInfo*, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = fileInfo->isAttributes(OptInfoType::kIsHidden);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, canAttributes_CanDrop)
+{
+    // Test can drop attribute
+    bool result = fileInfo->canAttributes(CanableInfoType::kCanDrop);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, canAttributes_Default)
+{
+    // Test other can attributes fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, canAttributes), [](const ProxyFileInfo*, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = fileInfo->canAttributes(CanableInfoType::kCanDelete);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, nameOf_FileName)
+{
+    // Test getting file name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kFileName);
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, nameOf_FileCopyName)
+{
+    // Test getting file copy name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kFileCopyName);
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, nameOf_Default)
+{
+    // Test other name types fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, nameOf), [](const ProxyFileInfo*, NameInfoType) -> QString {
+        __DBG_STUB_INVOKE__
+        return "DefaultName";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kCompleteBaseName);
+
+    EXPECT_EQ(name, "DefaultName");
+}
+
+TEST_F(UT_TagFileInfo, displayOf_FileDisplayName)
+{
+    // Test getting file display name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString display = fileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+
+    EXPECT_EQ(display, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, displayOf_Default)
+{
+    // Test other display types fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, displayOf), [](const ProxyFileInfo*, DisPlayInfoType) -> QString {
+        __DBG_STUB_INVOKE__
+        return "DefaultDisplay";
+    });
+
+    QString display = fileInfo->displayOf(DisPlayInfoType::kSizeDisplayName);
+
+    EXPECT_EQ(display, "DefaultDisplay");
+}
+
+TEST_F(UT_TagFileInfo, fileType)
+{
+    // Test file type
+    FileInfo::FileType type = fileInfo->fileType();
+
+    EXPECT_EQ(type, FileInfo::FileType::kDirectory);
+}
+
+TEST_F(UT_TagFileInfo, fileIcon)
+{
+    // QIcon::fromTheme() returns a null icon when no icon theme engine is
+    // available (offscreen), so pin the theme lookup instead.
+    QPixmap pix(16, 16);
+    pix.fill(Qt::red);
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(&QIcon::fromTheme),
+                   [pix](const QString &name) -> QIcon {
+                       __DBG_STUB_INVOKE__
+                       EXPECT_EQ(name, QString("folder"));
+                       return QIcon(pix);
+                   });
+
+    // Test file icon
+    QIcon icon = fileInfo->fileIcon();
+
+    EXPECT_FALSE(icon.isNull());
+}
+
+TEST_F(UT_TagFileInfo, tagName)
+{
+    // Test getting tag name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->tagName();
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, multipleInstances)
+{
+    // Test creating multiple instances
+    QUrl url1;
+    url1.setScheme("tag");
+    url1.setPath("/Tag1");
+
+    QUrl url2;
+    url2.setScheme("tag");
+    url2.setPath("/Tag2");
+
+    TagFileInfo info1(url1);
+    TagFileInfo info2(url2);
+
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate* d) -> QString {
+        __DBG_STUB_INVOKE__
+        // Return different names based on the object
+        return "Tag1"; // Simplified for testing
+    });
+
+    EXPECT_NO_THROW(info1.tagName());
+    EXPECT_NO_THROW(info2.tagName());
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmenuscene.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "menu/private/tagmenuscene_p.h"
+#include "menu/tagmenuscene.h"
+#include "utils/taghelper.h"
+#include "utils/tagmanager.h"
+#include "widgets/tagcolorlistwidget.h"
+#include "data/tagproxyhandle.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QMenu>
+#include <QPaintEvent>
+#include <QWidgetAction>
+#include <QPainter>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagMenuSceneTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // The daemon DBus interface is null in the test environment; stub the
+        // read-only queries so no test case can reach the DBus layer.
+        stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            return { { "red", QVariant { QColor("#ff0000") } } };
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+            __DBG_STUB_INVOKE__
+            return { { "red", QVariant { QColor("#ff0000") } } };
+        });
+        stub.set_lamda(&TagProxyHandle::getAllFileWithTags, [](TagProxyHandle *) -> QVariantHash {
+            __DBG_STUB_INVOKE__
+            return {};
+        });
+
+        auto creator = new TagMenuCreator();
+        scene = static_cast<dfmplugin_tag::TagMenuScene *>(creator->create());
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TagMenuScene *scene { nullptr };
+    TagMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(TagMenuSceneTest, name)
+{
+    EXPECT_TRUE(scene->name() == "TagMenu");
+}
+
+TEST_F(TagMenuSceneTest, initialize)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"),
+                       QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_TRUE(scene->initialize({ { "currentDir", true } }));
+    EXPECT_TRUE(scene->initialize(
+            { { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_EQ(d->onDesktop, true);
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_TRUE(scene->initialize({ { "indexFlags", true } }));
+}
+
+TEST_F(TagMenuSceneTest, create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    d->focusFile = QUrl("file:///test");
+    d->focusFileInfo.reset(new FileInfo(d->focusFile));
+    // TagMenuScene::createColorListAction() queries the color of each tag;
+    // the daemon DBus interface is null in the test environment.
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return { { "red", QVariant { QColor("#ff0000") } } };
+    });
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return { { "red", QVariant { QColor("#ff0000") } } };
+    });
+    stub.set_lamda(&TagManager::getTagsByUrls, [] {
+        __DBG_STUB_INVOKE__
+        return QList<QString>() << "red";
+    });
+    stub.set_lamda(VADDR(FileInfo, exists), [] { __DBG_STUB_INVOKE__ return true; });
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(scene->create(&menu));
+}
+
+TEST_F(TagMenuSceneTest, triggered)
+{
+    auto act = new QAction("hello");
+    stub.set_lamda(&TagHelper::showTagEdit, [] { __DBG_STUB_INVOKE__ });
+    act->setProperty(ActionPropertyKey::kActionID, "hello");
+    scene->d->predicateAction.insert(TagActionId::kActTagAddKey, act);
+    scene->d->focusFile.setUrl("/hello");
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", false } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", false } }));
+    EXPECT_FALSE(scene->triggered(act));
+}
+
+TEST_F(TagMenuSceneTest, scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(),
+                 "dfmplugin_tag::TagMenuScene");
+
+    d->predicateAction.clear();
+    scene->scene(act);
+    delete act;
+    act = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, onHoverChanged)
+{
+    scene->d->selectFiles << QUrl::fromLocalFile("/test");
+    stub.set_lamda(&TagManager::getTagsByUrls,
+                   []() { __DBG_STUB_INVOKE__ return QStringList(); });
+    bool flag = false;
+    TagColorListWidget *tagWidget = new TagColorListWidget();
+    stub.set_lamda(&TagMenuScene::getMenuListWidget, [tagWidget]() {
+        __DBG_STUB_INVOKE__
+        return tagWidget;
+    });
+    stub.set_lamda(&TagColorListWidget::setToolTipText,
+                   [&flag]() { __DBG_STUB_INVOKE__ flag = true; });
+    stub.set_lamda(&TagManager::getTagsColor, []() {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> map;
+        map["red"] = QColor("red");
+        return map;
+    });
+    scene->onHoverChanged(QColor("red"));
+    EXPECT_TRUE(flag);
+    delete tagWidget;
+    tagWidget = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, onColorClicked)
+{
+    TagColorListWidget *tagWidget = new TagColorListWidget();
+    stub.set_lamda(&TagMenuScene::getMenuListWidget, [tagWidget]() {
+        __DBG_STUB_INVOKE__
+        return tagWidget;
+    });
+
+    bool flag = false;
+    // No cached color->tag mapping: make the DB fallback return a known tag
+    // so onColorClicked() reaches the tag-manager layer.
+    stub.set_lamda(&TagHelper::queryDisplayNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString("red");
+    });
+    stub.set_lamda(&TagColorListWidget::checkedColorList, [](const TagColorListWidget *) -> QList<QColor> {
+        __DBG_STUB_INVOKE__
+        return { QColor("red") };
+    });
+    stub.set_lamda(&TagManager::addTagsForFiles, [&flag]() {
+        __DBG_STUB_INVOKE__ flag = true;
+        return true;
+    });
+    stub.set_lamda(&TagManager::removeTagsOfFiles, [&flag]() {
+        __DBG_STUB_INVOKE__ flag = true;
+        return true;
+    });
+    scene->onColorClicked(QColor("red"));
+    EXPECT_TRUE(flag);
+    delete tagWidget;
+    tagWidget = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, getSurfaceRect)
+{
+    QWidget *w = new QWidget();
+    QWidget w2;
+    w2.setFixedSize(10, 10);
+    w2.setProperty("WidgetName", QString("organizersurface"));
+    w->setParent(&w2);
+    EXPECT_TRUE(d->getSurfaceRect(w) == w2.rect());
+}
+
+TEST_F(TagMenuSceneTest, getMenuListWidget)
+{
+    bool isRun = false;
+    d->predicateAction.insert(TagActionId::kActTagColorListKey, new QWidgetAction(scene));
+    stub.set_lamda(&QWidgetAction::defaultWidget, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return nullptr;
+    });
+    scene->getMenuListWidget();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagMenuSceneTest, createColorListAction)
+{
+    QMenu m;
+    bool isRun = false;
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        isRun = true;
+        return QStringList() << "red";
+    });
+    stub.set_lamda(&TagHelper::isDefaultTag, []() { return true; });
+    stub.set_lamda(&TagHelper::queryColorByDisplayName, []() { return QColor("red"); });
+    scene->createColorListAction(&m);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagMenuSceneTest, updateState)
+{
+    QMenu m;
+    bool isRun = false;
+    stub.set_lamda(&QMenu::removeAction, [&isRun]() { isRun = true; });
+    scene->updateState(&m);
+    EXPECT_TRUE(isRun);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagpainter.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagpainter.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagpainter.h"
+
+#include <gtest/gtest.h>
+
+#include <QPainter>
+#include <QPixmap>
+#include <QTextFormat>
+
+using namespace dfmplugin_tag;
+
+class UT_TagPainter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        painter = new TagPainter();
+    }
+
+    virtual void TearDown() override
+    {
+        delete painter;
+        painter = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagPainter *painter = nullptr;
+};
+
+TEST_F(UT_TagPainter, constructor)
+{
+    // Test constructor
+    EXPECT_NE(painter, nullptr);
+}
+
+TEST_F(UT_TagPainter, drawObject)
+{
+    // Test drawing object
+    QPixmap pixmap(100, 100);
+    QPainter qpainter(&pixmap);
+    QRectF rect(0, 0, 100, 100);
+    QTextDocument doc;
+    int posInDocument = 0;
+    QTextFormat format;
+
+    // drawObject is virtual, test it doesn't crash
+    EXPECT_NO_THROW(painter->drawObject(&qpainter, rect, &doc, posInDocument, format));
+}
+
+TEST_F(UT_TagPainter, intrinsicSize)
+{
+    // Test intrinsic size calculation
+    QTextDocument doc;
+    int posInDocument = 0;
+    QTextFormat format;
+
+    QSizeF size = painter->intrinsicSize(&doc, posInDocument, format);
+
+    // Size should be non-negative
+    EXPECT_GE(size.width(), 0);
+    EXPECT_GE(size.height(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagtextformat.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagtextformat.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagtextformat.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+
+using namespace dfmplugin_tag;
+
+class TagTextFormatTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        ins = new TagTextFormat(1, QList<QColor>() << QColor("red"), QColor("red"));
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagTextFormat *ins;
+};
+
+TEST_F(TagTextFormatTest, colors)
+{
+    EXPECT_TRUE(ins->colors().contains(QColor("red")));
+}
+
+TEST_F(TagTextFormatTest, borderColor)
+{
+    EXPECT_TRUE(ins->borderColor() == QColor("red"));
+}
+
+TEST_F(TagTextFormatTest, diameter)
+{
+    EXPECT_TRUE(ins->diameter() == kTagDiameter);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagwidget.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagwidget.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagwidget.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <DCrumbEdit>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagWidgetTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagManager::getTagsColor, []() -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["red"] = QColor("red");
+            return map;
+        });
+        stub.set_lamda(&TagManager::getTagsByUrls, []() {
+            __DBG_STUB_INVOKE__
+            return QStringList();
+        });
+        stub.set_lamda(&TagManager::getAllTags, []() {
+            __DBG_STUB_INVOKE__
+            return QMap<QString, QColor>();
+        });
+        ins = new TagWidget(QUrl("file://hello/world"));
+        ins->initialize();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagWidget *ins;
+};
+
+TEST_F(TagWidgetTest, loadTags)
+{
+    stub.set_lamda(&TagColorListWidget::setCheckedColorList, [](TagColorListWidget *, const QList<QColor> &colorNames) {
+        __DBG_STUB_INVOKE__
+        qInfo() << "455555555" << colorNames;
+        EXPECT_TRUE(colorNames.contains(QColor("red")));
+    });
+    stub.set_lamda(&TagHelper::isDefaultTag, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    ins->loadTags(QUrl("file://hello/world"));
+}
+
+TEST_F(TagWidgetTest, shouldShow)
+{
+    EXPECT_TRUE(ins->shouldShow(QUrl("file://hello/world")));
+}
+
+TEST_F(TagWidgetTest, onCrumbListChanged)
+{
+    stub.set_lamda(&TagManager::setTagsForFiles, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&TagCrumbEdit::property, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    ins->onCrumbListChanged();
+}
+
+TEST_F(TagWidgetTest, onCheckedColorChanged)
+{
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    stub.set_lamda(&TagColorListWidget::checkedColorList, [] {
+        __DBG_STUB_INVOKE__
+        return QList<QColor>();
+    });
+    ins->onCheckedColorChanged(QColor("red"));
+}
+
+TEST_F(TagWidgetTest, onTagChanged)
+{
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    QVariantMap map;
+    map[QUrl("file://hello/world").path()] = "";
+    ins->onTagChanged(map);
+}
+
+TEST_F(TagWidgetTest, updateCrumbsColor)
+{
+    auto func = static_cast<bool (TagCrumbEdit::*)(const DCrumbTextFormat &, int)>(&TagCrumbEdit::insertCrumb);
+    stub.set_lamda(func, [](TagCrumbEdit *, const DCrumbTextFormat format, int) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(format.text() == "red");
+        return true;
+    });
+    ins->updateCrumbsColor(QMap<QString, QColor>());
+    QMap<QString, QColor> map;
+    map["red"] = QColor("red");
+    ins->updateCrumbsColor(map);
+}


### PR DESCRIPTION
Part 2/2 of dfmplugin-tag unit tests, split by module for easier review:
标签界面组件与绘制.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-tag 单元测试第 2/2 部分（按模块拆分以便评审）：标签界面组件与绘制。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-tag 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Tests:
- Add unit coverage for dfmplugin-tag UI widgets, menu scenes, file information, editors, painters, text formats, and related tag interactions.