### PR TITLE
test: add unit tests for dfmplugin-utils (part 5/5: event receivers and misc)

### DIFF
--- a/autotests/plugins/dfmplugin-utils/test_appendcompresseventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_appendcompresseventreceiver.cpp
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "appendcompress/appendcompresseventreceiver.h"
+#include "appendcompress/appendcompresshelper.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <QMimeData>
+#include <QUrl>
+#include <QPoint>
+#include <QVariantHash>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_AppendCompressEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        receiver = new AppendCompressEventReceiver();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete receiver;
+        receiver = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    AppendCompressEventReceiver *receiver { nullptr };
+};
+
+/**
+ * @brief Test initEventConnect method
+ * Verifies that event connections are properly initialized
+ */
+TEST_F(UT_AppendCompressEventReceiver, initEventConnect_WorkspaceHooks_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    // Stub dpfHookSequence->follow to prevent actual hook registration
+    bool workspaceFollowCalled = false;
+    typedef bool (AppendCompressEventReceiver::*HookFunc)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
+    typedef bool (EventSequenceManager::*HookType)(const QString &, const QString &, AppendCompressEventReceiver *, HookFunc);
+    stub.set_lamda(static_cast<HookType>(&EventSequenceManager::follow),
+                   [&workspaceFollowCalled] {
+                       __DBG_STUB_INVOKE__
+                       workspaceFollowCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(DPF_NAMESPACE::Event, eventType),
+                   [](DPF_NAMESPACE::Event *, const QString &, const QString &) -> int {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(workspaceFollowCalled);
+}
+
+/**
+ * @brief Test handleSetMouseStyle with valid parameters
+ * Verifies that mouse style is set correctly
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyle_ValidParams_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyle(fromUrls, toUrl, &action);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyle returns false when helper fails
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyle_HelperFails_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/invalid.txt");
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleSetMouseStyle(fromUrls, toUrl, &action);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompress with valid parameters
+ * Verifies that drag-drop compression is handled correctly
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompress_ValidParams_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt"),
+                             QUrl::fromLocalFile("/tmp/file2.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompress(fromUrls, toUrl);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompress returns false when helper fails
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompress_HelperFails_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/invalid.txt");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleDragDropCompress(fromUrls, toUrl);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    Qt::DropAction action = Qt::CopyAction;
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = reinterpret_cast<qint64>(&action);
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with null dropAction pointer
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_NullDropAction_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = 0;   // Null pointer
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnDesktop with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnDesktop_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["dropUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompressOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnDesktop with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnDesktop_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleDragDropCompressOnDesktop(0, &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    Qt::DropAction action = Qt::CopyAction;
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = reinterpret_cast<qint64>(&action);
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with null dropAction pointer
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_NullDropAction_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = 0;   // Null pointer
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnOsrganizer with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnOsrganizer_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["dropUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompressOnOsrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnOsrganizer with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnOsrganizer_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleDragDropCompressOnOsrganizer("view-id", &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleIsDrop with compressed file
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleIsDrop_CompressedFile_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleIsDrop(url);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleIsDrop with non-compressed file
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleIsDrop_NonCompressedFile_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QUrl url = QUrl::fromLocalFile("/tmp/document.txt");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleIsDrop(url);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test constructor creates valid object
+ */
+TEST_F(UT_AppendCompressEventReceiver, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    AppendCompressEventReceiver *testReceiver = new AppendCompressEventReceiver();
+
+    EXPECT_NE(testReceiver, nullptr);
+
+    delete testReceiver;
+}

--- a/autotests/plugins/dfmplugin-utils/test_appendcompresshelper.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_appendcompresshelper.cpp
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresshelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QProcess>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_AppendCompressHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// ========== isCompressedFile 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_ZipFile_ReturnsTrue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/zip";
+                       return "archive.zip";
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_7zFile_ReturnsTrue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.7z");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-7z-compressed";
+                       return "archive.7z";
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_Tar7zFile_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.tar.7z");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-7z-compressed";
+                       return "archive.tar.7z";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_NonCompressedFile_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/document.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "text/plain";
+                       return "document.txt";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_NullFileInfo_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/nonexistent.zip");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+// ========== canAppendCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_ValidParams_ReturnsTrue)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(toUrl));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsWritable;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_InvalidParams_ReturnsFalse)
+{
+    QList<QUrl> emptyUrls;
+    QUrl invalidUrl;
+    QUrl validUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(emptyUrls, validUrl));
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress({ validUrl }, invalidUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_FTPFile_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl("ftp://example.com/file.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &url) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return url.scheme() == "ftp";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_HookProhibits_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_NotWritableOrNotCompressed_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(toUrl));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+// ========== appendCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, appendCompress_ValidParams_LaunchesCompressor)
+{
+    QString toFilePath = "/tmp/archive.zip";
+    QStringList fromFilePaths = { "/tmp/file1.txt", "/tmp/file2.txt" };
+
+    bool startDetachedCalled = false;
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&] {
+                       __DBG_STUB_INVOKE__
+                       startDetachedCalled = true;
+                       return true;
+                   });
+
+    bool result = AppendCompressHelper::appendCompress(toFilePath, fromFilePaths);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(startDetachedCalled);
+}
+
+// ========== dragDropCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_ValidParams_ReturnsTrue)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(fromUrls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes),
+                   [](FileInfo *, const CanableInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, appendCompress),
+                   [](const QString &, const QStringList &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::dragDropCompress(toUrl, fromUrls));
+}
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_RedirectedUrls_UsesRedirectedPath)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    QUrl redirectedUrl = QUrl::fromLocalFile("/tmp/redirected.txt");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(fromUrls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes),
+                   [](FileInfo *, const CanableInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == CanableInfoType::kCanRedirectionFileUrl;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf),
+                   [&redirectedUrl](FileInfo *, const UrlInfoType) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return redirectedUrl;
+                   });
+
+    QString capturedPath;
+    stub.set_lamda(ADDR(AppendCompressHelper, appendCompress),
+                   [&capturedPath, &redirectedUrl](const QString &, const QStringList &fromPaths) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!fromPaths.isEmpty())
+                           capturedPath = fromPaths[0];
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::dragDropCompress(toUrl, fromUrls));
+    EXPECT_EQ(capturedPath, redirectedUrl.path());
+}
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_InvalidParams_ReturnsFalse)
+{
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       out->clear();
+                       return true;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::dragDropCompress(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }));
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::dragDropCompress(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }));
+}
+
+// ========== setMouseStyle 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_CanAppend_SetsCopyAction)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction dropAction = Qt::IgnoreAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::setMouseStyle(toUrl, fromUrls, &dropAction));
+    EXPECT_EQ(dropAction, Qt::CopyAction);
+}
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_CannotAppend_SetsIgnoreAction)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction dropAction = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::setMouseStyle(toUrl, fromUrls, &dropAction));
+    EXPECT_EQ(dropAction, Qt::IgnoreAction);
+}
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_NotCompressedOrEmpty_ReturnsFalse)
+{
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/document.txt");
+    Qt::DropAction dropAction = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::setMouseStyle(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }, &dropAction));
+
+    EXPECT_FALSE(AppendCompressHelper::setMouseStyle(toUrl, QList<QUrl>(), &dropAction));
+}

