### PR TITLE
test: add unit tests for dfmplugin-utils (part 3/5: openwith and reportlog)

### DIFF
--- a/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QCheckBox>
+#include <QMouseEvent>
+#include <QKeyEvent>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QString();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                       [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                           __DBG_STUB_INVOKE__
+                           return nullptr;
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialog, Constructor_WithUrlList_CreatesDialog)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, Constructor_WithSingleUrl_CreatesDialog)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    OpenWithDialog *dialog = new OpenWithDialog(url);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, openFileByApp_NoCheckedItem_Returns)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    dialog->openFileByApp();
+
+    delete dialog;
+}
+
+// ========== OpenWithDialogListItem 测试 ==========
+
+class UT_OpenWithDialogListItem : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialogListItem, Constructor_CreatesItem)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, setChecked_UpdatesCheckState)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    item->setChecked(true);
+    item->setChecked(false);
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, text_ReturnsLabelText)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "My Application");
+
+    EXPECT_EQ(item->text(), "My Application");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, Constructor_EmptyIconName_UsesDefaultIcon)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("", "Test App");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, initUiForSizeMode_SetsSize)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test");
+
+    item->initUiForSizeMode();
+
+    EXPECT_EQ(item->width(), 220);
+
+    delete item;
+}
+
+// ========== OpenWithDialog Additional Tests ==========
+
+TEST_F(UT_OpenWithDialog, Constructor_EmptyUrlList_CreatesDialog)
+{
+    QList<QUrl> urls;
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, checkItem_SetsCheckedItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test App", dialog);
+
+    dialog->checkItem(item);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, checkItem_UnchecksOldItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item1 = new OpenWithDialogListItem("icon", "App1", dialog);
+    OpenWithDialogListItem *item2 = new OpenWithDialogListItem("icon", "App2", dialog);
+
+    dialog->checkItem(item1);
+    dialog->checkItem(item2);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, createItem_ReturnsValidItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = dialog->createItem("icon", "Test App", "/usr/share/applications/test.desktop");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+    EXPECT_EQ(item->property("app").toString(), "/usr/share/applications/test.desktop");
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, eventFilter_MouseButtonPress_ChecksItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test App", dialog);
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    bool result = dialog->eventFilter(item, &event);
+
+    EXPECT_TRUE(result);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, eventFilter_OtherEvent_ReturnsFalse)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier);
+    bool result = dialog->eventFilter(dialog, &event);
+
+    EXPECT_FALSE(result);
+
+    delete dialog;
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/dpf.h>
+
+#include <QApplication>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new OpenWithEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    OpenWithEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithEventReceiver, initEventConnect_ConnectsSlot)
+{
+    bool connected = false;
+
+    typedef bool (EventChannelManager::*Connect)(const QString &, const QString &, OpenWithEventReceiver *, decltype(&OpenWithEventReceiver::showOpenWithDialog));
+    stub.set_lamda(static_cast<Connect>(&EventChannelManager::connect),
+                   [&connected] {
+                       __DBG_STUB_INVOKE__
+                       connected = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(connected);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithValidWinId_FindsWindow)
+{
+    quint64 winId = 12345;
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    FileManagerWindow mockWindow(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(ADDR(FileManagerWindowsManager, findWindowById),
+                   [&mockWindow] {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(winId, urls);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithZeroWinId_NoParent)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(0, urls);
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithHelper : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithHelper, Constructor_CreatesObject)
+{
+    OpenWithHelper *helper = new OpenWithHelper();
+    EXPECT_NE(helper, nullptr);
+    delete helper;
+}
+
+TEST_F(UT_OpenWithHelper, Constructor_WithParent_CreatesObject)
+{
+    QObject parent;
+    OpenWithHelper *helper = new OpenWithHelper(&parent);
+    EXPECT_NE(helper, nullptr);
+    EXPECT_EQ(helper->parent(), &parent);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_InvalidUrl_ReturnsNull)
+{
+    QUrl invalidUrl;
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(invalidUrl);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_NullFileInfo_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_IsDirectory_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/testdir");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_HookDisabled_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = true;
+                       return true;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_ValidFile_ReturnsWidget)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = false;
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(OpenWithWidget, selectFileUrl),
+                   [](OpenWithWidget *, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_NE(result, nullptr);
+    if (result)
+        delete result;
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+
+#include <DRadioButton>
+#include <QListWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_OpenWithWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithWidget, Constructor_CreatesWidget)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    EXPECT_NE(widget, nullptr);
+    EXPECT_NE(widget->openWithListWidget, nullptr);
+    EXPECT_NE(widget->openWithBtnGroup, nullptr);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, selectFileUrl_SetsCurrentUrl)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    widget->selectFileUrl(url);
+
+    EXPECT_EQ(widget->currentFileUrl, url);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_FalseState_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(false);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_InvalidUrl_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_NullFileInfo_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    widget->currentFileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_ValidUrl_LoadsApps)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    widget->currentFileUrl = url;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, fileMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QMimeType();
+                   });
+
+    stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString();
+                   });
+
+    stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QStringList();
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_WithButton_SetsDefault)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    Dtk::Widget::DRadioButton btn;
+    btn.setProperty("mimeTypeName", "text/plain");
+    btn.setProperty("appPath", "/usr/share/applications/test.desktop");
+
+    widget->openWithBtnChecked(&btn);
+
+    EXPECT_TRUE(setDefaultCalled);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_NullButton_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    widget->openWithBtnChecked(nullptr);
+
+    EXPECT_FALSE(setDefaultCalled);
+
+    delete widget;
+}

