### PR TITLE
test: add unit tests for dfmplugin-utils (part 2/5: dfmext extension)

### DIFF
--- a/autotests/plugins/dfmplugin-utils/test_dfmextactionimpl.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextactionimpl.cpp
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextactionimpl_p.h"
+
+#include <QAction>
+#include <QMenu>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtActionImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImpl, Constructor_WithNullAction_CreatesNewAction)
+{
+    DFMExtActionImpl *impl = new DFMExtActionImpl(nullptr);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+TEST_F(UT_DFMExtActionImpl, Constructor_WithExistingAction_UsesAction)
+{
+    QAction *action = new QAction();
+    DFMExtActionImpl *impl = new DFMExtActionImpl(action);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+// ========== DFMExtActionImplPrivate Tests ==========
+
+class UT_DFMExtActionImplPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        action = new QAction();
+        impl = new DFMExtActionImpl(nullptr);
+        d = dynamic_cast<DFMExtActionImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete action;
+        action = nullptr;
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    QAction *action { nullptr };
+    DFMExtActionImpl *impl { nullptr };
+    DFMExtActionImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImplPrivate, isInterior_ExternalAction_ReturnsFalse)
+{
+    EXPECT_FALSE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setText_SetsActionText)
+{
+    d->setText("Test Text");
+
+    std::string result = d->text();
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setToolTip_SetsActionToolTip)
+{
+    d->setToolTip("Test Tooltip");
+
+    std::string result = d->toolTip();
+    EXPECT_EQ(result, "Test Tooltip");
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setSeparator_SetsActionSeparator)
+{
+    d->setSeparator(true);
+
+    EXPECT_TRUE(d->isSeparator());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setCheckable_SetsActionCheckable)
+{
+    d->setCheckable(true);
+
+    EXPECT_TRUE(d->isCheckable());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setEnabled_SetsActionEnabled)
+{
+    d->setEnabled(false);
+
+    EXPECT_FALSE(d->isEnabled());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_ThemeName_SetsIcon)
+{
+    d->setIcon("dialog-information");
+
+    std::string result = d->icon();
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, qaction_ReturnsQAction)
+{
+    QAction *result = d->qaction();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, actionImpl_ReturnsImpl)
+{
+    DFMExtActionImpl *result = d->actionImpl();
+
+    EXPECT_EQ(result, impl);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setChecked_SetsActionChecked)
+{
+    d->setCheckable(true);
+    d->setChecked(true);
+
+    bool result = d->isChecked();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_FilePath_SetsIcon)
+{
+    d->setIcon("/usr/share/icons/default.png");
+
+    std::string result = d->icon();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_EmptyPath_SetsEmptyIcon)
+{
+    d->setIcon("");
+
+    std::string result = d->icon();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, text_WithEmptyAction_ReturnsEmpty)
+{
+    std::string result = d->text();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setMenu_NullMenu_DoesNotCrash)
+{
+    d->setMenu(nullptr);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, menu_NoMenu_ReturnsNull)
+{
+    DFMEXT::DFMExtMenu *result = d->menu();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+// ========== Interior Action Tests ==========
+
+class UT_DFMExtActionImplPrivate_Interior : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        action = new QAction();
+        impl = new DFMExtActionImpl(action);
+        d = dynamic_cast<DFMExtActionImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    QAction *action { nullptr };
+    DFMExtActionImpl *impl { nullptr };
+    DFMExtActionImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, isInterior_InteriorAction_ReturnsTrue)
+{
+    EXPECT_TRUE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setText_InteriorAction_DoesNotSetText)
+{
+    QString originalText = action->text();
+
+    d->setText("New Text");
+
+    EXPECT_EQ(action->text(), originalText);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setIcon_InteriorAction_DoesNotSetIcon)
+{
+    d->setIcon("dialog-information");
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setToolTip_InteriorAction_DoesNotSetToolTip)
+{
+    QString originalTip = action->toolTip();
+
+    d->setToolTip("New Tip");
+
+    EXPECT_EQ(action->toolTip(), originalTip);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setSeparator_InteriorAction_DoesNotSetSeparator)
+{
+    bool originalSeparator = action->isSeparator();
+
+    d->setSeparator(true);
+
+    EXPECT_EQ(action->isSeparator(), originalSeparator);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setCheckable_InteriorAction_DoesNotSetCheckable)
+{
+    bool originalCheckable = action->isCheckable();
+
+    d->setCheckable(true);
+
+    EXPECT_EQ(action->isCheckable(), originalCheckable);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setChecked_InteriorAction_DoesNotSetChecked)
+{
+    action->setCheckable(true);
+    bool originalChecked = action->isChecked();
+
+    d->setChecked(true);
+
+    EXPECT_EQ(action->isChecked(), originalChecked);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setEnabled_InteriorAction_DoesNotSetEnabled)
+{
+    bool originalEnabled = action->isEnabled();
+
+    d->setEnabled(false);
+
+    EXPECT_EQ(action->isEnabled(), originalEnabled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenucache.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenucache.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenucache.h"
+
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtMenuCache : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuCache, instance_ReturnsSingleton)
+{
+    DFMExtMenuCache &instance1 = DFMExtMenuCache::instance();
+    DFMExtMenuCache &instance2 = DFMExtMenuCache::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_DFMExtMenuCache, extMenuSortRules_InitiallyEmpty)
+{
+    DFMExtMenuCache &cache = DFMExtMenuCache::instance();
+
+    cache.extMenuSortRules.clear();
+
+    EXPECT_TRUE(cache.extMenuSortRules.isEmpty());
+}
+
+TEST_F(UT_DFMExtMenuCache, extMenuSortRules_CanAddRules)
+{
+    DFMExtMenuCache &cache = DFMExtMenuCache::instance();
+    cache.extMenuSortRules.clear();
+
+    QAction action1;
+    QAction action2;
+    cache.extMenuSortRules.append(qMakePair(&action1, &action2));
+
+    EXPECT_EQ(cache.extMenuSortRules.size(), 1);
+    cache.extMenuSortRules.clear();
+}

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenuimpl.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenuimpl.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextmenuimpl_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+
+#include <QMenu>
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtMenuImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImpl, Constructor_WithNullMenu_CreatesNewMenu)
+{
+    DFMExtMenuImpl *impl = new DFMExtMenuImpl(nullptr);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+TEST_F(UT_DFMExtMenuImpl, Constructor_WithExistingMenu_UsesMenu)
+{
+    QMenu *menu = new QMenu();
+    DFMExtMenuImpl *impl = new DFMExtMenuImpl(menu);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+// ========== DFMExtMenuImplPrivate Tests ==========
+
+class UT_DFMExtMenuImplPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        impl = new DFMExtMenuImpl(nullptr);
+        d = dynamic_cast<DFMExtMenuImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImpl *impl { nullptr };
+    DFMExtMenuImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplPrivate, isInterior_ExternalMenu_ReturnsFalse)
+{
+    EXPECT_FALSE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, setTitle_SetsMenuTitle)
+{
+    d->setTitle("Test Title");
+
+    std::string result = d->title();
+    EXPECT_EQ(result, "Test Title");
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, setIcon_ThemeName_SetsIcon)
+{
+    d->setIcon("dialog-information");
+
+    std::string result = d->icon();
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, qmenu_ReturnsQMenu)
+{
+    QMenu *result = d->qmenu();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, menuImpl_ReturnsImpl)
+{
+    DFMExtMenuImpl *result = d->menuImpl();
+
+    EXPECT_EQ(result, impl);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, addAction_ExternalAction_ReturnsTrue)
+{
+    DFMExtActionImpl *action = new DFMExtActionImpl(nullptr);
+
+    bool result = d->addAction(action);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, addAction_NullAction_ReturnsFalse)
+{
+    bool result = d->addAction(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, menuAction_ReturnsMenuAction)
+{
+    DFMEXT::DFMExtAction *result = d->menuAction();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, actions_ReturnsActionList)
+{
+    std::list<DFMEXT::DFMExtAction *> result = d->actions();
+
+    // Initially may be empty or contain menu action
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenuimplproxy.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenuimplproxy.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimplproxy.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextmenuimplproxy_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+USING_DFMEXT_NAMESPACE
+
+class UT_DFMExtMenuImplProxy : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        proxy = new DFMExtMenuImplProxy();
+    }
+
+    void TearDown() override
+    {
+        delete proxy;
+        proxy = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImplProxy *proxy { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplProxy, Constructor_CreatesProxy)
+{
+    EXPECT_NE(proxy, nullptr);
+}
+
+// ========== DFMExtMenuImplProxyPrivate Tests ==========
+
+class UT_DFMExtMenuImplProxyPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        d = new DFMExtMenuImplProxyPrivate();
+    }
+
+    void TearDown() override
+    {
+        delete d;
+        d = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImplProxyPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, createMenu_ReturnsNewMenu)
+{
+    DFMExtMenu *menu = d->createMenu();
+
+    EXPECT_NE(menu, nullptr);
+
+    d->deleteMenu(menu);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteMenu_NullMenu_ReturnsTrue)
+{
+    bool result = d->deleteMenu(nullptr);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteMenu_ExternalMenu_ReturnsTrue)
+{
+    DFMExtMenu *menu = d->createMenu();
+
+    bool result = d->deleteMenu(menu);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, createAction_ReturnsNewAction)
+{
+    DFMExtAction *action = d->createAction();
+
+    EXPECT_NE(action, nullptr);
+
+    d->deleteAction(action);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteAction_NullAction_ReturnsTrue)
+{
+    bool result = d->deleteAction(nullptr);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteAction_ExternalAction_ReturnsTrue)
+{
+    DFMExtAction *action = d->createAction();
+
+    bool result = d->deleteAction(action);
+
+    EXPECT_TRUE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionemblemmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionemblemmanager.cpp
@@ -1,0 +1,523 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QIcon>
+#include <QSignalSpy>
+#include <QThread>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+// ========== ExtensionEmblemManagerPrivate Tests ==========
+
+class UT_ExtensionEmblemManagerPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        manager = new ExtensionEmblemManager();
+        d = new ExtensionEmblemManagerPrivate(manager);
+    }
+
+    void TearDown() override
+    {
+        delete d;
+        d = nullptr;
+        delete manager;
+        manager = nullptr;
+        stub.clear();
+    }
+
+    ExtensionEmblemManager *manager { nullptr };
+    ExtensionEmblemManagerPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, Constructor_InitializesFields)
+{
+    EXPECT_NE(d, nullptr);
+    EXPECT_EQ(d->q_ptr, manager);
+    EXPECT_FALSE(d->readyFlag);
+    EXPECT_TRUE(d->readyLocalPaths.isEmpty());
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_AddsPath)
+{
+    QPair<QString, int> path("/test/file.txt", 0);
+
+    d->addReadyLocalPath(path);
+
+    EXPECT_TRUE(d->readyLocalPaths.contains(path));
+    EXPECT_TRUE(d->readyFlag);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_DuplicatePath_NotAdded)
+{
+    QPair<QString, int> path("/test/file.txt", 0);
+
+    d->addReadyLocalPath(path);
+    d->addReadyLocalPath(path);
+
+    EXPECT_EQ(d->readyLocalPaths.count(), 1);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_DifferentPaths_AllAdded)
+{
+    d->addReadyLocalPath({ "/test/file1.txt", 0 });
+    d->addReadyLocalPath({ "/test/file2.txt", 1 });
+    d->addReadyLocalPath({ "/test/file3.txt", 2 });
+
+    EXPECT_EQ(d->readyLocalPaths.count(), 3);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, clearReadyLocalPath_ClearsAll)
+{
+    d->addReadyLocalPath({ "/test/file1.txt", 0 });
+    d->addReadyLocalPath({ "/test/file2.txt", 1 });
+
+    d->clearReadyLocalPath();
+
+    EXPECT_TRUE(d->readyLocalPaths.isEmpty());
+    EXPECT_FALSE(d->readyFlag);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_ThemeName_ReturnsThemeIcon)
+{
+    // Offscreen platform: QIcon::fromTheme finds no theme engine, so stub it
+    // to return a valid icon as a real theme would.
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(&QIcon::fromTheme), [](const QString &) -> QIcon {
+        __DBG_STUB_INVOKE__
+        QPixmap pm(16, 16);
+        pm.fill(Qt::red);
+        return QIcon(pm);
+    });
+    stub.set_lamda(static_cast<QIcon (*)(const QString &, const QIcon &)>(&QIcon::fromTheme), [](const QString &, const QIcon &) -> QIcon {
+        __DBG_STUB_INVOKE__
+        QPixmap pm(16, 16);
+        pm.fill(Qt::red);
+        return QIcon(pm);
+    });
+
+    QIcon result = d->makeIcon("dialog-information");
+
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_FilePath_ReturnsFileIcon)
+{
+    QIcon result = d->makeIcon("/nonexistent/path/icon.png");
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_EmptyPath_ReturnsEmptyIcon)
+{
+    QIcon result = d->makeIcon("");
+
+    EXPECT_TRUE(result.isNull());
+}
+
+// ========== ExtensionEmblemManager Tests ==========
+
+class UT_ExtensionEmblemManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionEmblemManager, instance_ReturnsSingleton)
+{
+    ExtensionEmblemManager &instance1 = ExtensionEmblemManager::instance();
+    ExtensionEmblemManager &instance2 = ExtensionEmblemManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionEmblemManager, initialize_RegistersMetaType)
+{
+    ExtensionEmblemManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_InvalidUrl_ReturnsFalse)
+{
+    QUrl invalidUrl;
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(invalidUrl, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_PluginsNotInitialized_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kReady;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_NoEmblemPlugin_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_TooManyEmblems_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+    for (int i = 0; i < 5; ++i)
+        emblems.append(QIcon());
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onEmblemIconChanged_UpdatesCache)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [](EventChannelManager *, const QString &, const QString &, QUrl) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant();
+                   });
+
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    QString path = "/tmp/test.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("emblem-default"), 0) };
+
+    ExtensionEmblemManager::instance().onEmblemIconChanged(path, group);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onUrlChanged_ClearsCacheAndEmitsSignal)
+{
+    QSignalSpy spy(&ExtensionEmblemManager::instance(), &ExtensionEmblemManager::requestClearCache);
+
+    bool result = ExtensionEmblemManager::instance().onUrlChanged(0, QUrl::fromLocalFile("/tmp"));
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onAllPluginsInitialized_StartsWorkerThread)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, emblemPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtEmblemIconPlugin *>();
+                   });
+
+    ExtensionEmblemManager::instance().onAllPluginsInitialized();
+}
+
+// ========== EmblemIconWorker Tests ==========
+
+class UT_EmblemIconWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new EmblemIconWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    EmblemIconWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemIconWorker, Constructor_CreatesWorker)
+{
+    EXPECT_NE(worker, nullptr);
+}
+
+TEST_F(UT_EmblemIconWorker, onClearCache_ClearsCaches)
+{
+    worker->onClearCache();
+}
+
+TEST_F(UT_EmblemIconWorker, onFetchEmblemIcons_EmptyPaths_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, emblemPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtEmblemIconPlugin *>();
+                   });
+
+    stub.set_lamda(&QThread::currentThread, []() {
+        __DBG_STUB_INVOKE__
+        return nullptr;   // Different from app thread
+    });
+
+    QList<QPair<QString, int>> emptyPaths;
+    worker->onFetchEmblemIcons(emptyPaths);
+}
+
+TEST_F(UT_EmblemIconWorker, makeCache_ReturnsValidCache)
+{
+    QString path = "/test/file.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("icon"), 0) };
+
+    auto cache = worker->makeCache(path, group);
+
+    EXPECT_TRUE(cache.contains(path));
+    EXPECT_EQ(cache.value(path), group);
+}
+
+TEST_F(UT_EmblemIconWorker, makeLayoutGroup_EmptyLayouts_ReturnsEmptyGroup)
+{
+    std::vector<DFMEXT::DFMExtEmblemIconLayout> layouts;
+    QList<QPair<QString, int>> group;
+
+    worker->makeLayoutGroup(layouts, &group);
+
+    EXPECT_TRUE(group.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_EmptyIcons_ReturnsEmptyGroup)
+{
+    std::vector<std::string> icons;
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_TRUE(group.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_WithIcons_CreatesGroup)
+{
+    std::vector<std::string> icons = { "icon1", "icon2" };
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_EQ(group.size(), 2);
+    EXPECT_EQ(group[0].first, "icon1");
+    EXPECT_EQ(group[0].second, 0);
+    EXPECT_EQ(group[1].first, "icon2");
+    EXPECT_EQ(group[1].second, 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_BothEmpty_ReturnsEmpty)
+{
+    QList<QPair<QString, int>> oldGroup;
+    QList<QPair<QString, int>> newGroup;
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_OnlyOldGroup_ReturnsOld)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup;
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_OnlyNewGroup_ReturnsNew)
+{
+    QList<QPair<QString, int>> oldGroup;
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 0) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_SamePosition_NewOverwritesOld)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 0) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].first, "new-icon");
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_EmptyCache_ReturnsGroup)
+{
+    QList<QPair<QString, int>> cache;
+    QList<QPair<QString, int>> group = { qMakePair(QString("icon"), 0) };
+
+    auto result = worker->updateLayoutGroup(cache, group);
+
+    EXPECT_EQ(result, group);
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_SameAsCache_ReturnsGroup)
+{
+    QList<QPair<QString, int>> data = { qMakePair(QString("icon"), 0) };
+
+    auto result = worker->updateLayoutGroup(data, data);
+
+    EXPECT_EQ(result, data);
+}
+
+TEST_F(UT_EmblemIconWorker, hasCachedByOtherLocationEmblem_NoCache_ReturnsFalse)
+{
+    bool result = worker->hasCachedByOtherLocationEmblem("/test/file.txt", 0);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_PositionOverflow_LimitsGroup)
+{
+    std::vector<std::string> icons = { "icon1", "icon2", "icon3", "icon4", "icon5" };
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_LE(group.size(), 4);   // kMaxEmblemCount = 4
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_DifferentPositions_MergesBoth)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 1) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_DifferentCache_ReturnsUpdatedGroup)
+{
+    QList<QPair<QString, int>> cache = { qMakePair(QString("cached"), 0) };
+    QList<QPair<QString, int>> group = { qMakePair(QString("new"), 1) };
+
+    auto result = worker->updateLayoutGroup(cache, group);
+
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(UT_EmblemIconWorker, makeLayoutGroup_WithLayouts_CreatesGroup)
+{
+    std::vector<DFMEXT::DFMExtEmblemIconLayout> layouts;
+    DFMEXT::DFMExtEmblemIconLayout layout(DFMEXT::DFMExtEmblemIconLayout::LocationType::BottomRight, "test-icon");
+    layouts.push_back(layout);
+
+    QList<QPair<QString, int>> group;
+    worker->makeLayoutGroup(layouts, &group);
+
+    EXPECT_EQ(group.size(), 1);
+    EXPECT_EQ(group[0].first, "test-icon");
+}
+
+// ========== ExtensionEmblemManager Additional Tests ==========
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_ValidUrlWithCache_ReturnsResult)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onEmblemIconChanged_DesktopPlugin_PushesToCanvas)
+{
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return 1;   // Valid event type
+                   });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [](EventChannelManager *, const QString &, const QString &, QUrl) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant();
+                   });
+
+    QString path = "/tmp/test.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("emblem"), 0) };
+
+    ExtensionEmblemManager::instance().onEmblemIconChanged(path, group);
+}