--- a/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <QProcess>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_GlobalEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new GlobalEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    GlobalEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+// ========== initEventConnect 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, initEventConnect_SubscribesEvent)
+{
+    bool subscribed = false;
+
+    typedef bool (EventDispatcherManager::*Subscribe)(EventType, GlobalEventReceiver *, decltype(&GlobalEventReceiver::handleOpenAsAdmin));
+    auto subscribe = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe,
+                   [&subscribed] {
+                       __DBG_STUB_INVOKE__
+                       subscribed = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(subscribed);
+}
+
+// ========== handleOpenAsAdmin 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_InvalidUrl_ReturnsEarly)
+{
+    bool processStarted = false;
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(QUrl());
+    EXPECT_FALSE(processStarted);
+
+    receiver->handleOpenAsAdmin(QUrl(""));
+    EXPECT_FALSE(processStarted);
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_ValidLocalFile_StartsProcess)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    QString capturedPath;
+    bool processStarted = false;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted, &capturedPath](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return program == "dde-file-manager-pkexec";
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+    EXPECT_EQ(capturedPath, url.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_DirSymlink_UsesRedirectedPath)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/symlink_dir");
+    QUrl redirectedUrl = QUrl::fromLocalFile("/tmp/real_dir");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir || type == OptInfoType::kIsSymLink;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf),
+                   [&redirectedUrl](FileInfo *, const UrlInfoType) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return redirectedUrl;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, redirectedUrl.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NonLocalUrl_UsesUrlString)
+{
+    QUrl url("smb://server/share");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, url.toString());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NullFileInfo_ContinuesExecution)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    bool processStarted = false;
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+}