--- a/autotests/plugins/dfmplugin-utils/test_reportdatas.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportdatas.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/appstartupreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/blockmountreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/desktopstartupreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/enterdirreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/filemenureportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/searchreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/sidebarreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/smbreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/vaultreportdata.h"
+
+#include <QDateTime>
+#include <QJsonObject>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+// ========== AppStartupReportData 测试 ==========
+
+class UT_AppStartupReportData : public testing::Test
+{
+protected:
+    AppStartupReportData data;
+};
+
+TEST_F(UT_AppStartupReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "AppStartup");
+}
+
+TEST_F(UT_AppStartupReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("testKey", "testValue");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500006);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("testKey").toString(), "testValue");
+}
+
+// ========== BlockMountReportData 测试 ==========
+
+class UT_BlockMountReportData : public testing::Test
+{
+protected:
+    BlockMountReportData data;
+};
+
+TEST_F(UT_BlockMountReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "BlockMount");
+}
+
+TEST_F(UT_BlockMountReportData, prepareData_ContainsTidAndOpTime)
+{
+    QVariantMap args;
+    args.insert("device", "/dev/sda1");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500004);
+    EXPECT_TRUE(result.contains("opTime"));
+    EXPECT_EQ(result.value("device").toString(), "/dev/sda1");
+}
+
+// ========== DesktopStartUpReportData 测试 ==========
+
+class UT_DesktopStartUpReportData : public testing::Test
+{
+protected:
+    DesktopStartUpReportData data;
+};
+
+TEST_F(UT_DesktopStartUpReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "DesktopStartup");
+}
+
+TEST_F(UT_DesktopStartUpReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500008);
+    EXPECT_TRUE(result.contains("sysTime"));
+}
+
+// ========== EnterDirReportData 测试 ==========
+
+class UT_EnterDirReportData : public testing::Test
+{
+protected:
+    EnterDirReportData data;
+};
+
+TEST_F(UT_EnterDirReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "EnterDirectory");
+}
+
+TEST_F(UT_EnterDirReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("path", "/home/user");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500007);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("path").toString(), "/home/user");
+}
+
+// ========== FileMenuReportData 测试 ==========
+
+class UT_FileMenuReportData : public testing::Test
+{
+protected:
+    FileMenuReportData data;
+};
+
+TEST_F(UT_FileMenuReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "FileMenu");
+}
+
+TEST_F(UT_FileMenuReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("action", "copy");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500005);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("action").toString(), "copy");
+}
+
+// ========== SearchReportData 测试 ==========
+
+class UT_SearchReportData : public testing::Test
+{
+protected:
+    SearchReportData data;
+};
+
+TEST_F(UT_SearchReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Search");
+}
+
+TEST_F(UT_SearchReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("keyword", "test");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500002);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("keyword").toString(), "test");
+}
+
+// ========== SidebarReportData 测试 ==========
+
+class UT_SidebarReportData : public testing::Test
+{
+protected:
+    SidebarReportData data;
+};
+
+TEST_F(UT_SidebarReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Sidebar");
+}
+
+TEST_F(UT_SidebarReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("item", "bookmark");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500003);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("item").toString(), "bookmark");
+}
+
+// ========== SmbReportData 测试 ==========
+
+class UT_SmbReportData : public testing::Test
+{
+protected:
+    SmbReportData data;
+};
+
+TEST_F(UT_SmbReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Smb");
+}
+
+TEST_F(UT_SmbReportData, prepareData_SuccessResult_ClearsErrorFields)
+{
+    QVariantMap args;
+    args.insert("result", true);
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500001);
+    EXPECT_TRUE(result.contains("resultTime"));
+    EXPECT_EQ(result.value("errorId").toInt(), 0);
+    EXPECT_EQ(result.value("errorSysMsg").toString(), "");
+    EXPECT_EQ(result.value("errorUiMsg").toString(), "");
+}
+
+TEST_F(UT_SmbReportData, prepareData_FailedResult_KeepsErrorFields)
+{
+    QVariantMap args;
+    args.insert("result", false);
+    args.insert("errorId", 100);
+    args.insert("errorSysMsg", "connection failed");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500001);
+    EXPECT_TRUE(result.contains("resultTime"));
+    EXPECT_EQ(result.value("errorId").toInt(), 100);
+    EXPECT_EQ(result.value("errorSysMsg").toString(), "connection failed");
+}
+
+// ========== VaultReportData 测试 ==========
+
+class UT_VaultReportData : public testing::Test
+{
+protected:
+    VaultReportData data;
+};
+
+TEST_F(UT_VaultReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Vault");
+}
+
+TEST_F(UT_VaultReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("operation", "unlock");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500000);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("operation").toString(), "unlock");
+}

