### PR TITLE
test: add unit tests for dfmplugin-utils (part 4/5: shred and vault helper)

### DIFF
--- a/autotests/plugins/dfmplugin-utils/test_fileshredworker.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_fileshredworker.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/fileshredworker.h"
+
+#include <QSignalSpy>
+#include <QProcess>
+#include <QDir>
+#include <QFile>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_FileShredWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new FileShredWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    FileShredWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_FileShredWorker, Constructor_InitializesMembers)
+{
+    EXPECT_NE(worker, nullptr);
+}
+
+TEST_F(UT_FileShredWorker, stop_SetsShouldStopFlag)
+{
+    worker->stop();
+}
+
+TEST_F(UT_FileShredWorker, shredFile_EmptyList_EmitsFinished)
+{
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+    QSignalSpy progressSpy(worker, &FileShredWorker::progressUpdated);
+
+    worker->shredFile(QList<QUrl>());
+
+    EXPECT_GE(progressSpy.count(), 1);
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_TRUE(args.at(0).toBool());
+    }
+}
+
+TEST_F(UT_FileShredWorker, shredFile_StopRequested_EmitsCancelled)
+{
+    worker->stop();
+
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/test.txt") });
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_FALSE(args.at(0).toBool());
+    }
+}
+
+TEST_F(UT_FileShredWorker, shredFile_SymLink_RemovesFile)
+{
+    bool removeCalled = false;
+
+    stub.set_lamda(static_cast<bool (*)(const QString &)>(&QFile::remove),
+                   [&removeCalled](const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(QFileInfo, isSymLink),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/symlink") });
+
+    EXPECT_TRUE(removeCalled);
+}
+
+TEST_F(UT_FileShredWorker, shredFile_ProcessStartFailed_EmitsFailure)
+{
+    stub.set_lamda(ADDR(QFileInfo, isSymLink),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QFileInfo, isDir),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QProcess, waitForStarted),
+                   [](QProcess *, int) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/test.txt") });
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_FALSE(args.at(0).toBool());
+    }
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_shredfilemodel.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredfilemodel.cpp
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredfilemodel.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <QIcon>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShredFileModel : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        model = new ShredFileModel();
+    }
+
+    void TearDown() override
+    {
+        delete model;
+        model = nullptr;
+        stub.clear();
+    }
+
+    ShredFileModel *model { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredFileModel, Constructor_InitializesModel)
+{
+    EXPECT_NE(model, nullptr);
+    EXPECT_EQ(model->rowCount(), 0);
+}
+
+TEST_F(UT_ShredFileModel, setFileList_UpdatesModel)
+{
+    QList<QUrl> urls = {
+        QUrl::fromLocalFile("/tmp/file1.txt"),
+        QUrl::fromLocalFile("/tmp/file2.txt")
+    };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    EXPECT_EQ(model->rowCount(), 2);
+}
+
+TEST_F(UT_ShredFileModel, rowCount_ReturnsCorrectCount)
+{
+    EXPECT_EQ(model->rowCount(), 0);
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    EXPECT_EQ(model->rowCount(), 1);
+}
+
+TEST_F(UT_ShredFileModel, columnCount_ReturnsOne)
+{
+    EXPECT_EQ(model->columnCount(), 1);
+}
+
+TEST_F(UT_ShredFileModel, parent_ReturnsInvalidIndex)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    QModelIndex childIndex = model->index(0, 0);
+    QModelIndex parentIndex = model->parent(childIndex);
+
+    EXPECT_FALSE(parentIndex.isValid());
+}
+
+TEST_F(UT_ShredFileModel, index_ValidRow_ReturnsValidIndex)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+
+    EXPECT_TRUE(idx.isValid());
+    EXPECT_EQ(idx.row(), 0);
+    EXPECT_EQ(idx.column(), 0);
+}
+
+TEST_F(UT_ShredFileModel, index_InvalidRow_ReturnsInvalidIndex)
+{
+    QModelIndex idx = model->index(100, 0);
+
+    EXPECT_FALSE(idx.isValid());
+}
+
+TEST_F(UT_ShredFileModel, index_NegativeRow_ReturnsInvalidIndex)
+{
+    QModelIndex idx = model->index(-1, 0);
+
+    EXPECT_FALSE(idx.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_InvalidIndex_ReturnsEmpty)
+{
+    QModelIndex idx;
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_NullFileInfo_ReturnsEmpty)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_DisplayRole_ReturnsFileName)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, displayOf),
+                   [](FileInfo *, const DisPlayInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "test.txt";
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_EQ(result.toString(), "test.txt");
+}
+
+TEST_F(UT_ShredFileModel, data_DecorationRole_ReturnsIcon)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, fileIcon),
+                   [](FileInfo *) -> QIcon {
+                       __DBG_STUB_INVOKE__
+                       return QIcon::fromTheme("text-plain");
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DecorationRole);
+
+    EXPECT_TRUE(result.canConvert<QIcon>());
+}
+
+TEST_F(UT_ShredFileModel, data_UnknownRole_ReturnsEmpty)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::UserRole + 100);
+
+    EXPECT_FALSE(result.isValid());
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_shredmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredmenuscene.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredmenuscene.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/universalutils.h>
+
+#include <QMenu>
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+// ========== ShredMenuCreator Tests ==========
+
+class UT_ShredMenuCreator : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        creator = new ShredMenuCreator();
+    }
+
+    void TearDown() override
+    {
+        delete creator;
+        creator = nullptr;
+        stub.clear();
+    }
+
+    ShredMenuCreator *creator { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredMenuCreator, name_ReturnsShredMenu)
+{
+    EXPECT_EQ(ShredMenuCreator::name(), "ShredMenu");
+}
+
+TEST_F(UT_ShredMenuCreator, create_ReturnsNewScene)
+{
+    AbstractMenuScene *scene = creator->create();
+
+    EXPECT_NE(scene, nullptr);
+
+    delete scene;
+}
+
+// ========== ShredMenuScene Tests ==========
+
+class UT_ShredMenuScene : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        scene = new ShredMenuScene();
+    }
+
+    void TearDown() override
+    {
+        delete scene;
+        scene = nullptr;
+        stub.clear();
+    }
+
+    ShredMenuScene *scene { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredMenuScene, Constructor_CreatesScene)
+{
+    EXPECT_NE(scene, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, name_ReturnsShredMenu)
+{
+    EXPECT_EQ(scene->name(), "ShredMenu");
+}
+
+TEST_F(UT_ShredMenuScene, initialize_SetsParameters)
+{
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    params.insert("kWindowId", 1ULL);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_ShredDisabled_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_EmptyArea_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QVariantHash params;
+    params.insert("kIsEmptyArea", true);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_NullMenu_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = scene->create(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, triggered_UnknownAction_ReturnsFalse)
+{
+    QAction unknownAction;
+
+    bool result = scene->triggered(&unknownAction);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, scene_NullAction_ReturnsNull)
+{
+    AbstractMenuScene *result = scene->scene(nullptr);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, scene_UnknownAction_ReturnsNull)
+{
+    QAction unknownAction;
+
+    AbstractMenuScene *result = scene->scene(&unknownAction);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, updateState_EmptyPredicateAction_Returns)
+{
+    QMenu menu;
+
+    scene->updateState(&menu);
+}
+
+TEST_F(UT_ShredMenuScene, create_VirtualUrl_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&UniversalUtils::urlTransformToLocal,
+                   [](const QUrl &, QUrl *target) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (target)
+                           *target = QUrl("trash:///");
+                       return true;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl("trash:///"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_NullFileInfo_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_InvalidFile_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test.txt")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(ADDR(ShredUtils, isValidFile),
+                   [](ShredUtils *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, initialize_EmptySelectFiles_SetsFocusFileEmpty)
+{
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>()));
+    params.insert("kIsEmptyArea", false);
+    params.insert("kWindowId", 1ULL);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredMenuScene, triggered_UnknownAction_CallsParent)
+{
+    QAction unknownAction;
+    unknownAction.setProperty("kActionID", "unknown-action");
+
+    bool result = scene->triggered(&unknownAction);
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_shredutils.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredutils.cpp
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <DDialog>
+#include <DSettingsOption>
+
+#include <QStandardPaths>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+
+class UT_ShredUtils : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        utils = ShredUtils::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    ShredUtils *utils { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredUtils, instance_ReturnsSingleton)
+{
+    ShredUtils *instance1 = ShredUtils::instance();
+    ShredUtils *instance2 = ShredUtils::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_ShredUtils, isShredEnabled_ReturnsConfigValue)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = utils->isShredEnabled();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isShredEnabled_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = utils->isShredEnabled();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, setShredEnabled_CallsSetValue)
+{
+    bool setCalled = false;
+    bool capturedValue = false;
+
+    stub.set_lamda(ADDR(DConfigManager, setValue),
+                   [&setCalled, &capturedValue](DConfigManager *, const QString &, const QString &, const QVariant &value) {
+                       __DBG_STUB_INVOKE__
+                       setCalled = true;
+                       capturedValue = value.toBool();
+                   });
+
+    utils->setShredEnabled(true);
+
+    EXPECT_TRUE(setCalled);
+    EXPECT_TRUE(capturedValue);
+}
+
+TEST_F(UT_ShredUtils, initDconfig_CallsAddConfig)
+{
+    bool addConfigCalled = false;
+
+    stub.set_lamda(ADDR(DConfigManager, addConfig),
+                   [&addConfigCalled](DConfigManager *, const QString &, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addConfigCalled = true;
+                       return true;
+                   });
+
+    utils->initDconfig();
+}
+
+TEST_F(UT_ShredUtils, isValidFile_NullFileInfo_ReturnsFalse)
+{
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ExternalBlockMount_ReturnsTrue)
+{
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/media/usb/test.txt")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "/media/usb/test.txt";
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/media/usb/test.txt");
+    bool result = utils->isValidFile(url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ProtectedDirectory_ReturnsFalse)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(desktopPath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&desktopPath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return desktopPath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&desktopPath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return desktopPath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(desktopPath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_HomePathItself_ReturnsFalse)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(homePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&homePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return homePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&homePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return homePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(homePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ValidFileInHome_ReturnsTrue)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString filePath = homePath + "/mydir/test.txt";
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(filePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&filePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return filePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&filePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return filePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(filePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_PathOutsideHome_ReturnsFalse)
+{
+    QString outsidePath = "/opt/test.txt";
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(outsidePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&outsidePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return outsidePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&outsidePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return outsidePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(outsidePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, shredfile_EmptyList_ReturnsEarly)
+{
+    bool confirmCalled = false;
+
+    utils->shredfile(QList<QUrl>(), 0);
+
+    EXPECT_FALSE(confirmCalled);
+}
+
+TEST_F(UT_ShredUtils, shredfile_CancelledDialog_ReturnsEarly)
+{
+    stub.set_lamda(VADDR(DDialog, exec),
+                   [](DDialog *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/tmp/test.txt");
+
+    utils->shredfile(files, 0);
+}
+
+TEST_F(UT_ShredUtils, createShredSettingItem_ReturnsWidget)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    Dtk::Core::DSettingsOption option;
+    QWidget *widget = utils->createShredSettingItem(&option);
+
+    EXPECT_NE(widget, nullptr);
+
+    if (widget)
+        delete widget;
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_vaultassitcontrol.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_vaultassitcontrol.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaultassitcontrol.h"
+
+#include <dfm-io/dfmio_utils.h>
+
+#include <QDir>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VaultAssitControl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        control = VaultAssitControl::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    VaultAssitControl *control { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VaultAssitControl, instance_ReturnsSingleton)
+{
+    VaultAssitControl *instance1 = VaultAssitControl::instance();
+    VaultAssitControl *instance2 = VaultAssitControl::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_VaultAssitControl, scheme_ReturnsDfmvault)
+{
+    QString result = control->scheme();
+
+    EXPECT_EQ(result, "dfmvault");
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_VaultScheme_ReturnsTrue)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test/file.txt");
+
+    bool result = control->isVaultFile(vaultUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_NonVaultScheme_ReturnsFalse)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    bool result = control->isVaultFile(fileUrl);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_PathInMountDir_ReturnsTrue)
+{
+    // Build the URL from the product's own mount dir so the path matches
+    // regardless of the test user's home directory.
+    QUrl fileUrl = QUrl::fromLocalFile(control->vaultMountDirLocalPath() + "/test.txt");
+
+    bool result = control->isVaultFile(fileUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultAssitControl, vaultBaseDirLocalPath_ReturnsPath)
+{
+    QString result = control->vaultBaseDirLocalPath();
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, vaultMountDirLocalPath_ReturnsPath)
+{
+    QString result = control->vaultMountDirLocalPath();
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, buildVaultLocalPath_EmptyBase_UsesDefault)
+{
+    QString result = control->buildVaultLocalPath("test", "");
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, buildVaultLocalPath_WithBase_UsesBase)
+{
+    QString result = control->buildVaultLocalPath("test", "custom_base");
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, vaultUrlToLocalUrl_NonVaultScheme_ReturnsOriginal)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    QUrl result = control->vaultUrlToLocalUrl(fileUrl);
+
+    EXPECT_EQ(result, fileUrl);
+}
+
+TEST_F(UT_VaultAssitControl, vaultUrlToLocalUrl_VaultScheme_ReturnsLocalUrl)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test/file.txt");
+
+    QUrl result = control->vaultUrlToLocalUrl(vaultUrl);
+
+    EXPECT_EQ(result.scheme(), "file");
+}
+
+TEST_F(UT_VaultAssitControl, transUrlsToLocal_MixedUrls_TransformsVaultOnly)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/vault/file.txt");
+
+    QUrl localUrl = QUrl::fromLocalFile("/tmp/local.txt");
+
+    QList<QUrl> urls = { vaultUrl, localUrl };
+
+    QList<QUrl> result = control->transUrlsToLocal(urls);
+
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_EQ(result[0].scheme(), "file");
+    EXPECT_EQ(result[1], localUrl);
+}
+
+TEST_F(UT_VaultAssitControl, transUrlsToLocal_EmptyList_ReturnsEmpty)
+{
+    QList<QUrl> urls;
+
+    QList<QUrl> result = control->transUrlsToLocal(urls);
+
+    EXPECT_TRUE(result.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-utils/test_vaulthelperreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_vaulthelperreceiver.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaulthelperreceiver.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaultassitcontrol.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_VaultHelperReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new VaultHelperReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    VaultHelperReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VaultHelperReceiver, Constructor_CreatesReceiver)
+{
+    EXPECT_NE(receiver, nullptr);
+}
+
+TEST_F(UT_VaultHelperReceiver, initEventConnect_FollowsHook)
+{
+    bool followCalled = false;
+
+    typedef bool (EventSequenceManager::*Follow)(const QString &, const QString &, VaultHelperReceiver *, decltype(&VaultHelperReceiver::handlemoveToTrash));
+    stub.set_lamda(static_cast<Follow>(&EventSequenceManager::follow),
+                   [&followCalled] {
+                       __DBG_STUB_INVOKE__
+                       followCalled = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(followCalled);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_EmptySource_ReturnsFalse)
+{
+    bool result = receiver->handlemoveToTrash(0, QList<QUrl>(), AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_NonVaultFile_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    bool result = receiver->handlemoveToTrash(0, urls, AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_VaultFile_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(VaultAssitControl, transUrlsToLocal),
+                   [](VaultAssitControl *, const QList<QUrl> &urls) -> QList<QUrl> {
+                       __DBG_STUB_INVOKE__
+                       return urls;
+                   });
+
+    typedef bool (EventDispatcherManager::*Publish)(EventType, quint64, QList<QUrl> &, AbstractJobHandler::JobFlags &,
+                                                    std::nullptr_t &&, QVariant &&, AbstractJobHandler::OperatorCallback &);
+    stub.set_lamda(static_cast<Publish>(&EventDispatcherManager::publish),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test.txt");
+    QList<QUrl> urls = { vaultUrl };
+
+    bool result = receiver->handlemoveToTrash(0, urls, AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handleFinishedNotify_RestoresCursor)
+{
+    bool restoreCalled = false;
+
+    stub.set_lamda(&QApplication::restoreOverrideCursor,
+                   [&restoreCalled]() {
+                       __DBG_STUB_INVOKE__
+                       restoreCalled = true;
+                   });
+
+    JobInfoPointer jobInfo(new QMap<quint8, QVariant>());
+    receiver->handleFinishedNotify(jobInfo);
+
+    EXPECT_TRUE(restoreCalled);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualshredplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualshredplugin.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/vitrualshredplugin.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/settingdialog/customsettingitemregister.h>
+#include <dfm-base/utils/dialogmanager.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_VirtualShredPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(ShredUtils, initDconfig),
+                       [](ShredUtils *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(ADDR(SettingJsonGenerator, addGroup),
+                       [](SettingJsonGenerator *, const QString &, const QString &) {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(ADDR(SettingJsonGenerator, addConfig),
+                       [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(ADDR(DialogManager, registerSettingWidget),
+                       [](DialogManager *, const QString &, std::function<QWidget *(QObject *)>) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualShredPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualShredPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualShredPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualShredPlugin, initialize_DoesNothing)
+{
+    plugin->initialize();
+}
+
+TEST_F(UT_VirtualShredPlugin, start_AllPluginsStarted_ReturnsTrue)
+{
+    stub.set_lamda(&LifeCycle::isAllPluginsStarted,
+                   []() -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VirtualShredPlugin, start_PluginsNotStarted_ConnectsSignal)
+{
+    stub.set_lamda(&LifeCycle::isAllPluginsStarted,
+                   []() -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualvaulthelperplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualvaulthelperplugin.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/virtualvaulthelperplugin.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaulthelperreceiver.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualVaultHelperPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(VaultHelperReceiver, initEventConnect),
+                       [](VaultHelperReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualVaultHelperPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualVaultHelperPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualVaultHelperPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualVaultHelperPlugin, initialize_CallsInitEventConnect)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(VaultHelperReceiver, initEventConnect),
+                   [&initCalled](VaultHelperReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initCalled);
+}
+
+TEST_F(UT_VirtualVaultHelperPlugin, start_ReturnsTrue)
+{
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+


### PR DESCRIPTION
Part 4/5 of dfmplugin-utils unit tests, split by module for easier review:
文件粉碎与保险箱辅助.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-utils 单元测试第 4/5 部分（按模块拆分以便评审）：文件粉碎与保险箱辅助。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-utils 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Expand dfmplugin-utils unit tests across file shredding and vault-assistance functionality.

Tests:
- Add unit coverage for file shredding workers, models, menu scenes, utilities, and plugin lifecycle behavior.
- Add unit coverage for vault URL/path handling, trash integration, event forwarding, and vault helper plugin behavior.