--- a/autotests/plugins/dfmplugin-utils/test_progressdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_progressdialog.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/progressdialog.h"
+
+#include <DWaterProgress>
+#include <DLabel>
+
+#include <QKeyEvent>
+#include <QStackedWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DWIDGET_USE_NAMESPACE
+
+// ========== ProgressWidget Tests ==========
+
+class UT_ProgressWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        widget = new ProgressWidget();
+    }
+
+    void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+    ProgressWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProgressWidget, Constructor_InitializesWidget)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_ProgressWidget, setValue_UpdatesProgress)
+{
+    bool startCalled = false;
+
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [&startCalled](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                       startCalled = true;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    widget->setValue(50, "test.txt");
+
+    EXPECT_TRUE(startCalled);
+}
+
+TEST_F(UT_ProgressWidget, setValue_At100_ShowsMessage)
+{
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    widget->setValue(100, "Complete");
+}
+
+TEST_F(UT_ProgressWidget, stopProgress_StopsWaterProgress)
+{
+    bool stopCalled = false;
+
+    stub.set_lamda(ADDR(DWaterProgress, stop),
+                   [&stopCalled](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                       stopCalled = true;
+                   });
+
+    widget->stopProgress();
+
+    EXPECT_TRUE(stopCalled);
+}
+
+// ========== ShredFailedWidget Tests ==========
+
+class UT_ShredFailedWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        widget = new ShredFailedWidget();
+    }
+
+    void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+    ShredFailedWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredFailedWidget, Constructor_InitializesWidget)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_ShredFailedWidget, setMessage_ShortMessage_ShowsFull)
+{
+    widget->setMessage("Short error");
+}
+
+TEST_F(UT_ShredFailedWidget, setMessage_LongMessage_Truncates)
+{
+    QString longMessage = QString("A").repeated(100);
+    widget->setMessage(longMessage);
+}
+
+// ========== ProgressDialog Tests ==========
+
+class UT_ProgressDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dialog = new ProgressDialog();
+    }
+
+    void TearDown() override
+    {
+        delete dialog;
+        dialog = nullptr;
+        stub.clear();
+    }
+
+    ProgressDialog *dialog { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProgressDialog, Constructor_InitializesDialog)
+{
+    EXPECT_NE(dialog, nullptr);
+}
+
+TEST_F(UT_ProgressDialog, updateProgressValue_ValidValue_UpdatesProgress)
+{
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    dialog->updateProgressValue(50, "test.txt");
+}
+
+TEST_F(UT_ProgressDialog, updateProgressValue_InvalidValue_Ignores)
+{
+    dialog->updateProgressValue(-1, "test.txt");
+    dialog->updateProgressValue(150, "test.txt");
+}
+
+TEST_F(UT_ProgressDialog, handleShredResult_Failure_ShowsFailedWidget)
+{
+    stub.set_lamda(ADDR(DWaterProgress, stop),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    dialog->handleShredResult(false, "Error message");
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_testingeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_testingeventreceiver.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/testing/events/testingeventrecevier.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QAccessible>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_TestingEventRecevier : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = TestingEventRecevier::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    TestingEventRecevier *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_TestingEventRecevier, instance_ReturnsSingleton)
+{
+    TestingEventRecevier *instance1 = TestingEventRecevier::instance();
+    TestingEventRecevier *instance2 = TestingEventRecevier::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_TestingEventRecevier, initializeConnections_InstallsAccessible)
+{
+    bool installFactoryCalled = false;
+
+    stub.set_lamda(&QAccessible::installFactory,
+                   [&installFactoryCalled](QAccessible::InterfaceFactory) {
+                       __DBG_STUB_INVOKE__
+                       installFactoryCalled = true;
+                   });
+
+    stub.set_lamda(&QAccessible::setActive,
+                   [](bool) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    receiver->initializeConnections();
+
+    EXPECT_TRUE(installFactoryCalled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_virtualappendcompressplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualappendcompressplugin.cpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/virtualappendcompressplugin.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresseventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualAppendCompressPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(DPF_NAMESPACE::Event, eventType),
+                       [](DPF_NAMESPACE::Event *, const QString &, const QString &) -> int {
+            __DBG_STUB_INVOKE__
+            return DPF_NAMESPACE::EventTypeScope::kInValid;
+        });
+
+        plugin = new VirtualAppendCompressPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualAppendCompressPlugin *plugin { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object
+ * Verifies that the plugin is properly constructed with eventReceiver initialized
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(plugin, nullptr);
+
+    // According to dfm_ut.md, we can access private members directly
+    // Verify that eventReceiver is properly initialized
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+/**
+ * @brief Test initialize method calls eventReceiver's initEventConnect
+ * Verifies that the plugin properly initializes event connections
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_CallsInitEventConnect)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+/**
+ * @brief Test initialize can be called multiple times
+ * Verifies that calling initialize multiple times doesn't cause issues
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_MultipleCallsSafe)
+{
+    __DBG_STUB_INVOKE__
+
+    int initEventConnectCallCount = 0;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCallCount](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCallCount++;
+    });
+
+    plugin->initialize();
+    plugin->initialize();
+    plugin->initialize();
+
+    // initEventConnect should be called 3 times (once per initialize call)
+    EXPECT_EQ(initEventConnectCallCount, 3);
+}
+
+/**
+ * @brief Test initialize with valid eventReceiver
+ * Verifies that initialize works correctly when eventReceiver is valid
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_ValidEventReceiver_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    // Ensure eventReceiver is not null before initialization
+    ASSERT_NE(plugin->eventReceiver.data(), nullptr);
+
+    bool initEventConnectCalled = false;
+    AppendCompressEventReceiver *capturedReceiver = nullptr;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled, &capturedReceiver](AppendCompressEventReceiver *receiver) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+        capturedReceiver = receiver;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+    EXPECT_EQ(capturedReceiver, plugin->eventReceiver.data());
+}
+
+/**
+ * @brief Test start method returns true
+ * Verifies that the plugin starts successfully
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test start can be called multiple times
+ * Verifies that calling start multiple times always returns true
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_MultipleCallsReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_TRUE(plugin->start());
+    EXPECT_TRUE(plugin->start());
+    EXPECT_TRUE(plugin->start());
+}
+
+/**
+ * @brief Test start without initialize
+ * Verifies that start can be called before initialize
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_WithoutInitialize_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    // Don't call initialize before start
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test initialize then start
+ * Verifies the typical usage pattern: initialize followed by start
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, InitializeThenStart_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    // Typical usage pattern
+    plugin->initialize();
+    bool startResult = plugin->start();
+
+    EXPECT_TRUE(initEventConnectCalled);
+    EXPECT_TRUE(startResult);
+}
+
+/**
+ * @brief Test eventReceiver ownership
+ * Verifies that eventReceiver is properly managed by QScopedPointer
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, EventReceiver_ProperlyManaged)
+{
+    __DBG_STUB_INVOKE__
+
+    // Access private member according to dfm_ut.md
+    AppendCompressEventReceiver *receiver = plugin->eventReceiver.data();
+
+    EXPECT_NE(receiver, nullptr);
+
+    // Verify that the eventReceiver is the same instance after operations
+    plugin->initialize();
+    EXPECT_EQ(plugin->eventReceiver.data(), receiver);
+
+    plugin->start();
+    EXPECT_EQ(plugin->eventReceiver.data(), receiver);
+}
+
+/**
+ * @brief Test plugin lifecycle
+ * Verifies the complete plugin lifecycle: construct -> initialize -> start
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, PluginLifecycle_CompleteFlow)
+{
+    __DBG_STUB_INVOKE__
+
+    int initCallCount = 0;
+    int startCallCount = 0;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initCallCount](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initCallCount++;
+    });
+
+    // Simulate complete plugin lifecycle
+    ASSERT_NE(plugin, nullptr); // Construction
+
+    plugin->initialize(); // Initialization
+    EXPECT_EQ(initCallCount, 1);
+
+    bool startResult = plugin->start(); // Start
+    EXPECT_TRUE(startResult);
+
+    // Verify state after full lifecycle
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+/**
+ * @brief Test start before initialize (reversed order)
+ * Verifies that the plugin handles reversed initialization order
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, StartBeforeInitialize_BothSucceed)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    // Call start before initialize (unusual but should work)
+    bool startResult = plugin->start();
+    EXPECT_TRUE(startResult);
+    EXPECT_FALSE(initEventConnectCalled);
+
+    // Then call initialize
+    plugin->initialize();
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+/**
+ * @brief Test eventReceiver member is not null by default
+ * Verifies that eventReceiver is initialized during construction
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, EventReceiver_NotNullByDefault)
+{
+    __DBG_STUB_INVOKE__
+
+    // Create a new plugin instance
+    VirtualAppendCompressPlugin *newPlugin = new VirtualAppendCompressPlugin();
+
+    EXPECT_NE(newPlugin->eventReceiver.data(), nullptr);
+
+    delete newPlugin;
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/virtualglobalplugin.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualGlobalPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                       [](GlobalEventReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualGlobalPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualGlobalPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualGlobalPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, start_ReturnsTrue)
+{
+    EXPECT_TRUE(plugin->start());
+}
+
+TEST_F(UT_VirtualGlobalPlugin, PluginLifecycle_InitializeThenStart)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+    EXPECT_TRUE(initCalled);
+
+    EXPECT_TRUE(plugin->start());
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualtestingplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualtestingplugin.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/testing/virtualtestingplugin.h"
+#include "plugins/common/dfmplugin-utils/testing/events/testingeventrecevier.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualTestingPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(TestingEventRecevier, initializeConnections),
+                       [](TestingEventRecevier *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualTestingPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualTestingPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualTestingPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualTestingPlugin, initialize_CallsInitializeConnections)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(TestingEventRecevier, initializeConnections),
+                   [&initCalled](TestingEventRecevier *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initCalled);
+}
+
+TEST_F(UT_VirtualTestingPlugin, start_ReturnsTrue)
+{
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+


### PR DESCRIPTION
Part 5/5 of dfmplugin-utils unit tests, split by module for easier review:
全局事件接收与压缩等其他模块.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-utils 单元测试第 5/5 部分（按模块拆分以便评审）：全局事件接收与压缩等其他模块。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-utils 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Expand dfmplugin-utils unit-test coverage across compression, global and testing event handling, progress dialogs, and virtual plugin lifecycles.

Tests:
- Add unit coverage for compression helpers and event receivers, including archive detection, append-compression eligibility, drag-and-drop handling, mouse actions, and administrative file opening.
- Add unit coverage for progress and shred result widgets, testing and compression plugin lifecycles, singleton behavior, and event connection setup.