--- a/autotests/plugins/dfmplugin-utils/test_reportlogeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogeventreceiver.cpp
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
+
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_ReportLogEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new ReportLogEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    ReportLogEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogEventReceiver, Constructor_CreatesObject)
+{
+    EXPECT_NE(receiver, nullptr);
+}
+
+TEST_F(UT_ReportLogEventReceiver, Constructor_WithParent_CreatesObject)
+{
+    QObject parent;
+    ReportLogEventReceiver *recv = new ReportLogEventReceiver(&parent);
+
+    EXPECT_NE(recv, nullptr);
+    EXPECT_EQ(recv->parent(), &parent);
+}
+
+TEST_F(UT_ReportLogEventReceiver, commit_CallsManager)
+{
+    bool managerCalled = false;
+    QString capturedType;
+
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [&managerCalled, &capturedType](ReportLogManager *, const QString &type, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                       capturedType = type;
+                   });
+
+    receiver->commit("TestType", QVariantMap());
+
+    EXPECT_TRUE(managerCalled);
+    EXPECT_EQ(capturedType, "TestType");
+}
+
+TEST_F(UT_ReportLogEventReceiver, commit_WithArgs_PassesArgs)
+{
+    QVariantMap capturedArgs;
+
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [&capturedArgs](ReportLogManager *, const QString &, const QVariantMap &args) {
+                       __DBG_STUB_INVOKE__
+                       capturedArgs = args;
+                   });
+
+    QVariantMap testArgs;
+    testArgs["key1"] = "value1";
+    testArgs["key2"] = 123;
+
+    receiver->commit("TestType", testArgs);
+
+    EXPECT_EQ(capturedArgs["key1"].toString(), "value1");
+    EXPECT_EQ(capturedArgs["key2"].toInt(), 123);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMenuData_CallsManager)
+{
+    bool managerCalled = false;
+    QString capturedName;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportMenuData),
+                   [&managerCalled, &capturedName](ReportLogManager *, const QString &name, const QList<QUrl> &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                       capturedName = name;
+                   });
+
+    receiver->handleMenuData("TestMenu", QList<QUrl>());
+
+    EXPECT_TRUE(managerCalled);
+    EXPECT_EQ(capturedName, "TestMenu");
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMenuData_WithUrls_PassesUrls)
+{
+    QList<QUrl> capturedUrls;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportMenuData),
+                   [&capturedUrls](ReportLogManager *, const QString &, const QList<QUrl> &urls) {
+                       __DBG_STUB_INVOKE__
+                       capturedUrls = urls;
+                   });
+
+    QList<QUrl> testUrls;
+    testUrls << QUrl::fromLocalFile("/tmp/file1.txt");
+    testUrls << QUrl::fromLocalFile("/tmp/file2.txt");
+
+    receiver->handleMenuData("TestMenu", testUrls);
+
+    EXPECT_EQ(capturedUrls.size(), 2);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleBlockMountData_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportBlockMountData),
+                   [&managerCalled](ReportLogManager *, const QString &, bool) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleBlockMountData("/dev/sda1", true);
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleBlockMountData_PassesCorrectParams)
+{
+    QString capturedId;
+    bool capturedResult = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportBlockMountData),
+                   [&capturedId, &capturedResult](ReportLogManager *, const QString &id, bool result) {
+                       __DBG_STUB_INVOKE__
+                       capturedId = id;
+                       capturedResult = result;
+                   });
+
+    receiver->handleBlockMountData("/dev/sdb1", false);
+
+    EXPECT_EQ(capturedId, "/dev/sdb1");
+    EXPECT_FALSE(capturedResult);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMountNetworkResult_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportNetworkMountData),
+                   [&managerCalled](ReportLogManager *, bool, dfmmount::DeviceError, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleMountNetworkResult("smb://server", true, dfmmount::DeviceError::kNoError, "");
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMountNetworkResult_PassesCorrectParams)
+{
+    bool capturedRet = false;
+    dfmmount::DeviceError capturedErr;
+    QString capturedMsg;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportNetworkMountData),
+                   [&capturedRet, &capturedErr, &capturedMsg](ReportLogManager *, bool ret, dfmmount::DeviceError err, const QString &msg) {
+                       __DBG_STUB_INVOKE__
+                       capturedRet = ret;
+                       capturedErr = err;
+                       capturedMsg = msg;
+                   });
+
+    receiver->handleMountNetworkResult("smb://server", false, dfmmount::DeviceError::kUserErrorFailed, "Connection failed");
+
+    EXPECT_FALSE(capturedRet);
+    EXPECT_EQ(capturedErr, dfmmount::DeviceError::kUserErrorFailed);
+    EXPECT_EQ(capturedMsg, "Connection failed");
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleDesktopStartupData_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportDesktopStartUp),
+                   [&managerCalled](ReportLogManager *, const QString &, const QVariant &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleDesktopStartupData("testKey", QVariant("testData"));
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleDesktopStartupData_PassesCorrectParams)
+{
+    QString capturedKey;
+    QVariant capturedData;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportDesktopStartUp),
+                   [&capturedKey, &capturedData](ReportLogManager *, const QString &key, const QVariant &data) {
+                       __DBG_STUB_INVOKE__
+                       capturedKey = key;
+                       capturedData = data;
+                   });
+
+    receiver->handleDesktopStartupData("loadTime", QVariant(1500));
+
+    EXPECT_EQ(capturedKey, "loadTime");
+    EXPECT_EQ(capturedData.toInt(), 1500);
+}
+
+TEST_F(UT_ReportLogEventReceiver, bindEvents_ConnectsSignals)
+{
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->bindEvents();
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindCommitEvent_PluginStarted_SubscribesDirectly)
+{
+    auto mockMeta = QSharedPointer<PluginMetaObject>::create();
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMeta] {
+                       __DBG_STUB_INVOKE__
+                       return mockMeta;
+                   });
+
+    stub.set_lamda(ADDR(PluginMetaObject, pluginState),
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    bool subscribeCalled = false;
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [&subscribeCalled](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       subscribeCalled = true;
+                       return true;
+                   });
+
+    receiver->lazyBindCommitEvent("dfmplugin-search", "dfmplugin_search");
+
+    EXPECT_TRUE(subscribeCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindCommitEvent_PluginNotStarted_ConnectsListener)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->lazyBindCommitEvent("dfmplugin-search", "dfmplugin_search");
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindMenuDataEvent_PluginStarted_SubscribesDirectly)
+{
+    auto mockMeta = QSharedPointer<PluginMetaObject>::create();
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMeta] {
+                       __DBG_STUB_INVOKE__
+                       return mockMeta;
+                   });
+
+    stub.set_lamda(ADDR(PluginMetaObject, pluginState),
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    bool subscribeCalled = false;
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QList<QUrl> &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [&subscribeCalled](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QList<QUrl> &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       subscribeCalled = true;
+                       return true;
+                   });
+
+    receiver->lazyBindMenuDataEvent("dfmplugin-myshares", "dfmplugin_myshares");
+
+    EXPECT_TRUE(subscribeCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindMenuDataEvent_PluginNotStarted_ConnectsListener)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->lazyBindMenuDataEvent("dfmplugin-myshares", "dfmplugin_myshares");
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_reportlogmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogmanager.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogworker.h"
+
+#include <QThread>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_ReportLogManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        manager = ReportLogManager::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    ReportLogManager *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogManager, instance_ReturnsSingleton)
+{
+    ReportLogManager *instance1 = ReportLogManager::instance();
+    ReportLogManager *instance2 = ReportLogManager::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_ReportLogManager, commit_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestCommitLog);
+
+    manager->commit("TestType", QVariantMap());
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportMenuData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportMenuData);
+
+    manager->reportMenuData("TestMenu", QList<QUrl>());
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportBlockMountData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportBlockMountData);
+
+    manager->reportBlockMountData("/dev/sda1", true);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportNetworkMountData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportNetworkMountData);
+
+    manager->reportNetworkMountData(true, dfmmount::DeviceError::kNoError, "");
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportDesktopStartUp_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportDesktopStartUp);
+
+    manager->reportDesktopStartUp("testKey", QVariant("testData"));
+
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-utils/test_reportlogworker.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogworker.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogworker.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/reportdatainterface.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/device/private/devicehelper.h>
+
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ReportLogWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new ReportLogWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    ReportLogWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogWorker, init_LibraryLoadFailed_NoCrash)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_NO_THROW(worker->init());
+}
+
+TEST_F(UT_ReportLogWorker, init_ResolveFailed_NoCrash)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const char *>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    EXPECT_NO_THROW(worker->init());
+}
+
+TEST_F(UT_ReportLogWorker, commitLog_UnregisteredType_Returns)
+{
+    worker->commitLog("UnknownType", QVariantMap());
+}
+
+TEST_F(UT_ReportLogWorker, registerLogData_DuplicateType_ReturnsFalse)
+{
+    class MockReportData : public ReportDataInterface
+    {
+    public:
+        QString type() const override { return "MockType"; }
+        QJsonObject prepareData(const QVariantMap &) const override { return QJsonObject(); }
+    };
+
+    MockReportData *data1 = new MockReportData();
+    MockReportData *data2 = new MockReportData();
+
+    bool result1 = worker->registerLogData("MockType", data1);
+    bool result2 = worker->registerLogData("MockType", data2);
+
+    EXPECT_TRUE(result1);
+    EXPECT_FALSE(result2);
+
+    delete data2;
+}
+
+TEST_F(UT_ReportLogWorker, handleMenuData_WithUrls_SetsFileLocation)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "text/plain";
+                   });
+
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMenuData("TestAction", urls);
+}
+
+TEST_F(UT_ReportLogWorker, handleMenuData_EmptyUrls_SetsWorkspaceLocation)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMenuData("TestAction", QList<QUrl>());
+}
+
+TEST_F(UT_ReportLogWorker, handleBlockMountData_EmptyId_Returns)
+{
+    worker->handleBlockMountData("", true);
+}
+
+TEST_F(UT_ReportLogWorker, handleBlockMountData_FailedResult_CommitsWithUnknown)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleBlockMountData("/dev/sda1", false);
+}
+
+TEST_F(UT_ReportLogWorker, handleMountNetworkResult_Success_CommitsData)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMountNetworkResult(true, dfmmount::DeviceError::kNoError, "");
+}
+
+TEST_F(UT_ReportLogWorker, handleMountNetworkResult_UserCancelled_SetsErrorId)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMountNetworkResult(false, dfmmount::DeviceError::kUserErrorUserCancelled, "User cancelled");
+}
+
+TEST_F(UT_ReportLogWorker, commit_NullArgs_Returns)
+{
+    worker->commit(QVariant());
+}
+
+TEST_F(UT_ReportLogWorker, commit_InvalidArgs_Returns)
+{
+    QVariant invalid;
+    worker->commit(invalid);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/lifecycle/pluginmetaobject.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualOpenWithPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new VirtualOpenWithPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualOpenWithPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualOpenWithPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(OpenWithEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](OpenWithEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogInitialized_RegsView)
+{
+    bool regViewCalled = false;
+
+    auto mockMetaObj = QSharedPointer<PluginMetaObject>(new PluginMetaObject);
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMetaObj] {
+                       __DBG_STUB_INVOKE__
+                       return mockMetaObj;
+                   });
+
+    stub.set_lamda(&PluginMetaObject::pluginState,
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, std::function<QWidget *(const QUrl &)>, std::function<void (QWidget *, const QUrl &)> &, QString &&, int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&regViewCalled] {
+                       __DBG_STUB_INVOKE__
+                       regViewCalled = true;
+                       return QVariant();
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(regViewCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogNotInitialized_ConnectsListener)
+{
+    bool listenerConnected = false;
+
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    stub.set_lamda(ADDR(Listener, instance),
+                   [&listenerConnected]() -> Listener * {
+                       __DBG_STUB_INVOKE__
+                       listenerConnected = true;
+                       static Listener listener;
+                       return &listener;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(listenerConnected);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, regViewToPropertyDialog_PushesSlot)
+{
+    bool pushCalled = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, std::function<QWidget *(const QUrl &)>, std::function<void (QWidget *, const QUrl &)> &, QString &&, int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&pushCalled] {
+                       __DBG_STUB_INVOKE__
+                       pushCalled = true;
+                       return QVariant();
+                   });
+
+    plugin->regViewToPropertyDialog();
+    EXPECT_TRUE(pushCalled);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualreportlogplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualreportlogplugin.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/virtualreportlogplugin.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <QTimer>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_VirtualReportLogPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(ReportLogManager, init),
+                       [](ReportLogManager *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(ADDR(ReportLogEventReceiver, bindEvents),
+                       [](ReportLogEventReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualReportLogPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualReportLogPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualReportLogPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualReportLogPlugin, initialize_CallsManagerInitAndBindEvents)
+{
+    bool managerInitCalled = false;
+    bool bindEventsCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, init),
+                   [&managerInitCalled](ReportLogManager *) {
+                       __DBG_STUB_INVOKE__
+                       managerInitCalled = true;
+                   });
+
+    stub.set_lamda(ADDR(ReportLogEventReceiver, bindEvents),
+                   [&bindEventsCalled](ReportLogEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       bindEventsCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(managerInitCalled);
+    EXPECT_TRUE(bindEventsCalled);
+}
+
+TEST_F(UT_VirtualReportLogPlugin, start_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [](ReportLogManager *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}


### PR DESCRIPTION
Part 3/5 of dfmplugin-utils unit tests, split by module for easier review:
打开方式与日志上报.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-utils 单元测试第 3/5 部分（按模块拆分以便评审）：打开方式与日志上报。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-utils 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Expand dfmplugin-utils unit-test coverage for open-with functionality and report logging.

Tests:
- Add unit coverage for the open-with dialogs, widgets, helpers, event receiver, and plugin lifecycle.
- Add unit coverage for report-log data preparation, event forwarding, manager signals, worker handling, and plugin lifecycle.