--- a/autotests/plugins/dfmplugin-utils/test_extensionfilemanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionfilemanager.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/fileimpl/extensionfilemanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/utils/applaunchutils.h>
+#include <dfm-extension/file/dfmextfileplugin.h>
+
+#include <QTimer>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionFileManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionFileManager, instance_ReturnsSingleton)
+{
+    ExtensionFileManager &instance1 = ExtensionFileManager::instance();
+    ExtensionFileManager &instance2 = ExtensionFileManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionFileManager, initialize_PluginsInitialized_CallsOnAllPluginsInitialized)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionFileManager, onAllPluginsInitialized_EmptyPlugins_DoesNotAddStrategy)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+}
+
+TEST_F(UT_ExtensionFileManager, launch_EmptyContainer_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("test.desktop", QStringList() << "/tmp/test.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_MultipleFiles_ReturnsFalse)
+{
+    QStringList files;
+    files << "/tmp/file1.txt" << "/tmp/file2.txt" << "/tmp/file3.txt";
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_EmptyFileList_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("test.desktop", QStringList());
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithDesktopFile_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("/usr/share/applications/deepin-editor.desktop",
+                                                          QStringList() << "/tmp/test.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithSpecialChars_ReturnsFalse)
+{
+    QStringList files;
+    files << "/tmp/文件.txt" << "/tmp/file with spaces.txt";
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, onAllPluginsInitialized_CalledMultipleTimes_OnlyInitializesOnce)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+}
+
+TEST_F(UT_ExtensionFileManager, launch_VariousDesktopFiles_ReturnsFalse)
+{
+    QStringList files = { "/home/user/document.pdf" };
+
+    bool result1 = ExtensionFileManager::instance().launch("org.gnome.Evince.desktop", files);
+    bool result2 = ExtensionFileManager::instance().launch("libreoffice-writer.desktop", files);
+
+    EXPECT_FALSE(result1);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithAbsolutePaths_ReturnsFalse)
+{
+    QStringList files = {
+        "/home/user/Documents/test.txt",
+        "/var/log/syslog",
+        "/etc/hosts"
+    };
+
+    bool result = ExtensionFileManager::instance().launch("gedit.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithSingleFile_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("vim.desktop",
+                                                          QStringList() << "/tmp/single.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithLargeFileList_ReturnsFalse)
+{
+    QStringList files;
+    for (int i = 0; i < 100; ++i) {
+        files << QString("/tmp/file%1.txt").arg(i);
+    }
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionlibmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionlibmenuscene.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+// ========== ExtensionLibMenuSceneCreator Tests ==========
+
+class UT_ExtensionLibMenuSceneCreator : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        creator = new ExtensionLibMenuSceneCreator();
+    }
+
+    void TearDown() override
+    {
+        delete creator;
+        creator = nullptr;
+        stub.clear();
+    }
+
+    ExtensionLibMenuSceneCreator *creator { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionLibMenuSceneCreator, name_ReturnsExtensionLibMenu)
+{
+    EXPECT_EQ(ExtensionLibMenuSceneCreator::name(), "ExtensionLibMenu");
+}
+
+TEST_F(UT_ExtensionLibMenuSceneCreator, create_ReturnsNewScene)
+{
+    AbstractMenuScene *scene = creator->create();
+
+    EXPECT_NE(scene, nullptr);
+
+    delete scene;
+}
+
+// ========== ExtensionLibMenuScene Tests ==========
+
+class UT_ExtensionLibMenuScene : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        scene = new ExtensionLibMenuScene();
+    }
+
+    void TearDown() override
+    {
+        delete scene;
+        scene = nullptr;
+        stub.clear();
+    }
+
+    ExtensionLibMenuScene *scene { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionLibMenuScene, Constructor_CreatesScene)
+{
+    EXPECT_NE(scene, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, name_ReturnsExtensionLibMenu)
+{
+    EXPECT_EQ(scene->name(), "ExtensionLibMenu");
+}
+
+TEST_F(UT_ExtensionLibMenuScene, initialize_EmptyParams_ReturnsFalse)
+{
+    QVariantHash params;
+    params[MenuParamKey::kCurrentDir] = QUrl::fromLocalFile("/home");
+
+    bool result = scene->initialize(params);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, initialize_ValidParams_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    QVariantHash params;
+    params.insert(MenuParamKey::kCurrentDir, QUrl::fromLocalFile("/tmp"));
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert(MenuParamKey::kIsEmptyArea, false);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, create_NullMenu_ReturnsFalse)
+{
+    bool result = scene->create(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, create_PluginsNotInitialized_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kReady;
+                   });
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, triggered_CallsBaseClass)
+{
+    QAction action;
+
+    bool result = scene->triggered(&action);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, scene_NullAction_ReturnsNull)
+{
+    AbstractMenuScene *result = scene->scene(nullptr);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, scene_UnknownAction_ReturnsNull)
+{
+    QAction unknownAction;
+
+    AbstractMenuScene *result = scene->scene(&unknownAction);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, updateState_NullMenu_Returns)
+{
+    scene->updateState(nullptr);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionpluginloader.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionpluginloader.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginloader.h"
+
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_ExtensionPluginLoader : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginLoader, Constructor_SetsFileName)
+{
+    ExtensionPluginLoader loader("/path/to/plugin.so");
+
+    EXPECT_EQ(loader.fileName(), "/path/to/plugin.so");
+}
+
+TEST_F(UT_ExtensionPluginLoader, fileName_ReturnsLoaderFileName)
+{
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    QString result = loader.fileName();
+
+    EXPECT_EQ(result, "/test/plugin.so");
+}
+
+TEST_F(UT_ExtensionPluginLoader, lastError_InitiallyEmpty)
+{
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    QString result = loader.lastError();
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_EmptyFileName_ReturnsFalse)
+{
+    ExtensionPluginLoader loader("");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(loader.lastError().isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_LoadFailed_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QLibrary, errorString),
+                   [](QLibrary *) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "Load error";
+                   });
+
+    ExtensionPluginLoader loader("/nonexistent/plugin.so");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_LoadSuccess_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, initialize_NotLoaded_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.initialize();
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(loader.lastError().isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, initialize_ResolveFailed_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(static_cast<QFunctionPointer (QLibrary::*)(const char *)>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.initialize();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveMenuPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtMenuPlugin *result = loader.resolveMenuPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveEmblemPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtEmblemIconPlugin *result = loader.resolveEmblemPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveWindowPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtWindowPlugin *result = loader.resolveWindowPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveFilePlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtFilePlugin *result = loader.resolveFilePlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, shutdown_ResolveFailed_ReturnsFalse)
+{
+    stub.set_lamda(static_cast<QFunctionPointer (QLibrary::*)(const char *)>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.shutdown();
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionpluginmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionpluginmanager.cpp
@@ -1,0 +1,364 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginloader.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <QSignalSpy>
+#include <QThread>
+#include <QCoreApplication>
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionPluginManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginManager, instance_ReturnsSingleton)
+{
+    ExtensionPluginManager &instance1 = ExtensionPluginManager::instance();
+    ExtensionPluginManager &instance2 = ExtensionPluginManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionPluginManager, currentState_ReturnsValidState)
+{
+    ExtensionPluginManager::InitState state = ExtensionPluginManager::instance().currentState();
+
+    EXPECT_TRUE(state == ExtensionPluginManager::kReady ||
+                state == ExtensionPluginManager::kScanned ||
+                state == ExtensionPluginManager::kLoaded ||
+                state == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManager, initialized_ReturnsCorrectState)
+{
+    bool result = ExtensionPluginManager::instance().initialized();
+    ExtensionPluginManager::InitState state = ExtensionPluginManager::instance().currentState();
+
+    EXPECT_EQ(result, state == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_Menu_ReturnsCorrectValue)
+{
+    bool result = ExtensionPluginManager::instance().exists(ExtensionPluginManager::kMenu);
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_EmblemIcon_ReturnsCorrectValue)
+{
+    bool result = ExtensionPluginManager::instance().exists(ExtensionPluginManager::kEmblemIcon);
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_InvalidType_ReturnsFalse)
+{
+    bool result = ExtensionPluginManager::instance().exists(static_cast<ExtensionPluginManager::ExtensionType>(99));
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginManager, menuPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtMenuPlugin *> result = ExtensionPluginManager::instance().menuPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, emblemPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtEmblemIconPlugin *> result = ExtensionPluginManager::instance().emblemPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, windowPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtWindowPlugin *> result = ExtensionPluginManager::instance().windowPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, filePlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtFilePlugin *> result = ExtensionPluginManager::instance().filePlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, pluginMenuProxy_ReturnsNonNull)
+{
+    DFMEXT::DFMExtMenuProxy *result = ExtensionPluginManager::instance().pluginMenuProxy();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManager, onLoadingPlugins_CalledOnce)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManagerPrivate, startInitializePlugins),
+                   [](ExtensionPluginManagerPrivate *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    ExtensionPluginManager::instance().onLoadingPlugins();
+}
+
+// ========== ExtensionPluginManagerPrivate Tests ==========
+
+class UT_ExtensionPluginManagerPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginManagerPrivate, startMonitorPlugins_NotDesktop_DoesNothing)
+{
+    stub.set_lamda(&QCoreApplication::applicationName,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString("dde-file-manager");
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->startMonitorPlugins();
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, restartDesktop_NonSoFile_ReturnsEarly)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->restartDesktop(QUrl::fromLocalFile("/tmp/test.txt"));
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, release_CalledMultipleTimes_SafelyHandled)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->release();
+    d->release();
+}
+
+// ========== ExtensionPluginInitWorker Tests ==========
+
+class UT_ExtensionPluginInitWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new ExtensionPluginInitWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    ExtensionPluginInitWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_EmptyPaths_EmitsSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+    QSignalSpy loadSpy(worker, &ExtensionPluginInitWorker::loadPluginsFinished);
+    QSignalSpy initSpy(worker, &ExtensionPluginInitWorker::initPluginsFinished);
+
+    worker->doWork(QStringList());
+
+    EXPECT_EQ(scanSpy.count(), 1);
+    EXPECT_EQ(loadSpy.count(), 1);
+    EXPECT_EQ(initSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_NonExistentPath_EmitsSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+
+    worker->doWork({ "/nonexistent/path" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_MultiplePaths_EmitsAllSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+    QSignalSpy loadSpy(worker, &ExtensionPluginInitWorker::loadPluginsFinished);
+    QSignalSpy initSpy(worker, &ExtensionPluginInitWorker::initPluginsFinished);
+
+    worker->doWork({ "/nonexistent/path1", "/nonexistent/path2" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+    EXPECT_EQ(loadSpy.count(), 1);
+    EXPECT_EQ(initSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_TmpPath_ScansDirectory)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+
+    worker->doWork({ "/tmp" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+}
+
+// ========== ExtensionPluginManagerPrivate Additional Tests ==========
+
+TEST_F(UT_ExtensionPluginManagerPrivate, startMonitorPlugins_IsDesktop_CreatesWatcher)
+{
+    stub.set_lamda(&QCoreApplication::applicationName,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString("dde-desktop");
+                   });
+
+    stub.set_lamda(&WatcherFactory::create<AbstractFileWatcher>,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->startMonitorPlugins();
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, restartDesktop_SoFile_CallsUpgrade)
+{
+    stub.set_lamda(&QLibrary::load,
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->restartDesktop(QUrl::fromLocalFile("/tmp/test.so"));
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, curState_InitialValue_IsReady)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_TRUE(d->curState == ExtensionPluginManager::kReady ||
+                d->curState == ExtensionPluginManager::kScanned ||
+                d->curState == ExtensionPluginManager::kLoaded ||
+                d->curState == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, defaultPluginPath_IsNotEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_FALSE(d->defaultPluginPath.isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, proxy_IsNotNull)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_NE(d->proxy.data(), nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, menuMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->menuMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, emblemMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->emblemMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, windowMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->windowMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, fileMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->fileMap.isEmpty())
+}
+
+// ========== ExtensionPluginManager Additional Tests ==========
+
+TEST_F(UT_ExtensionPluginManager, constructor_InitializesPrivate)
+{
+    EXPECT_NE(&ExtensionPluginManager::instance(), nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManager, onLoadingPlugins_SecondCall_DoesNotReinitialize)
+{
+    bool initCalled = false;
+    stub.set_lamda(ADDR(ExtensionPluginManagerPrivate, startInitializePlugins),
+                   [&initCalled](ExtensionPluginManagerPrivate *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    ExtensionPluginManager::instance().onLoadingPlugins();
+    initCalled = false;
+    ExtensionPluginManager::instance().onLoadingPlugins();
+
+    EXPECT_FALSE(initCalled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionwindowsmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionwindowsmanager.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/windowimpl/extensionwindowsmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-extension/window/dfmextwindowplugin.h>
+
+#include <QUrl>
+#include <QTimer>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionWindowsManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionWindowsManager, instance_ReturnsSingleton)
+{
+    ExtensionWindowsManager &instance1 = ExtensionWindowsManager::instance();
+    ExtensionWindowsManager &instance2 = ExtensionWindowsManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionWindowsManager, initialize_ConnectsSignals)
+{
+    ExtensionWindowsManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowOpened_PluginsInitialized_CallsHandleWindow)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onWindowOpened(100);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowClosed_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowClosed_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onLastWindowClosed_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onLastWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onLastWindowClosed_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onLastWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onCurrentUrlChanged_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onCurrentUrlChanged(1, QUrl::fromLocalFile("/tmp"));
+}
+
+TEST_F(UT_ExtensionWindowsManager, onCurrentUrlChanged_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onCurrentUrlChanged(1, QUrl::fromLocalFile("/home"));
+}
+
+TEST_F(UT_ExtensionWindowsManager, onAllPluginsInitialized_FirstWinIdZero_DoesNothing)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onAllPluginsInitialized();
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_virtualextensionimplplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualextensionimplplugin.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/virtualextensionimplplugin.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/windowimpl/extensionwindowsmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/fileimpl/extensionfilemanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualExtensionImplPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new VirtualExtensionImplPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    VirtualExtensionImplPlugin *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VirtualExtensionImplPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, initialize_InitializesManagers)
+{
+    bool emblemInitialized = false;
+    bool windowInitialized = false;
+    bool fileInitialized = false;
+
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize),
+                   [&emblemInitialized] {
+                       __DBG_STUB_INVOKE__
+                       emblemInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize),
+                   [&windowInitialized] {
+                       __DBG_STUB_INVOKE__
+                       windowInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize),
+                   [&fileInitialized] {
+                       __DBG_STUB_INVOKE__
+                       fileInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(emblemInitialized);
+    EXPECT_TRUE(windowInitialized);
+    EXPECT_TRUE(fileInitialized);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, start_RegistersMenuScene)
+{
+    bool sceneRegistered = false;
+    bool sceneBound = false;
+
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, followEvents_ValidEventID_FollowsHookSequence)
+{
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+
+    bool hookFollowed = false;
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return static_cast<DPF_NAMESPACE::EventType>(100);
+                   });
+
+    plugin->initialize();
+
+    // Test passes if no crash occurs
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, followEvents_InvalidEventID_ConnectsPluginStartedSignal)
+{
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    // Test passes if no crash occurs
+}
+


### PR DESCRIPTION
Part 2/5 of dfmplugin-utils unit tests, split by module for easier review:
dfmext 扩展接口与扩展插件管理.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-utils 单元测试第 2/5 部分（按模块拆分以便评审）：dfmext 扩展接口与扩展插件管理。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-utils 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Tests:
- Add unit coverage for dfmext action and menu implementations, menu caching, proxy management, extension managers, plugin loading, menu scenes, and virtual plugin initialization.