### PR TITLE
test: add unit tests for dfmplugin-burn

### DIFF
--- a/autotests/plugins/dfmplugin-burn/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-burn/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM test utilities to create plugin test
+dfm_create_plugin_test("dfmplugin-burn" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-burn")

--- a/autotests/plugins/dfmplugin-burn/main.cpp
+++ b/autotests/plugins/dfmplugin-burn/main.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QApplication>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_burn)

--- a/autotests/plugins/dfmplugin-burn/test_auditlogjob.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_auditlogjob.cpp
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/auditlogjob.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+
+#include <QDBusInterface>
+#include <QThread>
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QFile>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_AuditLogJob : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(QDBusAbstractInterface, isValid), []() {
+            return true;
+        });
+
+        // Register FileInfo classes like in core.cpp
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_AuditLogJob, AuditHelper_bunner)
+{
+    QString result1 = AuditHelper::bunner(QVariant("/dev/sr0"));
+    EXPECT_FALSE(result1.isEmpty());
+
+    QString result2 = AuditHelper::bunner(QVariant(""));
+    EXPECT_TRUE(result2.isEmpty());
+}
+
+TEST_F(UT_AuditLogJob, AuditHelper_opticalMedia)
+{
+    QString result1 = AuditHelper::opticalMedia(QVariant("optical_dvd_plus_rw"));
+    EXPECT_FALSE(result1.isEmpty());
+    EXPECT_EQ(result1, "DVD+RW");
+
+    QString result2 = AuditHelper::opticalMedia(QVariant(""));
+    EXPECT_TRUE(result2.isEmpty());
+}
+
+TEST_F(UT_AuditLogJob, AuditHelper_idGenerator)
+{
+    qint64 id1 = AuditHelper::idGenerator();
+    qint64 id2 = AuditHelper::idGenerator();
+
+    EXPECT_GT(id1, 0);
+    EXPECT_GT(id2, 0);
+    EXPECT_NE(id1, id2);   // Should generate different IDs
+}
+
+TEST_F(UT_AuditLogJob, AbstractAuditLogJob_Constructor)
+{
+    CopyFromDiscAuditLog job({}, {});
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, AbstractAuditLogJob_run)
+{
+    bool doLogCalled = false;
+
+    CopyFromDiscAuditLog job({}, {});
+    job.run();
+    EXPECT_FALSE(doLogCalled);
+
+    stub.set_lamda(ADDR(QDBusAbstractInterface, isValid), []() {
+        return true;
+    });
+
+    stub.set_lamda(VADDR(CopyFromDiscAuditLog, doLog), [&doLogCalled]() {
+        __DBG_STUB_INVOKE__
+        doLogCalled = true;
+    });
+
+    job.run();
+
+    EXPECT_TRUE(doLogCalled);
+}
+
+TEST_F(UT_AuditLogJob, CopyFromDiscAuditLog_Constructor)
+{
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    CopyFromDiscAuditLog job(srcUrls, destUrls);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, CopyFromDiscAuditLog_doLog)
+{
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    CopyFromDiscAuditLog job(srcUrls, destUrls);
+
+    bool writeLogCalled = false;
+    stub.set_lamda(ADDR(CopyFromDiscAuditLog, writeLog), [&writeLogCalled] {
+        __DBG_STUB_INVOKE__
+        writeLogCalled = true;
+    });
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+    job.doLog(interface);
+
+    EXPECT_FALSE(writeLogCalled);
+}
+
+TEST_F(UT_AuditLogJob, CopyFromDiscAuditLog_doLog_EmptyUrls)
+{
+    QList<QUrl> emptyUrls;
+
+    CopyFromDiscAuditLog job(emptyUrls, emptyUrls);
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+
+    // Should handle empty URLs gracefully
+    job.doLog(interface);
+    // Should not crash
+}
+
+TEST_F(UT_AuditLogJob, CopyFromDiscAuditLog_writeLog)
+{
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    CopyFromDiscAuditLog job(srcUrls, destUrls);
+
+    bool dbusCallCalled = false;
+    stub.set_lamda(ADDR(QDBusInterface, doCall), [&dbusCallCalled] {
+        __DBG_STUB_INVOKE__
+        dbusCallCalled = true;
+        return QDBusMessage();
+    });
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+    job.writeLog(interface, "/media/sr0/file1.txt", "/tmp/file1.txt");
+
+    EXPECT_TRUE(dbusCallCalled);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_Constructor)
+{
+    QUrl stagingUrl = QUrl::fromLocalFile("/tmp/staging");
+
+    BurnFilesAuditLogJob job(stagingUrl, true);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_Constructor_Failed)
+{
+    QUrl stagingUrl = QUrl::fromLocalFile("/tmp/staging");
+
+    BurnFilesAuditLogJob job(stagingUrl, false);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_doLog_Success)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.write("test content");
+    file1.close();
+
+    QUrl stagingUrl = QUrl::fromLocalFile(tempDir.path());
+    BurnFilesAuditLogJob job(stagingUrl, true);
+
+    bool writeLogCalled = false;
+    stub.set_lamda(ADDR(BurnFilesAuditLogJob, writeLog), [&writeLogCalled] {
+        __DBG_STUB_INVOKE__
+        writeLogCalled = true;
+    });
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+    job.doLog(interface);
+
+    EXPECT_TRUE(writeLogCalled);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_doLog_Failed)
+{
+    QUrl stagingUrl = QUrl::fromLocalFile("/tmp/nonexistent");
+    BurnFilesAuditLogJob job(stagingUrl, false);
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+
+    // Should handle failure case gracefully
+    job.doLog(interface);
+    // Should not crash
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_writeLog)
+{
+    QUrl stagingUrl = QUrl::fromLocalFile("/tmp/staging");
+    BurnFilesAuditLogJob job(stagingUrl, true);
+
+    bool dbusCallCalled = false;
+
+    stub.set_lamda(ADDR(QDBusInterface, doCall), [&dbusCallCalled] {
+        __DBG_STUB_INVOKE__
+        dbusCallCalled = true;
+        return QDBusMessage();
+    });
+
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+    job.writeLog(interface, "/dev/sr0/file1.txt", "/tmp/staging/file1.txt", 1024);
+
+    EXPECT_TRUE(dbusCallCalled);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_burnedFileInfoList)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.write("test content 1");
+    file1.close();
+
+    QFile file2(tempDir.path() + "/file2.txt");
+    ASSERT_TRUE(file2.open(QIODevice::WriteOnly));
+    file2.write("test content 2");
+    file2.close();
+
+    QUrl stagingUrl = QUrl::fromLocalFile(tempDir.path());
+    BurnFilesAuditLogJob job(stagingUrl, true);
+
+    QFileInfoList fileList = job.burnedFileInfoList();
+
+    EXPECT_EQ(fileList.size(), 2);
+}
+
+TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_burnedFileInfoList_EmptyDir)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QUrl stagingUrl = QUrl::fromLocalFile(tempDir.path());
+    BurnFilesAuditLogJob job(stagingUrl, true);
+
+    QFileInfoList fileList = job.burnedFileInfoList();
+
+    EXPECT_TRUE(fileList.isEmpty());
+}
+
+TEST_F(UT_AuditLogJob, EraseDiscAuditLogJob_Constructor_Success)
+{
+    EraseDiscAuditLogJob job(true);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, EraseDiscAuditLogJob_Constructor_Failed)
+{
+    EraseDiscAuditLogJob job(false);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_AuditLogJob, EraseDiscAuditLogJob_doLog_Success)
+{
+    EraseDiscAuditLogJob job(true);
+
+    bool dbusCallCalled = false;
+
+    stub.set_lamda(ADDR(QDBusInterface, doCall), [&dbusCallCalled] {
+        __DBG_STUB_INVOKE__
+        dbusCallCalled = true;
+        return QDBusMessage();
+    });
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+    job.doLog(interface);
+
+    EXPECT_TRUE(dbusCallCalled);
+}
+
+TEST_F(UT_AuditLogJob, EraseDiscAuditLogJob_doLog_Failed)
+{
+    EraseDiscAuditLogJob job(false);
+
+    QDBusInterface interface("test.service", "/test/path", "test.interface");
+
+    // Should handle failure case gracefully
+    job.doLog(interface);
+    // Should not crash (no D-Bus call expected for failed erase)
+}
+
+TEST_F(UT_AuditLogJob, AbstractAuditLogJob_run_DBusInterfaceError)
+{
+    CopyFromDiscAuditLog job({}, {});
+
+    // Mock QDBusInterface to be invalid
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should handle invalid D-Bus interface gracefully
+    job.run();
+    // Should not crash
+}

--- a/autotests/plugins/dfmplugin-burn/test_burn.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burn.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/burn.h"
+#include "plugins/common/dfmplugin-burn/utils/discstatemanager.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+#include "plugins/common/dfmplugin-burn/utils/burnsignalmanager.h"
+#include "plugins/common/dfmplugin-burn/events/burneventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+
+#include <QUrl>
+#include <QSet>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_Burn : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new Burn();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    Burn *plugin = nullptr;
+};
+
+TEST_F(UT_Burn, initialize)
+{
+    bool bindEventsCalled = false;
+    stub.set_lamda(ADDR(Burn, bindEvents), [&bindEventsCalled] {
+        __DBG_STUB_INVOKE__
+        bindEventsCalled = true;
+    });
+
+    plugin->initialize();
+    EXPECT_TRUE(bindEventsCalled);
+}
+
+TEST_F(UT_Burn, initialize_BurnDisabled)
+{
+    bool initializeManagerCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, initilaize), [&initializeManagerCalled] {
+        __DBG_STUB_INVOKE__
+        initializeManagerCalled = true;
+    });
+
+    stub.set_lamda(ADDR(DiscStateManager, instance), [] {
+        __DBG_STUB_INVOKE__
+        static DiscStateManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(ADDR(BurnEventReceiver, instance), [] {
+        __DBG_STUB_INVOKE__
+        static BurnEventReceiver receiver;
+        return &receiver;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, isBurnEnabled), [] {
+        __DBG_STUB_INVOKE__
+        return false;   // Burn disabled
+    });
+
+    plugin->initialize();
+
+    EXPECT_FALSE(initializeManagerCalled);   // Should not initialize when disabled
+}
+
+TEST_F(UT_Burn, start)
+{
+    bool bindSceneCalled = false;
+
+    stub.set_lamda(ADDR(Burn, bindScene), [&bindSceneCalled] {
+        __DBG_STUB_INVOKE__
+        bindSceneCalled = true;
+    });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(bindSceneCalled);
+}
+
+TEST_F(UT_Burn, bindScene)
+{
+    plugin->bindScene("WorkspaceScene");
+}
+
+TEST_F(UT_Burn, bindSceneOnAdded)
+{
+    plugin->bindSceneOnAdded("WorkspaceScene");
+}
+
+TEST_F(UT_Burn, bindSceneOnAdded_NotInWaitList)
+{
+    bool bindSceneCalled = false;
+
+    stub.set_lamda(ADDR(Burn, bindScene), [&bindSceneCalled] {
+        __DBG_STUB_INVOKE__
+        bindSceneCalled = true;
+    });
+
+    plugin->bindSceneOnAdded("UnknownScene");
+
+    EXPECT_FALSE(bindSceneCalled);   // Should not bind unknown scenes
+}
+
+TEST_F(UT_Burn, bindEvents)
+{
+    plugin->bindEvents();
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_BurnUrl)
+{
+    QUrl burnUrl;
+    burnUrl.setScheme("burn");
+    burnUrl.setPath("/dev/sr0/disc_files/");
+    stub.set_lamda(&DeviceUtils::isWorkingOpticalDiscDev, []() {
+        return true;
+    });
+
+    bool result = plugin->changeUrlEventFilter(12345, burnUrl);
+
+    EXPECT_TRUE(result);   // Should handle burn URLs
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_NonBurnUrl)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    bool result = plugin->changeUrlEventFilter(12345, fileUrl);
+
+    EXPECT_FALSE(result);   // Should not handle non-burn URLs
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_BurnEnable_True)
+{
+    QVariantMap value;
+    value["working"] = true;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_BurnEnable_False)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["working"] = false;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not initialize when disabled
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_OtherGroup)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["working"] = true;
+    plugin->onPersistenceDataChanged("some_other_key", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not respond to other groups
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_OtherKey)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["otherField"] = true;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not respond to other keys
+}
+
+TEST_F(UT_Burn, Constructor)
+{
+    Burn burnPlugin;
+
+    // Should construct without crashing
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_Burn, bindEvents_EventSubscription)
+{
+    plugin->bindEvents();
+}
+
+TEST_F(UT_Burn, start_ReturnValue)
+{
+    stub.set_lamda(ADDR(Burn, bindScene), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(ADDR(Burn, bindEvents), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);   // Should always return true
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_EmptyUrl)
+{
+    QUrl emptyUrl;
+
+    bool result = plugin->changeUrlEventFilter(12345, emptyUrl);
+
+    EXPECT_FALSE(result);   // Should not handle empty URLs
+}

--- a/autotests/plugins/dfmplugin-burn/test_burncheckstrategy.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burncheckstrategy.cpp
@@ -1,0 +1,610 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/burncheckstrategy.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QTextStream>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+
+class UT_BurnCheckStrategy : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+        tempDir = new QTemporaryDir();
+        ASSERT_TRUE(tempDir->isValid());
+        testPath = tempDir->path();
+    }
+
+    virtual void TearDown() override
+    {
+        delete tempDir;
+        tempDir = nullptr;
+        stub.clear();
+    }
+
+    void createTestFile(const QString &fileName, const QString &content = "test content")
+    {
+        QFile file(testPath + "/" + fileName);
+        ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+        QTextStream stream(&file);
+        stream << content;
+        file.close();
+    }
+
+    void createTestDir(const QString &dirName)
+    {
+        QDir dir(testPath);
+        ASSERT_TRUE(dir.mkpath(dirName));
+    }
+
+    QString createLongString(int length, char c = 'a')
+    {
+        return QString(length, c);
+    }
+
+public:
+    stub_ext::StubExt stub;
+    QTemporaryDir *tempDir = nullptr;
+    QString testPath;
+};
+
+// Base BurnCheckStrategy Tests
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_Constructor)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    EXPECT_EQ(strategy.currentStagePath, testPath);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_EmptyDirectory)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    stub.set_lamda(ADDR(BurnHelper, localFileInfoList), [] {
+        __DBG_STUB_INVOKE__
+        return QFileInfoList();
+    });
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_SingleFile)
+{
+    createTestFile("test.txt");
+
+    BurnCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_NonExistentFile)
+{
+    BurnCheckStrategy strategy("/non/existent/path");
+
+    QFileInfo nonExistentInfo("/non/existent/path");
+
+    stub.set_lamda(ADDR(BurnHelper, localFileInfoList), [&nonExistentInfo] {
+        __DBG_STUB_INVOKE__
+        return QFileInfoList() << nonExistentInfo;
+    });
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);   // Non-existent files should be valid
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_DirectoryWithFiles)
+{
+    createTestDir("subdir");
+    createTestFile("subdir/file1.txt");
+    createTestFile("subdir/file2.txt");
+
+    BurnCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_lastError)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    // Initially should be empty
+    QString error = strategy.lastError();
+    EXPECT_TRUE(error.isEmpty());
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_lastInvalidName)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    // Initially should be empty
+    QString invalidName = strategy.lastInvalidName();
+    EXPECT_TRUE(invalidName.isEmpty());
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_autoFeed_ShortString)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString shortText = "short";
+    QString result = strategy.autoFeed(shortText);
+    EXPECT_EQ(result, shortText);   // Should remain unchanged
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_autoFeed_LongString)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString longText = createLongString(100, 'a');
+    QString result = strategy.autoFeed(longText);
+    EXPECT_TRUE(result.contains('\n'));   // Should contain line breaks
+    EXPECT_GT(result.length(), longText.length());   // Should be longer due to line breaks
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validCommonFileNameBytes_Valid)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString validName = "valid_filename.txt";
+    bool result = strategy.validCommonFileNameBytes(validName);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validCommonFileNameBytes_TooLong)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString longName = createLongString(300, 'a') + ".txt";   // > 255 bytes
+    bool result = strategy.validCommonFileNameBytes(longName);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validComontFilePathBytes_Valid)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString validPath = "/path/to/file.txt";
+    bool result = strategy.validComontFilePathBytes(validPath);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validComontFilePathBytes_TooLong)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString longPath = "/" + createLongString(1100, 'a');   // > 1024 bytes
+    bool result = strategy.validComontFilePathBytes(longPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validCommonFilePathDeepLength_Valid)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString validPath = "/a/b/c/d/e/f/g/h";   // 8 levels
+    bool result = strategy.validCommonFilePathDeepLength(validPath);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validCommonFilePathDeepLength_TooDeep)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    QString deepPath = "/a/b/c/d/e/f/g/h/i/j";   // > 8 levels
+    bool result = strategy.validCommonFilePathDeepLength(deepPath);
+    EXPECT_FALSE(result);
+}
+
+// ISO9660CheckStrategy Tests
+TEST_F(UT_BurnCheckStrategy, ISO9660CheckStrategy_Constructor)
+{
+    ISO9660CheckStrategy strategy(testPath);
+
+    EXPECT_EQ(strategy.currentStagePath, testPath);
+}
+
+TEST_F(UT_BurnCheckStrategy, ISO9660CheckStrategy_validFileNameCharacters_Valid)
+{
+    ISO9660CheckStrategy strategy(testPath);
+
+    QString validName = "short_name.txt";   // < 32 characters
+    bool result = strategy.validFileNameCharacters(validName);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, ISO9660CheckStrategy_validFileNameCharacters_TooLong)
+{
+    ISO9660CheckStrategy strategy(testPath);
+
+    QString longName = createLongString(35, 'a') + ".txt";   // > 32 characters
+    bool result = strategy.validFileNameCharacters(longName);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, ISO9660CheckStrategy_validFilePathDeepLength)
+{
+    ISO9660CheckStrategy strategy(testPath);
+
+    QString validPath = "/a/b/c/d/e/f/g/h";   // 8 levels
+    bool result = strategy.validFilePathDeepLength(validPath);
+    EXPECT_TRUE(result);
+
+    QString deepPath = "/a/b/c/d/e/f/g/h/i/j";   // > 8 levels
+    result = strategy.validFilePathDeepLength(deepPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, ISO9660CheckStrategy_check_ValidFiles)
+{
+    createTestFile("short.txt");
+    createTestDir("dir");
+    createTestFile("dir/file.txt");
+
+    ISO9660CheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+// JolietCheckStrategy Tests
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_Constructor)
+{
+    JolietCheckStrategy strategy(testPath);
+
+    EXPECT_EQ(strategy.currentStagePath, testPath);
+}
+
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_validFileNameCharacters_Valid)
+{
+    JolietCheckStrategy strategy(testPath);
+
+    QString validName = createLongString(59, 'a') + ".txt";   // < 64 characters
+    bool result = strategy.validFileNameCharacters(validName);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_validFileNameCharacters_TooLong)
+{
+    JolietCheckStrategy strategy(testPath);
+
+    // kMaxJolietFileNameSize is 103 (joliet_long_names extension)
+    QString longName = createLongString(110, 'a') + ".txt";   // > 103 characters
+    bool result = strategy.validFileNameCharacters(longName);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_validFilePathCharacters_Valid)
+{
+    JolietCheckStrategy strategy(testPath);
+
+    QString validPath = "/path/to/" + createLongString(100, 'a');   // < 120 characters
+    bool result = strategy.validFilePathCharacters(validPath);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_validFilePathCharacters_TooLong)
+{
+    JolietCheckStrategy strategy(testPath);
+
+    // kMaxJolietFilePathSize is 800
+    QString longPath = "/path/to/" + createLongString(850, 'a');   // > 800 characters
+    bool result = strategy.validFilePathCharacters(longPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, JolietCheckStrategy_check_ValidFiles)
+{
+    createTestFile("medium_name.txt");
+    createTestDir("subdir");
+    createTestFile("subdir/another.txt");
+
+    JolietCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+// RockRidgeCheckStrategy Tests
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_Constructor)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    EXPECT_EQ(strategy.currentStagePath, testPath);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_validFileNameBytes_Valid)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    QString validName = createLongString(200, 'a') + ".txt";   // < 255 bytes
+    bool result = strategy.validFileNameBytes(validName);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_validFileNameBytes_TooLong)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    QString longName = createLongString(300, 'a') + ".txt";   // > 255 bytes
+    bool result = strategy.validFileNameBytes(longName);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_validFilePathBytes_Valid)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    QString validPath = "/path/" + createLongString(900, 'a');   // < 1024 bytes
+    bool result = strategy.validFilePathBytes(validPath);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_validFilePathBytes_TooLong)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    QString longPath = "/" + createLongString(1100, 'a');   // > 1024 bytes
+    bool result = strategy.validFilePathBytes(longPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_validFilePathDeepLength)
+{
+    RockRidgeCheckStrategy strategy(testPath);
+
+    QString validPath = "/a/b/c/d/e/f/g/h";   // 8 levels
+    bool result = strategy.validFilePathDeepLength(validPath);
+    EXPECT_TRUE(result);
+
+    QString deepPath = "/a/b/c/d/e/f/g/h/i/j";   // > 8 levels
+    result = strategy.validFilePathDeepLength(deepPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, RockRidgeCheckStrategy_check_ValidFiles)
+{
+    createTestFile("long_filename_but_within_limits.txt");
+    createTestDir("subdir");
+    createTestFile("subdir/another_file.txt");
+
+    RockRidgeCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+// UDFCheckStrategy Tests
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_Constructor)
+{
+    UDFCheckStrategy strategy(testPath);
+
+    EXPECT_EQ(strategy.currentStagePath, testPath);
+}
+
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_validFileNameBytes_Valid)
+{
+    UDFCheckStrategy strategy(testPath);
+
+    QString validName = createLongString(200, 'a') + ".txt";   // < 255 bytes
+    bool result = strategy.validFileNameBytes(validName);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_validFileNameBytes_TooLong)
+{
+    UDFCheckStrategy strategy(testPath);
+
+    QString longName = createLongString(300, 'a') + ".txt";   // > 255 bytes
+    bool result = strategy.validFileNameBytes(longName);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_validFilePathBytes_Valid)
+{
+    UDFCheckStrategy strategy(testPath);
+
+    QString validPath = "/path/" + createLongString(900, 'a');   // < 1024 bytes
+    bool result = strategy.validFilePathBytes(validPath);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_validFilePathBytes_TooLong)
+{
+    UDFCheckStrategy strategy(testPath);
+
+    QString longPath = "/" + createLongString(1100, 'a');   // > 1024 bytes
+    bool result = strategy.validFilePathBytes(longPath);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, UDFCheckStrategy_check_ValidFiles)
+{
+    createTestFile("very_long_filename_that_is_still_within_udf_limits.txt");
+    createTestDir("subdir");
+    createTestFile("subdir/another_long_filename.txt");
+
+    UDFCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+// Integration Tests
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_ComplexDirectoryStructure)
+{
+    // Create a complex directory structure
+    createTestDir("level1");
+    createTestDir("level1/level2");
+    createTestDir("level1/level2/level3");
+    createTestFile("level1/file1.txt");
+    createTestFile("level1/level2/file2.txt");
+    createTestFile("level1/level2/level3/file3.txt");
+
+    BurnCheckStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_FileDoesNotExist)
+{
+    BurnCheckStrategy strategy(testPath);
+
+    // Mock BurnHelper to return a non-existent file
+    QFileInfo nonExistentFile("/non/existent/file.txt");
+    stub.set_lamda(ADDR(BurnHelper, localFileInfoList), [&nonExistentFile] {
+        __DBG_STUB_INVOKE__
+        return QFileInfoList() << nonExistentFile;
+    });
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);   // Non-existent files should pass validation
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_check_RegularFile)
+{
+    createTestFile("regular.txt");
+
+    BurnCheckStrategy strategy(testPath);
+
+    // Test with regular file (not directory)
+    QString filePath = testPath + "/regular.txt";
+    BurnCheckStrategy fileStrategy(filePath);
+
+    bool result = fileStrategy.check();
+    EXPECT_TRUE(result);   // Regular files should pass
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_validFile_ErrorScenarios)
+{
+    createTestFile("test.txt");
+
+    // Create a strategy that will fail validation
+    class TestStrategy : public BurnCheckStrategy
+    {
+    public:
+        TestStrategy(const QString &path)
+            : BurnCheckStrategy(path) { }
+
+        bool validFileNameCharacters(const QString &fileName) override
+        {
+            Q_UNUSED(fileName)
+            return false;   // Always fail
+        }
+    };
+
+    TestStrategy strategy(testPath);
+
+    bool result = strategy.check();
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(strategy.lastError().isEmpty());
+    EXPECT_FALSE(strategy.lastInvalidName().isEmpty());
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_ErrorMessages)
+{
+    createTestFile("test.txt");
+
+    // Test different error scenarios
+    class TestStrategy : public BurnCheckStrategy
+    {
+    public:
+        TestStrategy(const QString &path, int errorType)
+            : BurnCheckStrategy(path), errorType(errorType) { }
+
+        bool validFileNameCharacters(const QString &fileName) override
+        {
+            return errorType != 1;
+        }
+
+        bool validFilePathCharacters(const QString &filePath) override
+        {
+            return errorType != 2;
+        }
+
+        bool validFileNameBytes(const QString &fileName) override
+        {
+            return errorType != 3;
+        }
+
+        bool validFilePathBytes(const QString &filePath) override
+        {
+            return errorType != 4;
+        }
+
+        bool validFilePathDeepLength(const QString &filePath) override
+        {
+            return errorType != 5;
+        }
+
+    private:
+        int errorType;
+    };
+
+    // Test FileNameCharacters error
+    TestStrategy strategy1(testPath, 1);
+    EXPECT_FALSE(strategy1.check());
+    EXPECT_TRUE(strategy1.lastError().contains("Invalid FileNameCharacters Length"));
+
+    // Test FilePathCharacters error
+    TestStrategy strategy2(testPath, 2);
+    EXPECT_FALSE(strategy2.check());
+    EXPECT_TRUE(strategy2.lastError().contains("Invalid FilePathCharacters Length"));
+
+    // Test FileNameBytes error
+    TestStrategy strategy3(testPath, 3);
+    EXPECT_FALSE(strategy3.check());
+    EXPECT_TRUE(strategy3.lastError().contains("Invalid FileNameBytes Length"));
+
+    // Test FilePathBytes error
+    TestStrategy strategy4(testPath, 4);
+    EXPECT_FALSE(strategy4.check());
+    EXPECT_TRUE(strategy4.lastError().contains("Invalid FilePathBytes Length"));
+
+    // Test FilePathDeepLength error
+    TestStrategy strategy5(testPath, 5);
+    EXPECT_FALSE(strategy5.check());
+    EXPECT_TRUE(strategy5.lastError().contains("Invalid FilePathDeepLength"));
+}
+
+TEST_F(UT_BurnCheckStrategy, BurnCheckStrategy_RecursiveDirectoryCheck)
+{
+    // Create nested directory structure
+    createTestDir("deep");
+    createTestDir("deep/nested");
+    createTestDir("deep/nested/structure");
+    createTestFile("deep/file1.txt");
+    createTestFile("deep/nested/file2.txt");
+    createTestFile("deep/nested/structure/file3.txt");
+
+    BurnCheckStrategy strategy(testPath);
+
+    // Mock BurnHelper methods
+    stub.set_lamda(ADDR(BurnHelper, localFileInfoListRecursive), [] {
+        __DBG_STUB_INVOKE__
+        QFileInfoList list;
+        list << QFileInfo("/test/file1.txt");
+        list << QFileInfo("/test/file2.txt");
+        list << QFileInfo("/test/file3.txt");
+        return list;
+    });
+
+    bool result = strategy.check();
+    EXPECT_TRUE(result);
+}

--- a/autotests/plugins/dfmplugin-burn/test_burneventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burneventreceiver.cpp
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/events/burneventreceiver.h"
+#include "plugins/common/dfmplugin-burn/events/burneventcaller.h"
+#include "plugins/common/dfmplugin-burn/utils/burnjobmanager.h"
+#include "plugins/common/dfmplugin-burn/dialogs/burnoptdialog.h"
+#include "plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.h"
+
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-framework/event/event.h>
+
+#include <DDialog>
+#include <QWidget>
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_BurnEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(VADDR(DDialog, exec), [] {
+            __DBG_STUB_INVOKE__
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnEventReceiver, instance)
+{
+    BurnEventReceiver *receiver1 = BurnEventReceiver::instance();
+    BurnEventReceiver *receiver2 = BurnEventReceiver::instance();
+
+    EXPECT_TRUE(receiver1 != nullptr);
+    EXPECT_EQ(receiver1, receiver2);   // Should be singleton
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_UDFSupported)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    QWidget parent;
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", true, &parent);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_UDFNotSupported)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    QWidget parent;
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", false, &parent);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_NullParent)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", true, nullptr);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowDumpISODlg)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DumpISOOptDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    BurnEventReceiver::instance()->handleShowDumpISODlg("/dev/sr0");
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleErase)
+{
+    bool eraseStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startEraseDisc), [&eraseStarted] {
+        __DBG_STUB_INVOKE__
+        eraseStarted = true;
+    });
+    stub.set_lamda(VADDR(DDialog, exec), [&] { __DBG_STUB_INVOKE__ return DDialog::Accepted; });
+
+    BurnEventReceiver::instance()->handleErase("/dev/sr0");
+
+    EXPECT_TRUE(eraseStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handlePasteTo_Copy)
+{
+    bool pasteFilesCalled = false;
+    QList<QUrl> capturedUrls;
+    QUrl capturedDest;
+    bool capturedIsCopy = false;
+
+    stub.set_lamda(ADDR(BurnEventCaller, sendPasteFiles), [&](const QList<QUrl> &urls, const QUrl &dest, bool isCopy) {
+        __DBG_STUB_INVOKE__
+        pasteFilesCalled = true;
+        capturedUrls = urls;
+        capturedDest = dest;
+        capturedIsCopy = isCopy;
+    });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/file1.txt"),
+                         QUrl::fromLocalFile("/tmp/file2.txt") };
+    QUrl dest;
+    dest.setScheme("burn");
+    dest.setPath("/dev/sr0/disc_files/");
+
+    BurnEventReceiver::instance()->handlePasteTo(urls, dest, true);
+
+    EXPECT_TRUE(pasteFilesCalled);
+    EXPECT_EQ(capturedUrls, urls);
+    EXPECT_TRUE(capturedIsCopy);
+}
+
+TEST_F(UT_BurnEventReceiver, handlePasteTo_Move)
+{
+    bool pasteFilesCalled = false;
+    QList<QUrl> capturedUrls;
+    QUrl capturedDest;
+    bool capturedIsCopy = true; // Initialize to opposite of expected
+
+    stub.set_lamda(ADDR(BurnEventCaller, sendPasteFiles), [&](const QList<QUrl> &urls, const QUrl &dest, bool isCopy) {
+        __DBG_STUB_INVOKE__
+        pasteFilesCalled = true;
+        capturedUrls = urls;
+        capturedDest = dest;
+        capturedIsCopy = isCopy;
+    });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl dest;
+    dest.setScheme("burn");
+    dest.setPath("/dev/sr0/disc_files/");
+
+    BurnEventReceiver::instance()->handlePasteTo(urls, dest, false);
+
+    EXPECT_TRUE(pasteFilesCalled);
+    EXPECT_EQ(capturedUrls, urls);
+    EXPECT_FALSE(capturedIsCopy);
+}
+
+TEST_F(UT_BurnEventReceiver, handleMountImage)
+{
+    // This test requires complex framework event stubbing
+    // For now, just test that the method doesn't crash
+    QUrl isoUrl = QUrl::fromLocalFile("/tmp/test.iso");
+    BurnEventReceiver::instance()->handleMountImage(12345, isoUrl);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleCopyFilesResult_Success)
+{
+    bool auditLogStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startAuditLogForCopyFromDisc), [&auditLogStarted] {
+        __DBG_STUB_INVOKE__
+        auditLogStarted = true;
+    });
+
+    // Stub DeviceProxyManager to simulate copying from optical disc
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileFromOptical), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleCopyFilesResult(srcUrls, destUrls, true, "");
+
+    EXPECT_TRUE(auditLogStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleCopyFilesResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleCopyFilesResult(srcUrls, destUrls, false, "Copy failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileCutResult_Success)
+{
+    bool putFilesStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startPutFilesToDisc), [&putFilesStarted] {
+        __DBG_STUB_INVOKE__
+        putFilesStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleFileCutResult(srcUrls, destUrls, true, "");
+
+    EXPECT_TRUE(putFilesStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileCutResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleFileCutResult(srcUrls, destUrls, false, "Cut failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRemoveResult_Success)
+{
+    bool removeStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRemoveFilesFromDisc), [&removeStarted] {
+        __DBG_STUB_INVOKE__
+        removeStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls;
+    srcUrls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+
+    BurnEventReceiver::instance()->handleFileRemoveResult(srcUrls, true, "");
+
+    EXPECT_TRUE(removeStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRemoveResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls;
+    srcUrls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+
+    BurnEventReceiver::instance()->handleFileRemoveResult(srcUrls, false, "Remove failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_Success)
+{
+    bool renameStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRenameFileFromDisc), [&renameStarted] {
+        __DBG_STUB_INVOKE__
+        renameStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QMap<QUrl, QUrl> renamedUrls;
+    renamedUrls[QUrl::fromLocalFile("/media/sr0/oldname.txt")] = QUrl::fromLocalFile("/media/sr0/newname.txt");
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, renamedUrls, true, "");
+
+    EXPECT_TRUE(renameStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_Failure)
+{
+    // The method checks 'ok' parameter and returns early if false, but doesn't show error dialogs
+    // This test verifies that no rename operation is started when ok=false
+    bool renameStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRenameFileFromDisc), [&renameStarted] {
+        __DBG_STUB_INVOKE__
+        renameStarted = true;
+    });
+
+    QMap<QUrl, QUrl> renamedUrls;
+    renamedUrls[QUrl::fromLocalFile("/media/sr0/oldname.txt")] = QUrl::fromLocalFile("/media/sr0/newname.txt");
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, renamedUrls, false, "Rename failed");
+
+    // Should not start rename operation when ok=false
+    EXPECT_FALSE(renameStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_EmptyMap)
+{
+    // Should handle empty rename map gracefully
+    QMap<QUrl, QUrl> emptyMap;
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, emptyMap, true, "");
+    // Should not crash
+}

--- a/autotests/plugins/dfmplugin-burn/test_burnhelper.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnhelper.cpp
@@ -1,0 +1,410 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/dbusservice/opticalshareproxy.h>
+
+#include <DDialog>
+
+#include <QStandardPaths>
+#include <QApplication>
+#include <QDir>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+DPBURN_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_BurnHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnHelper, IsBurnEnabled)
+{
+    bool ret { false };
+    stub.set_lamda(&DConfigManager::value, [&] { __DBG_STUB_INVOKE__ return ret; });
+    EXPECT_FALSE(BurnHelper::isBurnEnabled());
+
+    ret = true;
+    EXPECT_TRUE(BurnHelper::isBurnEnabled());
+}
+
+TEST_F(UT_BurnHelper, IsBurnEnabled_InvalidValue)
+{
+    stub.set_lamda(&DConfigManager::value, [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();   // Invalid value
+    });
+    EXPECT_TRUE(BurnHelper::isBurnEnabled());   // Should return default true
+}
+
+TEST_F(UT_BurnHelper, showOpticalBlankConfirmationDialog)
+{
+    int expectedResult = 1;
+    stub.set_lamda(VADDR(DDialog, exec), [&expectedResult] {
+        __DBG_STUB_INVOKE__
+        return expectedResult;
+    });
+
+    int result = BurnHelper::showOpticalBlankConfirmationDialog();
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(UT_BurnHelper, showOpticalImageOpSelectionDialog)
+{
+    int expectedResult = 2;
+    stub.set_lamda(VADDR(DDialog, exec), [&expectedResult] {
+        __DBG_STUB_INVOKE__
+        return expectedResult;
+    });
+
+    int result = BurnHelper::showOpticalImageOpSelectionDialog();
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithDevice)
+{
+    QString testDev = "/dev/sr0";
+
+    stub.set_lamda(&QStandardPaths::writableLocation, [] {
+        __DBG_STUB_INVOKE__
+        return QString("/tmp/cache");
+    });
+
+    stub.set_lamda(&QApplication::organizationName, [] {
+        __DBG_STUB_INVOKE__
+        return QString("deepin");
+    });
+
+    QUrl result = BurnHelper::localStagingFile(testDev);
+    EXPECT_TRUE(result.isLocalFile());
+    EXPECT_TRUE(result.toLocalFile().contains("_dev_sr0"));
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithUrl)
+{
+    QUrl destUrl;
+    destUrl.setScheme("burn");
+    destUrl.setPath("/dev/sr0/disc_files/test.txt");
+
+    stub.set_lamda(ADDR(BurnHelper, burnDestDevice), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, burnFilePath), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/test.txt");
+    });
+
+    stub.set_lamda(&QStandardPaths::writableLocation, [] {
+        __DBG_STUB_INVOKE__
+        return QString("/tmp/cache");
+    });
+
+    stub.set_lamda(&QApplication::organizationName, [] {
+        __DBG_STUB_INVOKE__
+        return QString("deepin");
+    });
+
+    QUrl result = BurnHelper::localStagingFile(destUrl);
+    EXPECT_TRUE(result.isLocalFile());
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithUrl_EmptyDevice)
+{
+    QUrl destUrl;
+    destUrl.setScheme("burn");
+    destUrl.setPath("/invalid/path");
+
+    stub.set_lamda(ADDR(BurnHelper, burnDestDevice), [] {
+        __DBG_STUB_INVOKE__
+        return QString();   // Empty device
+    });
+
+    QUrl result = BurnHelper::localStagingFile(destUrl);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, fromBurnFile)
+{
+    QString testDev = "/dev/sr0";
+
+    QUrl result = BurnHelper::fromBurnFile(testDev);
+    EXPECT_EQ(result.scheme(), "burn");
+    EXPECT_TRUE(result.path().contains("staging_files"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_DuplicateFile)
+{
+    QStringList messages;
+    // The method expects both conditions in the same message string
+    messages << "While grafting '/path/to/file.txt' file object exists and may not be overwritten";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("duplicate file"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_InsufficientSpace)
+{
+    QStringList messages;
+    messages << "Image size 1024 exceeds free space on media 512";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Insufficient disc space"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_LostConnection)
+{
+    QStringList messages;
+    messages << "Lost connection to drive";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Lost connection to drive"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_ServoFailure)
+{
+    QStringList messages;
+    messages << "servo failure";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("not ready"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_DeviceBusy)
+{
+    QStringList messages;
+    messages << "Device or resource busy";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("busy"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_InvalidVolumeName)
+{
+    QStringList messages;
+    messages << "-volid: Text too long";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Invalid volume name"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_UnknownError)
+{
+    QStringList messages;
+    messages << "Some unknown error message";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Unknown error"));
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_ValidBurnUrl)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_EQ(result, "/dev/sr0");
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_InvalidScheme)
+{
+    QUrl url;
+    url.setScheme("file");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_InvalidPath)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/invalid/path");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, burnFilePath_ValidBurnUrl)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnFilePath(url);
+    EXPECT_EQ(result, "/test.txt");
+}
+
+TEST_F(UT_BurnHelper, burnFilePath_InvalidScheme)
+{
+    QUrl url;
+    url.setScheme("file");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnFilePath(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, discDataGroup)
+{
+    QStringList mockIds = { "/org/freedesktop/UDisks2/block_devices/sr0",
+                            "/org/freedesktop/UDisks2/block_devices/sda1" };
+
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [&mockIds] {
+        __DBG_STUB_INVOKE__
+        return mockIds;
+    });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [](DeviceProxyManager *, const QString &id, bool needDBusCall) {
+        __DBG_STUB_INVOKE__
+        Q_UNUSED(needDBusCall)
+        QVariantMap data;
+        if (id.contains("sr0")) {
+            data[DeviceProperty::kOptical] = true;
+            data[DeviceProperty::kOpticalDrive] = true;
+        } else {
+            data[DeviceProperty::kOptical] = false;
+            data[DeviceProperty::kOpticalDrive] = false;
+        }
+        return data;
+    });
+
+    QList<QVariantMap> result = BurnHelper::discDataGroup();
+    EXPECT_EQ(result.size(), 1);   // Only sr0 should be included
+}
+
+TEST_F(UT_BurnHelper, updateBurningStateToPersistence)
+{
+    // Product now forwards state to OpticalShareProxy (non-virtual, stubable)
+    bool setCalled = false;
+    bool clearCalled = false;
+
+    stub.set_lamda(ADDR(OpticalShareProxy, setBurnState), [&setCalled](OpticalShareProxy *, const QString &, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        setCalled = true;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(OpticalShareProxy, clearBurnState), [&clearCalled](OpticalShareProxy *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        clearCalled = true;
+        return true;
+    });
+
+    BurnHelper::updateBurningStateToPersistence("test_id", "/dev/sr0", true);
+    EXPECT_TRUE(setCalled);
+    EXPECT_FALSE(clearCalled);
+
+    BurnHelper::updateBurningStateToPersistence("test_id", "/dev/sr0", false);
+    EXPECT_TRUE(clearCalled);
+}
+
+TEST_F(UT_BurnHelper, mapStagingFilesPath_EmptyList)
+{
+    QList<QUrl> emptyList;
+
+    // Should not crash with empty lists
+    BurnHelper::mapStagingFilesPath(emptyList, emptyList);
+}
+
+TEST_F(UT_BurnHelper, mapStagingFilesPath_SizeMismatch)
+{
+    QList<QUrl> srcList = { QUrl::fromLocalFile("/src/file1.txt") };
+    QList<QUrl> targetList = { QUrl::fromLocalFile("/target/file1.txt"),
+                               QUrl::fromLocalFile("/target/file2.txt") };
+
+    // Should handle size mismatch gracefully
+    BurnHelper::mapStagingFilesPath(srcList, targetList);
+}
+
+TEST_F(UT_BurnHelper, burnIsOnLocalStaging_ValidPath)
+{
+    QUrl url = QUrl::fromLocalFile("/home/user/.cache/deepin/discburn/_dev_sr0/test.txt");
+
+    bool result = BurnHelper::burnIsOnLocalStaging(url);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnHelper, burnIsOnLocalStaging_InvalidPath)
+{
+    QUrl url = QUrl::fromLocalFile("/home/user/Documents/test.txt");
+
+    bool result = BurnHelper::burnIsOnLocalStaging(url);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnHelper, localFileInfoList_ValidDirectory)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.close();
+
+    QDir subDir(tempDir.path() + "/subdir");
+    ASSERT_TRUE(subDir.mkpath("."));
+
+    QFileInfoList result = BurnHelper::localFileInfoList(tempDir.path());
+    EXPECT_EQ(result.size(), 2);   // file1.txt and subdir
+}
+
+TEST_F(UT_BurnHelper, localFileInfoList_NonExistentDirectory)
+{
+    QFileInfoList result = BurnHelper::localFileInfoList("/non/existent/path");
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, localFileInfoListRecursive_ValidDirectory)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.close();
+
+    QDir subDir(tempDir.path() + "/subdir");
+    ASSERT_TRUE(subDir.mkpath("."));
+
+    QFile file2(tempDir.path() + "/subdir/file2.txt");
+    ASSERT_TRUE(file2.open(QIODevice::WriteOnly));
+    file2.close();
+
+    QFileInfoList result = BurnHelper::localFileInfoListRecursive(tempDir.path());
+    EXPECT_EQ(result.size(), 2);   // file1.txt and file2.txt (only files, not dirs)
+}
+
+TEST_F(UT_BurnHelper, localFileInfoListRecursive_NonExistentDirectory)
+{
+    QFileInfoList result = BurnHelper::localFileInfoListRecursive("/non/existent/path");
+    EXPECT_TRUE(result.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-burn/test_burnjob.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnjob.cpp
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "plugins/common/dfmplugin-burn/utils/burnjob.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/base/device/private/devicehelper.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+
+#include <QSet>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_BurnJob : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnJob, currentDeviceInfo)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+    job.curDeviceInfo["test"] = "test";
+    EXPECT_EQ(job.curDeviceInfo, job.currentDeviceInfo());
+}
+
+TEST_F(UT_BurnJob, property)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+    job.setProperty(AbstractBurnJob::PropertyType::kSpeeds, QVariant::fromValue(10));
+    EXPECT_EQ(job.property(AbstractBurnJob::PropertyType::kSpeeds), QVariant::fromValue(10));
+}
+
+TEST_F(UT_BurnJob, readyToWork_emptyInfo)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QVariantMap {};
+    });
+    EXPECT_FALSE(job.readyToWork());
+}
+
+TEST_F(UT_BurnJob, readyToWork_blank)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kOpticalBlank] = true;
+        return map;
+    });
+    EXPECT_TRUE(job.readyToWork());
+
+    // is dvd+rw/-rw
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kOpticalBlank] = false;
+        map[DeviceProperty::kSizeTotal] = 1024;
+        map[DeviceProperty::kSizeFree] = 1024;
+        return map;
+    });
+    EXPECT_TRUE(job.readyToWork());
+}
+
+TEST_F(UT_BurnJob, readyToWork_unmount)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kOpticalBlank] = false;
+        map[DeviceProperty::kMountPoint] = "/media/test/test";
+        return map;
+    });
+
+    stub.set_lamda(ADDR(DeviceManager, unmountBlockDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_TRUE(job.readyToWork());
+
+    // umount failed
+    stub.set_lamda(ADDR(DeviceManager, unmountBlockDev), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    EXPECT_FALSE(job.readyToWork());
+}
+
+TEST_F(UT_BurnJob, readyToWork)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kOpticalBlank] = true;
+        map[DeviceProperty::kMountPoint] = QString();
+        return map;
+    });
+
+    EXPECT_TRUE(job.readyToWork());
+}
+
+TEST_F(UT_BurnJob, onJobUpdated)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    EraseJob job { "/dev/sr0", jobHandler };
+
+    stub.set_lamda(ADDR(Settings, groups), [] {
+        __DBG_STUB_INVOKE__
+        return QSet<QString> {};
+    });
+    stub.set_lamda(ADDR(BurnHelper, updateBurningStateToPersistence), [] {
+        __DBG_STUB_INVOKE__
+    });
+    // failed
+    job.onJobUpdated(DFMBURN::JobStatus::kFailed, 30, {}, {});
+    EXPECT_EQ(job.lastProgress, 30);
+}
+
+TEST_F(UT_BurnJob, onJobUpdated_Success)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    EraseJob job { "/dev/sr0", jobHandler };
+
+    stub.set_lamda(ADDR(Settings, groups), [] {
+        __DBG_STUB_INVOKE__
+        return QSet<QString> {};
+    });
+    stub.set_lamda(ADDR(BurnHelper, updateBurningStateToPersistence), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    job.onJobUpdated(DFMBURN::JobStatus::kFinished, 100, "4x", {});
+    EXPECT_EQ(job.lastProgress, 100);
+    EXPECT_EQ(job.lastStatus, DFMBURN::JobStatus::kFinished);
+}
+
+TEST_F(UT_BurnJob, onJobUpdated_Running)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    EraseJob job { "/dev/sr0", jobHandler };
+
+    stub.set_lamda(ADDR(Settings, groups), [] {
+        __DBG_STUB_INVOKE__
+        return QSet<QString> {};
+    });
+    stub.set_lamda(ADDR(BurnHelper, updateBurningStateToPersistence), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    job.onJobUpdated(DFMBURN::JobStatus::kRunning, 50, "2x", { "Processing files" });
+    EXPECT_EQ(job.lastProgress, 50);
+    EXPECT_EQ(job.lastStatus, DFMBURN::JobStatus::kRunning);
+}
+
+TEST_F(UT_BurnJob, addTask)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    EraseJob job { "/dev/sr0", jobHandler };
+
+    // Test that addTask doesn't crash
+    job.addTask();
+}
+
+TEST_F(UT_BurnJob, setProperty_GetProperty)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    // Test string property
+    job.setProperty(AbstractBurnJob::PropertyType::kVolumeName, QString("TestVolume"));
+    EXPECT_EQ(job.property(AbstractBurnJob::PropertyType::kVolumeName).toString(), "TestVolume");
+
+    // Test int property
+    job.setProperty(AbstractBurnJob::PropertyType::kSpeeds, 4);
+    EXPECT_EQ(job.property(AbstractBurnJob::PropertyType::kSpeeds).toInt(), 4);
+
+    // Test URL property
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test.iso");
+    job.setProperty(AbstractBurnJob::PropertyType::kImageUrl, testUrl);
+    EXPECT_EQ(job.property(AbstractBurnJob::PropertyType::kImageUrl).toUrl(), testUrl);
+}
+
+TEST_F(UT_BurnJob, EraseJob_Constructor)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    EraseJob job { "/dev/sr0", jobHandler };
+
+    EXPECT_EQ(job.curDev, "/dev/sr0");
+    // firstJobType is only assigned in work(), left uninitialized by the constructor
+}
+
+TEST_F(UT_BurnJob, BurnISOFilesJob_Constructor)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    BurnISOFilesJob job { "/dev/sr1", jobHandler };
+
+    EXPECT_EQ(job.curDev, "/dev/sr1");
+    // firstJobType is only assigned in work(), left uninitialized by the constructor
+}
+
+TEST_F(UT_BurnJob, BurnISOImageJob_Constructor)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    BurnISOImageJob job { "/dev/sr2", jobHandler };
+
+    EXPECT_EQ(job.curDev, "/dev/sr2");
+    // firstJobType is only assigned in work(), left uninitialized by the constructor
+}
+
+TEST_F(UT_BurnJob, BurnUDFFilesJob_Constructor)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    BurnUDFFilesJob job { "/dev/sr3", jobHandler };
+
+    EXPECT_EQ(job.curDev, "/dev/sr3");
+    // firstJobType is only assigned in work(), left uninitialized by the constructor
+}
+
+TEST_F(UT_BurnJob, DumpISOImageJob_Constructor)
+{
+    JobHandlePointer jobHandler { new AbstractJobHandler };
+    DumpISOImageJob job { "/dev/sr4", jobHandler };
+
+    EXPECT_EQ(job.curDev, "/dev/sr4");
+    // firstJobType is only assigned in work(), left uninitialized by the constructor
+}
+
+TEST_F(UT_BurnJob, readyToWork_NotBlankButCanErase)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    // Current product code: readyToWork only fails when device info is empty
+    // or the unmount of a mounted non-blank disc fails; erasability is no
+    // longer checked here. Simulate the unmount-failure path.
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [](DeviceProxyManager *, const QString &, bool) {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kOpticalBlank] = false;
+        map[DeviceProperty::kMountPoint] = "/media/sr0";
+        return map;
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, isBlankOpticalDisc), [](const QString &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(ADDR(DeviceManager, unmountBlockDev), [](DeviceManager *, const QString &, const QVariantMap &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_FALSE(job.readyToWork());
+}
+
+TEST_F(UT_BurnJob, mediaChangDected)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    // Product queries media change state through a dfm-mount BlockDevice whose
+    // interface is pure virtual (not stubable). When no block device can be
+    // created the function must return false.
+    stub.set_lamda(ADDR(DeviceHelper, createBlockDevice), [](const QString &) {
+        __DBG_STUB_INVOKE__
+        return BlockDevAutoPtr();
+    });
+
+    EXPECT_FALSE(job.mediaChangDected());
+}
+
+TEST_F(UT_BurnJob, mediaChangDected_NoChange)
+{
+    EraseJob job { "/dev/sr0", nullptr };
+
+    // Set initial device info
+    job.curDeviceInfo[DeviceProperty::kDevice] = "/dev/sr0";
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map[DeviceProperty::kDevice] = "/dev/sr0";   // Same device
+        return map;
+    });
+
+    EXPECT_FALSE(job.mediaChangDected());
+}
+
+TEST_F(UT_BurnJob, comfort)
+{
+    stub.set_lamda(ADDR(AbstractBurnJob, onJobUpdated), []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    EraseJob job { "/dev/sr0", nullptr };
+
+    // Test that comfort method doesn't crash
+    job.comfort();
+}

--- a/autotests/plugins/dfmplugin-burn/test_burnjobmanager.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnjobmanager.cpp
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plugins/common/dfmplugin-burn/utils/burnjobmanager.h"
+#include "plugins/common/dfmplugin-burn/utils/burnjob.h"
+#include "plugins/common/dfmplugin-burn/utils/auditlogjob.h"
+#include "plugins/common/dfmplugin-burn/utils/packetwritingjob.h"
+
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-io/dfileinfo.h>
+
+#include "stubext.h"
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_BurnJobManager : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnJobManager, startEraseDisc)
+{
+    bool triggerAddTask { false };
+    stub.set_lamda(ADDR(DialogManager, addTask), [&triggerAddTask](DialogManager *, const JobHandlePointer task) {
+        __DBG_STUB_INVOKE__
+        triggerAddTask = true;
+        EXPECT_TRUE(task);
+    });
+
+    bool triggerInit { false };
+    stub.set_lamda(ADDR(BurnJobManager, initBurnJobConnect),
+                   [&triggerInit](BurnJobManager *, AbstractBurnJob *job) {
+                       __DBG_STUB_INVOKE__
+                       triggerInit = true;
+                       EXPECT_TRUE(job);
+                       EXPECT_TRUE(qobject_cast<EraseJob *>(job));
+                       EXPECT_EQ(job->curDev, "/test/dev/sr0");
+                   });
+
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart]() {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+    });
+    BurnJobManager::instance()->startEraseDisc("/test/dev/sr0");
+
+    EXPECT_TRUE(triggerAddTask);
+    EXPECT_TRUE(triggerInit);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startBurnISOFiles)
+{
+    bool triggerAddTask { false };
+    stub.set_lamda(ADDR(DialogManager, addTask), [&triggerAddTask](DialogManager *, const JobHandlePointer task) {
+        __DBG_STUB_INVOKE__
+        triggerAddTask = true;
+        EXPECT_TRUE(task);
+    });
+
+    bool triggerInit { false };
+    stub.set_lamda(ADDR(BurnJobManager, initBurnJobConnect),
+                   [&triggerInit](BurnJobManager *, AbstractBurnJob *job) {
+                       __DBG_STUB_INVOKE__
+                       triggerInit = true;
+                       EXPECT_TRUE(job);
+                       EXPECT_TRUE(qobject_cast<BurnISOFilesJob *>(job));
+                       EXPECT_EQ(job->curDev, "/test/dev/sr0");
+                   });
+
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart](QThread *obj, QThread::Priority) {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+        AbstractBurnJob *job { qobject_cast<AbstractBurnJob *>(obj) };
+        EXPECT_TRUE(job);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::KStagingUrl).toUrl(),
+                  QUrl::fromLocalFile("/tmp"));
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kSpeeds).toInt(),
+                  1);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kVolumeName).toString(),
+                  "test");
+    });
+
+    BurnJobManager::Config conf { "test", 1, {} };
+    BurnJobManager::instance()->startBurnISOFiles("/test/dev/sr0",
+                                                  QUrl::fromLocalFile("/tmp"), conf);
+
+    EXPECT_TRUE(triggerAddTask);
+    EXPECT_TRUE(triggerInit);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startBurnISOImage)
+{
+    bool triggerAddTask { false };
+    stub.set_lamda(ADDR(DialogManager, addTask), [&triggerAddTask](DialogManager *, const JobHandlePointer task) {
+        __DBG_STUB_INVOKE__
+        triggerAddTask = true;
+        EXPECT_TRUE(task);
+    });
+
+    bool triggerInit { false };
+    stub.set_lamda(ADDR(BurnJobManager, initBurnJobConnect),
+                   [&triggerInit](BurnJobManager *, AbstractBurnJob *job) {
+                       __DBG_STUB_INVOKE__
+                       triggerInit = true;
+                       EXPECT_TRUE(job);
+                       EXPECT_TRUE(qobject_cast<BurnISOImageJob *>(job));
+                       EXPECT_EQ(job->curDev, "/test/dev/sr0");
+                   });
+
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart](QThread *obj, QThread::Priority) {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+        AbstractBurnJob *job { qobject_cast<AbstractBurnJob *>(obj) };
+        EXPECT_TRUE(job);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kImageUrl).toUrl(),
+                  QUrl::fromLocalFile("/tmp/test.iso"));
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kSpeeds).toInt(),
+                  1);
+    });
+
+    BurnJobManager::Config conf { {}, 1, {} };
+    BurnJobManager::instance()->startBurnISOImage("/test/dev/sr0",
+                                                  QUrl::fromLocalFile("/tmp/test.iso"),
+                                                  conf);
+    EXPECT_TRUE(triggerAddTask);
+    EXPECT_TRUE(triggerInit);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startBurnUDFFiles)
+{
+    bool triggerAddTask { false };
+    stub.set_lamda(ADDR(DialogManager, addTask), [&triggerAddTask](DialogManager *, const JobHandlePointer task) {
+        __DBG_STUB_INVOKE__
+        triggerAddTask = true;
+        EXPECT_TRUE(task);
+    });
+
+    bool triggerInit { false };
+    stub.set_lamda(ADDR(BurnJobManager, initBurnJobConnect),
+                   [&triggerInit](BurnJobManager *, AbstractBurnJob *job) {
+                       __DBG_STUB_INVOKE__
+                       triggerInit = true;
+                       EXPECT_TRUE(job);
+                       EXPECT_TRUE(qobject_cast<BurnUDFFilesJob *>(job));
+                       EXPECT_EQ(job->curDev, "/test/dev/sr0");
+                   });
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart](QThread *obj, QThread::Priority) {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+        AbstractBurnJob *job { qobject_cast<AbstractBurnJob *>(obj) };
+        EXPECT_TRUE(job);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::KStagingUrl).toUrl(),
+                  QUrl::fromLocalFile("/tmp"));
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kSpeeds).toInt(),
+                  1);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kVolumeName).toString(),
+                  "test");
+    });
+
+    BurnJobManager::Config conf { "test", 1, {} };
+    BurnJobManager::instance()->startBurnUDFFiles("/test/dev/sr0",
+                                                  QUrl::fromLocalFile("/tmp"), conf);
+
+    EXPECT_TRUE(triggerAddTask);
+    EXPECT_TRUE(triggerInit);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startDumpISOImage)
+{
+    bool triggerAddTask { false };
+    stub.set_lamda(ADDR(DialogManager, addTask), [&triggerAddTask](DialogManager *, const JobHandlePointer task) {
+        __DBG_STUB_INVOKE__
+        triggerAddTask = true;
+        EXPECT_TRUE(task);
+    });
+
+    bool triggerInit { false };
+    stub.set_lamda(ADDR(BurnJobManager, initDumpJobConnect),
+                   [&triggerInit](BurnJobManager *, AbstractBurnJob *job) {
+                       __DBG_STUB_INVOKE__
+                       triggerInit = true;
+                       EXPECT_TRUE(job);
+                       EXPECT_TRUE(qobject_cast<DumpISOImageJob *>(job));
+                       EXPECT_EQ(job->curDev, "/test/dev/sr0");
+                   });
+
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart](QThread *obj, QThread::Priority) {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+        AbstractBurnJob *job { qobject_cast<AbstractBurnJob *>(obj) };
+        EXPECT_TRUE(job);
+        EXPECT_EQ(job->property(AbstractBurnJob::PropertyType::kImageUrl).toUrl(),
+                  QUrl::fromLocalFile("/tmp/test.iso"));
+    });
+
+    BurnJobManager::instance()->startDumpISOImage("/test/dev/sr0",
+                                                  QUrl::fromLocalFile("/tmp/test.iso"));
+
+    EXPECT_TRUE(triggerAddTask);
+    EXPECT_TRUE(triggerInit);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startAuditLogForCopyFromDisc)
+{
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart] {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+    });
+
+    QList<QUrl> srcs;
+    QList<QUrl> dests;
+    BurnJobManager::instance()->startAuditLogForCopyFromDisc(srcs, dests);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startAuditLogForBurnFiles)
+{
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart] {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+    });
+
+    BurnJobManager::instance()->startAuditLogForBurnFiles({}, {}, {});
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startAuditLogForEraseDisc)
+{
+    bool triggerStart { false };
+    stub.set_lamda(ADDR(QThread, start), [&triggerStart] {
+        __DBG_STUB_INVOKE__
+        triggerStart = true;
+    });
+
+    QVariantMap info;
+    info[DeviceProperty::kDrive] = "/dev/sr0";
+    info[DeviceProperty::kMedia] = "DVD+RW";
+    
+    BurnJobManager::instance()->startAuditLogForEraseDisc(info, true);
+    EXPECT_TRUE(triggerStart);
+}
+
+TEST_F(UT_BurnJobManager, startPutFilesToDisc)
+{
+    bool triggerAddJob { false };
+    stub.set_lamda(ADDR(PacketWritingScheduler, addJob), [&triggerAddJob](PacketWritingScheduler *, AbstractPacketWritingJob *job) {
+        __DBG_STUB_INVOKE__
+        triggerAddJob = true;
+        EXPECT_TRUE(job);
+        EXPECT_TRUE(qobject_cast<PutPacketWritingJob *>(job));
+        EXPECT_EQ(job->device(), "/dev/sr0");
+        
+        QList<QUrl> urls = job->property("pendingUrls").value<QList<QUrl>>();
+        EXPECT_EQ(urls.size(), 2);
+        EXPECT_EQ(urls[0], QUrl::fromLocalFile("/tmp/file1.txt"));
+        EXPECT_EQ(urls[1], QUrl::fromLocalFile("/tmp/file2.txt"));
+    });
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/file1.txt") << QUrl::fromLocalFile("/tmp/file2.txt");
+    
+    BurnJobManager::instance()->startPutFilesToDisc("/dev/sr0", urls);
+    EXPECT_TRUE(triggerAddJob);
+}
+
+TEST_F(UT_BurnJobManager, startRemoveFilesFromDisc)
+{
+    bool triggerAddJob { false };
+    stub.set_lamda(ADDR(PacketWritingScheduler, addJob), [&triggerAddJob](PacketWritingScheduler *, AbstractPacketWritingJob *job) {
+        __DBG_STUB_INVOKE__
+        triggerAddJob = true;
+        EXPECT_TRUE(job);
+        EXPECT_TRUE(qobject_cast<RemovePacketWritingJob *>(job));
+        EXPECT_EQ(job->device(), "/dev/sr0");
+        
+        QList<QUrl> urls = job->property("pendingUrls").value<QList<QUrl>>();
+        EXPECT_EQ(urls.size(), 2);
+        EXPECT_EQ(urls[0], QUrl::fromLocalFile("/media/sr0/file1.txt"));
+        EXPECT_EQ(urls[1], QUrl::fromLocalFile("/media/sr0/file2.txt"));
+    });
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/sr0/file1.txt") << QUrl::fromLocalFile("/media/sr0/file2.txt");
+    
+    BurnJobManager::instance()->startRemoveFilesFromDisc("/dev/sr0", urls);
+    EXPECT_TRUE(triggerAddJob);
+}
+
+TEST_F(UT_BurnJobManager, startRenameFileFromDisc)
+{
+    bool triggerAddJob { false };
+    stub.set_lamda(ADDR(PacketWritingScheduler, addJob), [&triggerAddJob](PacketWritingScheduler *, AbstractPacketWritingJob *job) {
+        __DBG_STUB_INVOKE__
+        triggerAddJob = true;
+        EXPECT_TRUE(job);
+        EXPECT_TRUE(qobject_cast<RenamePacketWritingJob *>(job));
+        EXPECT_EQ(job->device(), "/dev/sr0");
+        
+        QUrl srcUrl = job->property("srcUrl").toUrl();
+        QUrl destUrl = job->property("destUrl").toUrl();
+        EXPECT_EQ(srcUrl, QUrl::fromLocalFile("/media/sr0/oldname.txt"));
+        EXPECT_EQ(destUrl, QUrl::fromLocalFile("/media/sr0/newname.txt"));
+    });
+
+    QUrl srcUrl = QUrl::fromLocalFile("/media/sr0/oldname.txt");
+    QUrl destUrl = QUrl::fromLocalFile("/media/sr0/newname.txt");
+    
+    BurnJobManager::instance()->startRenameFileFromDisc("/dev/sr0", srcUrl, destUrl);
+    EXPECT_TRUE(triggerAddJob);
+}
+
+TEST_F(UT_BurnJobManager, initBurnJobConnect)
+{
+    EraseJob job("/dev/sr_test", {});
+    BurnJobManager::instance()->initBurnJobConnect(&job);
+
+    bool trigger { false };
+    {
+        stub.set_lamda(ADDR(BurnJobManager, showOpticalJobCompletionDialog), [&trigger] {
+            __DBG_STUB_INVOKE__
+            trigger = true;
+        });
+        emit job.requestCompletionDialog({}, {});
+        EXPECT_TRUE(trigger);
+    }
+
+    {
+        trigger = false;
+        stub.set_lamda(ADDR(BurnJobManager, showOpticalJobFailureDialog), [&trigger] {
+            __DBG_STUB_INVOKE__
+            trigger = true;
+        });
+        emit job.requestFailureDialog({}, {}, {});
+        EXPECT_TRUE(trigger);
+    }
+
+    {
+        trigger = false;
+        stub.set_lamda(ADDR(DialogManager, showErrorDialog), [&trigger] {
+            __DBG_STUB_INVOKE__
+            trigger = true;
+        });
+        emit job.requestErrorMessageDialog({}, {});
+        EXPECT_TRUE(trigger);
+    }
+}
+
+TEST_F(UT_BurnJobManager, initDumpJobConnect)
+{
+    DumpISOImageJob job("/dev/sr_test", {});
+    BurnJobManager::instance()->initDumpJobConnect(&job);
+
+    bool trigger { false };
+    {
+        stub.set_lamda(ADDR(BurnJobManager, showOpticalDumpISOSuccessDialog), [&trigger] {
+            __DBG_STUB_INVOKE__
+            trigger = true;
+        });
+        emit job.requestOpticalDumpISOSuccessDialog({});
+        EXPECT_TRUE(trigger);
+    }
+
+    {
+        trigger = false;
+        stub.set_lamda(ADDR(BurnJobManager, showOpticalDumpISOFailedDialog), [&trigger] {
+            __DBG_STUB_INVOKE__
+            trigger = true;
+        });
+        emit job.requestOpticalDumpISOFailedDialog();
+        EXPECT_TRUE(trigger);
+    }
+}
+
+TEST_F(UT_BurnJobManager, deleteStagingDir_NotDir)
+{
+    stub.set_lamda(ADDR(DFMIO::DFileInfo, attribute), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue((int)DFMIO::DFileInfo::AttributeID::kStandardIsFile);
+    });
+
+    QUrl notDirFile { QUrl::fromLocalFile("/test/abc") };
+    EXPECT_FALSE(BurnJobManager::instance()->deleteStagingDir(notDirFile));
+}
+
+TEST_F(UT_BurnJobManager, deleteStagingDir_NotDisc)
+{
+    stub.set_lamda(ADDR(DFMIO::DFileInfo, attribute), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue((int)DFMIO::DFileInfo::AttributeID::kStandardIsDir);
+    });
+
+    QUrl file { QUrl::fromLocalFile("/test/abc") };
+    EXPECT_FALSE(BurnJobManager::instance()->deleteStagingDir(file));
+}
+
+TEST_F(UT_BurnJobManager, deleteStagingDir_Deleted)
+{
+    stub.set_lamda(ADDR(DFMIO::DFileInfo, attribute), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue((int)DFMIO::DFileInfo::AttributeID::kStandardIsDir);
+    });
+
+    stub.set_lamda(ADDR(LocalFileHandler, deleteFileRecursive), [] {
+        return false;
+    });
+    QUrl file { QUrl::fromLocalFile("/test/_dev_sr0") };
+    EXPECT_FALSE(BurnJobManager::instance()->deleteStagingDir(file));
+
+    stub.set_lamda(ADDR(LocalFileHandler, deleteFileRecursive), [] {
+        return true;
+    });
+    file = QUrl::fromLocalFile("/test/_dev_sr0");
+    EXPECT_TRUE(BurnJobManager::instance()->deleteStagingDir(file));
+}
+
+TEST_F(UT_BurnJobManager, showOpticalJobCompletionDialog)
+{
+    bool trigger { false };
+    stub.set_lamda(VADDR(DDialog, exec), [&trigger] {
+        __DBG_STUB_INVOKE__
+        trigger = true;
+        return 0;
+    });
+    BurnJobManager::instance()->showOpticalJobCompletionDialog({}, {});
+    EXPECT_TRUE(trigger);
+}
+
+TEST_F(UT_BurnJobManager, showOpticalJobFailureDialog)
+{
+    bool trigger { false };
+    stub.set_lamda(VADDR(DDialog, exec), [&trigger] {
+        __DBG_STUB_INVOKE__
+        trigger = true;
+        return 0;
+    });
+    BurnJobManager::instance()->showOpticalJobFailureDialog({}, {}, {});
+    EXPECT_TRUE(trigger);
+}
+
+TEST_F(UT_BurnJobManager, showOpticalDumpISOSuccessDialog)
+{
+    bool trigger { false };
+    stub.set_lamda(VADDR(DDialog, exec), [&trigger] {
+        __DBG_STUB_INVOKE__
+        trigger = true;
+        return 0;
+    });
+    BurnJobManager::instance()->showOpticalDumpISOSuccessDialog({});
+    EXPECT_TRUE(trigger);
+}
+
+TEST_F(UT_BurnJobManager, showOpticalDumpISOFailedDialog)
+{
+    bool trigger { false };
+    stub.set_lamda(VADDR(DDialog, exec), [&trigger] {
+        __DBG_STUB_INVOKE__
+        trigger = true;
+        return 0;
+    });
+    BurnJobManager::instance()->showOpticalDumpISOFailedDialog();
+    EXPECT_TRUE(trigger);
+}

--- a/autotests/plugins/dfmplugin-burn/test_burnoptdialog.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnoptdialog.cpp
@@ -1,0 +1,515 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/dialogs/burnoptdialog.h"
+#include "plugins/common/dfmplugin-burn/utils/burnjobmanager.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+
+#include <dfm-burn/dopticaldiscmanager.h>
+#include <dfm-burn/dopticaldiscinfo.h>
+
+#include <QComboBox>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QFile>
+#include <QTemporaryFile>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_BurnOptDialog : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(VADDR(DDialog, exec), [&] { __DBG_STUB_INVOKE__ return QDialog::Accepted; });
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+
+        // Mock WindowUtils to avoid Wayland-specific code
+        stub.set_lamda(ADDR(WindowUtils, isWayLand), [] {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+        stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        dialog = new BurnOptDialog("/dev/sr0");
+    }
+
+    virtual void TearDown() override
+    {
+        delete dialog;
+        dialog = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    BurnOptDialog *dialog = nullptr;
+};
+
+TEST_F(UT_BurnOptDialog, Constructor)
+{
+    EXPECT_EQ(dialog->curDev, "/dev/sr0");
+    EXPECT_TRUE(dialog->isModal());
+}
+
+TEST_F(UT_BurnOptDialog, Constructor_Wayland)
+{
+    stub.set_lamda(ADDR(WindowUtils, isWayLand), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    BurnOptDialog waylandDialog("/dev/sr1");
+    EXPECT_EQ(waylandDialog.curDev, "/dev/sr1");
+}
+
+TEST_F(UT_BurnOptDialog, setUDFSupported_Supported)
+{
+    dialog->setUDFSupported(true, false);
+
+    EXPECT_TRUE(dialog->isSupportedUDF);
+}
+
+TEST_F(UT_BurnOptDialog, setUDFSupported_NotSupported)
+{
+    dialog->setUDFSupported(false, false);
+
+    EXPECT_FALSE(dialog->isSupportedUDF);
+}
+
+TEST_F(UT_BurnOptDialog, setUDFSupported_DisableISOOpts)
+{
+    dialog->setUDFSupported(true, true);
+
+    EXPECT_TRUE(dialog->isSupportedUDF);
+    // When ISO options are disabled, UDF should be selected by default
+    EXPECT_EQ(dialog->fsComb->currentIndex(), 3);
+}
+
+TEST_F(UT_BurnOptDialog, setISOImage_ValidImage)
+{
+    QTemporaryFile tempFile;
+    ASSERT_TRUE(tempFile.open());
+    QUrl imageUrl = QUrl::fromLocalFile(tempFile.fileName());
+
+    // Mock DOpticalDiscManager
+    stub.set_lamda(ADDR(DFMBURN::DOpticalDiscManager, createOpticalInfo), [] {
+        __DBG_STUB_INVOKE__
+        auto info = new DFMBURN::DOpticalDiscInfo();
+        // Mock volumeName method
+        return info;
+    });
+
+    EXPECT_NO_THROW(dialog->setISOImage(imageUrl));
+
+    EXPECT_EQ(dialog->imageFile, imageUrl);
+    EXPECT_FALSE(dialog->finalizeDiscCheckbox->isVisible());
+    EXPECT_FALSE(dialog->fsComb->isVisible());
+    EXPECT_FALSE(dialog->volnameEdit->isEnabled());
+}
+
+TEST_F(UT_BurnOptDialog, setISOImage_InvalidImage)
+{
+    QUrl invalidUrl = QUrl::fromLocalFile("/non/existent/file.iso");
+
+    stub.set_lamda(ADDR(DFMBURN::DOpticalDiscManager, createOpticalInfo), [] {
+        __DBG_STUB_INVOKE__
+        return nullptr;   // Return null for invalid image
+    });
+
+    dialog->setISOImage(invalidUrl);
+
+    EXPECT_EQ(dialog->imageFile, invalidUrl);
+}
+
+TEST_F(UT_BurnOptDialog, setDefaultVolName)
+{
+    QString testVolName = "TestVolume";
+
+    dialog->setDefaultVolName(testVolName);
+
+    EXPECT_EQ(dialog->volnameEdit->text(), testVolName);
+    EXPECT_EQ(dialog->lastVolName, testVolName);
+    EXPECT_TRUE(dialog->volnameEdit->hasSelectedText());
+}
+
+TEST_F(UT_BurnOptDialog, setDefaultVolName_Empty)
+{
+    QString emptyVolName = "";
+
+    dialog->setDefaultVolName(emptyVolName);
+
+    EXPECT_TRUE(dialog->volnameEdit->text().isEmpty());
+    EXPECT_TRUE(dialog->lastVolName.isEmpty());
+}
+
+TEST_F(UT_BurnOptDialog, setWriteSpeedInfo)
+{
+    QStringList speedInfo;
+    speedInfo << "1\t1.0"
+              << "2\t2.0"
+              << "4\t4.0"
+              << "8\t8.0";
+
+    dialog->setWriteSpeedInfo(speedInfo);
+
+    EXPECT_GT(dialog->writespeedComb->count(), 1);   // Should have more than just "Maximum"
+    EXPECT_TRUE(dialog->speedMap.contains("1.0x"));
+    EXPECT_TRUE(dialog->speedMap.contains("2.0x"));
+    EXPECT_TRUE(dialog->speedMap.contains("4.0x"));
+    EXPECT_TRUE(dialog->speedMap.contains("8.0x"));
+    EXPECT_EQ(dialog->speedMap["1.0x"], 1);
+    EXPECT_EQ(dialog->speedMap["4.0x"], 4);
+}
+
+TEST_F(UT_BurnOptDialog, setWriteSpeedInfo_EmptyList)
+{
+    QStringList emptySpeedInfo;
+
+    dialog->setWriteSpeedInfo(emptySpeedInfo);
+
+    EXPECT_EQ(dialog->writespeedComb->count(), 1);   // Should only have "Maximum"
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_DefaultOptions)
+{
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    // Default options should include KeepAppendable and EjectDisc
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kKeepAppendable);
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kEjectDisc);
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kJolietSupport);   // Default filesystem
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_VerifyData)
+{
+    dialog->checkdiscCheckbox->setChecked(true);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kVerifyDatas);
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_NoEject)
+{
+    dialog->ejectCheckbox->setChecked(false);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_FALSE(opts & DFMBURN::BurnOption::kEjectDisc);
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_NoAppendable)
+{
+    // Product semantics: checked "finalize disc" means NO appendable
+    dialog->finalizeDiscCheckbox->setChecked(true);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_FALSE(opts & DFMBURN::BurnOption::kKeepAppendable);
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_ISO9660Only)
+{
+    dialog->fsComb->setCurrentIndex(0);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kISO9660Only);
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_RockRidge)
+{
+    dialog->fsComb->setCurrentIndex(2);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kRockRidgeSupport);
+}
+
+TEST_F(UT_BurnOptDialog, currentBurnOptions_UDF)
+{
+    dialog->fsComb->setCurrentIndex(3);
+
+    DFMBURN::BurnOptions opts = dialog->currentBurnOptions();
+
+    EXPECT_TRUE(opts & DFMBURN::BurnOption::kUDF102Supported);
+}
+
+TEST_F(UT_BurnOptDialog, startDataBurn_ISOFiles)
+{
+    bool startBurnISOFilesCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startBurnISOFiles), [&startBurnISOFilesCalled] {
+        __DBG_STUB_INVOKE__
+        startBurnISOFilesCalled = true;
+    });
+
+    using LocalStagingFileFunc = QUrl (*)(QString);
+    stub.set_lamda(static_cast<LocalStagingFileFunc>(&BurnHelper::localStagingFile), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/tmp/staging");
+    });
+
+    dialog->volnameEdit->setText("TestVolume");
+    dialog->fsComb->setCurrentIndex(1);   // Joliet
+
+    dialog->startDataBurn();
+
+    EXPECT_TRUE(startBurnISOFilesCalled);
+}
+
+TEST_F(UT_BurnOptDialog, startDataBurn_UDFFiles)
+{
+    bool startBurnUDFFilesCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startBurnUDFFiles), [&startBurnUDFFilesCalled] {
+        __DBG_STUB_INVOKE__
+        startBurnUDFFilesCalled = true;
+    });
+
+    using LocalStagingFileFunc = QUrl (*)(QString);
+    stub.set_lamda(static_cast<LocalStagingFileFunc>(&BurnHelper::localStagingFile), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/tmp/staging");
+    });
+
+    dialog->volnameEdit->setText("TestVolume");
+    dialog->fsComb->setCurrentIndex(3);   // UDF
+
+    dialog->startDataBurn();
+
+    EXPECT_TRUE(startBurnUDFFilesCalled);
+}
+
+TEST_F(UT_BurnOptDialog, startDataBurn_EmptyVolumeName)
+{
+    bool startBurnISOFilesCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startBurnISOFiles), [&startBurnISOFilesCalled] {
+        __DBG_STUB_INVOKE__
+        startBurnISOFilesCalled = true;
+    });
+
+    using LocalStagingFileFunc = QUrl (*)(QString);
+    stub.set_lamda(static_cast<LocalStagingFileFunc>(&BurnHelper::localStagingFile), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/tmp/staging");
+    });
+
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    dialog->volnameEdit->clear();
+    dialog->lastVolName = "DefaultVolume";
+
+    dialog->startDataBurn();
+
+    EXPECT_TRUE(startBurnISOFilesCalled);
+}
+
+TEST_F(UT_BurnOptDialog, startImageBurn)
+{
+    bool startBurnISOImageCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startBurnISOImage), [&startBurnISOImageCalled] {
+        __DBG_STUB_INVOKE__
+        startBurnISOImageCalled = true;
+    });
+
+    QTemporaryFile tempFile;
+    ASSERT_TRUE(tempFile.open());
+    dialog->imageFile = QUrl::fromLocalFile(tempFile.fileName());
+
+    dialog->startImageBurn();
+
+    EXPECT_TRUE(startBurnISOImageCalled);
+}
+
+TEST_F(UT_BurnOptDialog, onIndexChanged_UDFSelected)
+{
+    dialog->onIndexChanged(3);   // UDF index
+
+    EXPECT_FALSE(dialog->checkdiscCheckbox->isChecked());
+    EXPECT_FALSE(dialog->checkdiscCheckbox->isEnabled());
+    // Product unchecks finalizeDiscCheckbox for UDF and leaves it enabled
+    EXPECT_FALSE(dialog->finalizeDiscCheckbox->isChecked());
+    EXPECT_TRUE(dialog->finalizeDiscCheckbox->isEnabled());
+    EXPECT_EQ(dialog->writespeedComb->currentIndex(), 0);
+    EXPECT_FALSE(dialog->writespeedComb->isEnabled());
+}
+
+TEST_F(UT_BurnOptDialog, onIndexChanged_NonUDFSelected)
+{
+    // First set UDF to disable controls
+    dialog->onIndexChanged(3);
+
+    // Then select non-UDF to re-enable controls
+    dialog->onIndexChanged(1);   // Joliet
+
+    EXPECT_TRUE(dialog->checkdiscCheckbox->isEnabled());
+    EXPECT_TRUE(dialog->finalizeDiscCheckbox->isEnabled());
+    EXPECT_TRUE(dialog->writespeedComb->isEnabled());
+}
+
+TEST_F(UT_BurnOptDialog, onButnBtnClicked_Burn_DeviceExists)
+{
+    bool startDataBurnCalled = false;
+
+    stub.set_lamda(ADDR(BurnOptDialog, startDataBurn), [&startDataBurnCalled] {
+        __DBG_STUB_INVOKE__
+        startDataBurnCalled = true;
+    });
+
+    // onButnBtnClicked checks device existence through the member overload
+    // QFile::exists() const (the static overload is NOT called here)
+    using QFileMemberExistsFunc = bool (QFile::*)() const;
+    stub.set_lamda(static_cast<QFileMemberExistsFunc>(&QFile::exists), [](QFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    dialog->imageFile = QUrl();   // Empty image file means data burn
+
+    dialog->onButnBtnClicked(1, "Burn");
+
+    EXPECT_TRUE(startDataBurnCalled);
+}
+
+TEST_F(UT_BurnOptDialog, onButnBtnClicked_Burn_ImageBurn)
+{
+    bool startImageBurnCalled = false;
+
+    stub.set_lamda(ADDR(BurnOptDialog, startImageBurn), [&startImageBurnCalled] {
+        __DBG_STUB_INVOKE__
+        startImageBurnCalled = true;
+    });
+
+    // onButnBtnClicked checks device existence through the member overload
+    // QFile::exists() const (the static overload is NOT called here)
+    using QFileMemberExistsFunc = bool (QFile::*)() const;
+    stub.set_lamda(static_cast<QFileMemberExistsFunc>(&QFile::exists), [](QFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QTemporaryFile tempFile;
+    ASSERT_TRUE(tempFile.open());
+    dialog->imageFile = QUrl::fromLocalFile(tempFile.fileName());
+
+    dialog->onButnBtnClicked(1, "Burn");
+
+    EXPECT_TRUE(startImageBurnCalled);
+}
+
+TEST_F(UT_BurnOptDialog, onButnBtnClicked_Burn_DeviceNotExists)
+{
+    bool errorDialogShown = false;
+
+    stub.set_lamda(ADDR(DialogManager, showErrorDialog), [&errorDialogShown] {
+        __DBG_STUB_INVOKE__
+        errorDialogShown = true;
+    });
+
+    using QFileExistsFunc = bool (*)(const QString &);
+    stub.set_lamda(static_cast<QFileExistsFunc>(&QFile::exists), [] {
+        __DBG_STUB_INVOKE__
+        return false;   // Device doesn't exist
+    });
+
+    dialog->onButnBtnClicked(1, "Burn");
+
+    EXPECT_TRUE(errorDialogShown);
+}
+
+TEST_F(UT_BurnOptDialog, volnameEdit_TextChanged_ValidLength)
+{
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QString validText = "ValidVolumeName";
+
+    dialog->volnameEdit->setText(validText);
+
+    EXPECT_EQ(dialog->volnameEdit->text(), validText);
+}
+
+TEST_F(UT_BurnOptDialog, volnameEdit_TextChanged_TooLong)
+{
+    // Create a string longer than 30 characters
+    QString longText = "This_is_a_very_long_volume_name_that_exceeds_the_limit";
+
+    dialog->volnameEdit->setText(longText);
+
+    // The text should be truncated to fit within the limit
+    EXPECT_LE(dialog->volnameEdit->text().toUtf8().length(), 30);
+}
+
+TEST_F(UT_BurnOptDialog, advanceBtn_Toggle)
+{
+    // Initially advanced settings should be hidden
+    EXPECT_TRUE(dialog->advancedSettings->isHidden());
+
+    // Simulate clicking the advance button
+    emit dialog->advanceBtn->clicked();
+
+    // Advanced settings should now be visible
+    EXPECT_FALSE(dialog->advancedSettings->isHidden());
+
+    // Click again to hide
+    emit dialog->advanceBtn->clicked();
+
+    // Should be hidden again
+    EXPECT_TRUE(dialog->advancedSettings->isHidden());
+}
+
+TEST_F(UT_BurnOptDialog, UI_Components_Existence)
+{
+    // Test that all UI components are properly created
+    EXPECT_TRUE(dialog->volnameLabel != nullptr);
+    EXPECT_TRUE(dialog->volnameEdit != nullptr);
+    EXPECT_TRUE(dialog->advanceBtn != nullptr);
+    EXPECT_TRUE(dialog->advancedSettings != nullptr);
+    EXPECT_TRUE(dialog->fsLabel != nullptr);
+    EXPECT_TRUE(dialog->fsComb != nullptr);
+    EXPECT_TRUE(dialog->writespeedLabel != nullptr);
+    EXPECT_TRUE(dialog->writespeedComb != nullptr);
+    EXPECT_TRUE(dialog->finalizeDiscCheckbox != nullptr);
+    EXPECT_TRUE(dialog->checkdiscCheckbox != nullptr);
+    EXPECT_TRUE(dialog->ejectCheckbox != nullptr);
+}
+
+TEST_F(UT_BurnOptDialog, UI_DefaultValues)
+{
+    // Test default values
+    EXPECT_EQ(dialog->fsComb->currentIndex(), 1);   // Default to Joliet
+    EXPECT_FALSE(dialog->finalizeDiscCheckbox->isChecked());   // Unchecked by default
+    EXPECT_TRUE(dialog->ejectCheckbox->isChecked());
+    EXPECT_FALSE(dialog->checkdiscCheckbox->isChecked());
+    EXPECT_EQ(dialog->writespeedComb->itemText(0), QObject::tr("Maximum"));
+}
+
+TEST_F(UT_BurnOptDialog, speedMap_DefaultMaximum)
+{
+    EXPECT_TRUE(dialog->speedMap.contains(QObject::tr("Maximum")));
+    EXPECT_EQ(dialog->speedMap[QObject::tr("Maximum")], 0);
+}

--- a/autotests/plugins/dfmplugin-burn/test_discstatemanager.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_discstatemanager.cpp
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/discstatemanager.h"
+
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+
+#include <QSignalSpy>
+#include <QVariant>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_DiscStateManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DiscStateManager, instance)
+{
+    DiscStateManager *manager1 = DiscStateManager::instance();
+    DiscStateManager *manager2 = DiscStateManager::instance();
+
+    EXPECT_TRUE(manager1 != nullptr);
+    EXPECT_EQ(manager1, manager2);   // Should be singleton
+}
+
+TEST_F(UT_DiscStateManager, initilaize)
+{
+    DiscStateManager::instance()->initilaize();
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc)
+{
+    bool getAllBlockIdsCalled = false;
+
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [&getAllBlockIdsCalled] {
+        __DBG_STUB_INVOKE__
+        getAllBlockIdsCalled = true;
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    bool queryBlockInfoCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryBlockInfoCalled] {
+        __DBG_STUB_INVOKE__
+        queryBlockInfoCalled = true;
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kMountPoint] = QString();   // Not mounted
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_TRUE(getAllBlockIdsCalled);
+    EXPECT_TRUE(queryBlockInfoCalled);
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_NoOpticalDevices)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sda1";   // Not optical
+        return ids;
+    });
+
+    bool queryBlockInfoCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryBlockInfoCalled] {
+        __DBG_STUB_INVOKE__
+        queryBlockInfoCalled = true;
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = false;   // Not optical
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    // Product filters devices by the "sr" prefix before querying, so a non-sr
+    // device is never queried nor mounted
+    EXPECT_FALSE(queryBlockInfoCalled);
+    EXPECT_FALSE(mountCalled);   // Should not mount non-optical devices
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_NotBlank)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = false;   // Not blank
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount non-blank discs
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_AlreadyMounted)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    // Product mounts blank discs whose free size is 0 (no mount-point check);
+    // a blank disc with free space must not be mounted
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kSizeFree] = 100;   // Has data, no ghost mount
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount blank discs that have free space
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OpticalBlank)
+{
+    // Product handles blank optical discs directly in onDevicePropertyChanged:
+    // it queries info and mounts when blank && free size is 0
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [](DeviceProxyManager *, const QString &, bool) {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kSizeFree] = 0;
+        return info;
+    });
+
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled](DeviceManager *, const QString &, const QVariantMap &, CallbackType1, int) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            DeviceProperty::kOptical,
+            QVariant(true));
+
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OpticalBlank_False)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            "OpticalBlank",
+            QVariant(false));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for non-blank
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OtherProperty)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            "SomeOtherProperty",
+            QVariant("value"));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for other properties
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_NonOpticalDevice)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sda1",   // Not optical
+            "OpticalBlank",
+            QVariant(true));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for non-optical devices
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_EmptyDeviceList)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        return QStringList();   // Empty list
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount anything
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_MultipleDevices)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0"
+            << "/org/freedesktop/UDisks2/block_devices/sr1"
+            << "/org/freedesktop/UDisks2/block_devices/sda1";   // Mix of optical and non-optical
+        return ids;
+    });
+
+    int queryCount = 0;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryCount](DeviceProxyManager *, const QString &id, bool reload) {
+        __DBG_STUB_INVOKE__
+        queryCount++;
+        QVariantMap info;
+        if (id.contains("sr")) {
+            info[DeviceProperty::kOptical] = true;
+            info[DeviceProperty::kOpticalBlank] = true;
+            info[DeviceProperty::kMountPoint] = QString();
+        } else {
+            info[DeviceProperty::kOptical] = false;
+        }
+        return info;
+    });
+
+    int mountCount = 0;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCount] {
+        __DBG_STUB_INVOKE__
+        mountCount++;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_EQ(queryCount, 2);   // Only the two "sr" devices are queried; sda1 is skipped
+    EXPECT_EQ(mountCount, 2);   // Should only mount the two optical devices
+}

--- a/autotests/plugins/dfmplugin-burn/test_dumpisooptdialog.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_dumpisooptdialog.cpp
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.h"
+#include "plugins/common/dfmplugin-burn/utils/burnjobmanager.h"
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+
+#include <DFileDialog>
+#include <QStandardPaths>
+#include <QPushButton>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_DumpISOOptDialog : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(VADDR(DDialog, exec), [&] { __DBG_STUB_INVOKE__
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });                                             return QDialog::Accepted; });
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+
+        // Mock WindowUtils to avoid Wayland-specific code
+        stub.set_lamda(ADDR(WindowUtils, isWayLand), [] {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        // Mock device info
+        stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+            __DBG_STUB_INVOKE__
+            QVariantMap info;
+            info[DeviceProperty::kIdLabel] = "TestDisc";
+            info[DeviceProperty::kDevice] = "/dev/sr0";
+            info[DeviceProperty::kUDisks2Size] = 700000000ULL;   // 700MB
+            return info;
+        });
+
+        dialog = new DumpISOOptDialog("/org/freedesktop/UDisks2/block_devices/sr0");
+    }
+
+    virtual void TearDown() override
+    {
+        delete dialog;
+        dialog = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    DumpISOOptDialog *dialog = nullptr;
+};
+
+TEST_F(UT_DumpISOOptDialog, Constructor)
+{
+    EXPECT_EQ(dialog->curDevId, "/org/freedesktop/UDisks2/block_devices/sr0");
+    EXPECT_TRUE(dialog->isModal());
+    EXPECT_EQ(dialog->curDiscName, "TestDisc");
+    EXPECT_EQ(dialog->curDev, "/dev/sr0");
+}
+
+TEST_F(UT_DumpISOOptDialog, Constructor_Wayland)
+{
+    stub.set_lamda(ADDR(WindowUtils, isWayLand), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    DumpISOOptDialog waylandDialog("/org/freedesktop/UDisks2/block_devices/sr1");
+    EXPECT_EQ(waylandDialog.curDevId, "/org/freedesktop/UDisks2/block_devices/sr1");
+}
+
+TEST_F(UT_DumpISOOptDialog, Constructor_EmptyDiscName)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kIdLabel] = "";   // Empty label
+        info[DeviceProperty::kDevice] = "/dev/sr0";
+        info[DeviceProperty::kUDisks2Size] = 700000000ULL;
+        return info;
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, nameOfDefault), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DefaultName");
+    });
+
+    DumpISOOptDialog emptyNameDialog("/org/freedesktop/UDisks2/block_devices/sr0");
+    EXPECT_EQ(emptyNameDialog.curDiscName, "DefaultName");
+}
+
+TEST_F(UT_DumpISOOptDialog, initData_ValidDiscName)
+{
+    EXPECT_EQ(dialog->curDiscName, "TestDisc");
+    EXPECT_EQ(dialog->curDev, "/dev/sr0");
+}
+
+TEST_F(UT_DumpISOOptDialog, onButtonClicked_Cancel)
+{
+    dialog->onButtonClicked(0, "Cancel");
+
+    // Should not trigger any dump operations
+    // No assertions needed as this is a cancel operation
+}
+
+TEST_F(UT_DumpISOOptDialog, onButtonClicked_CreateImage_ValidPath)
+{
+    bool startDumpISOImageCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startDumpISOImage), [&startDumpISOImageCalled] {
+        __DBG_STUB_INVOKE__
+        startDumpISOImageCalled = true;
+    });
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/tmp/test.iso");
+    });
+
+    dialog->fileChooser->setText("/tmp/test.iso");
+    dialog->onButtonClicked(1, "Create ISO Image");
+
+    EXPECT_TRUE(startDumpISOImageCalled);
+}
+
+TEST_F(UT_DumpISOOptDialog, onButtonClicked_CreateImage_InvalidPath)
+{
+    bool startDumpISOImageCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startDumpISOImage), [&startDumpISOImageCalled] {
+        __DBG_STUB_INVOKE__
+        startDumpISOImageCalled = true;
+    });
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl();   // Invalid URL
+    });
+
+    dialog->fileChooser->setText("");
+    dialog->onButtonClicked(1, "Create ISO Image");
+
+    EXPECT_TRUE(startDumpISOImageCalled);   // Should still be called even with invalid path
+}
+
+TEST_F(UT_DumpISOOptDialog, onButtonClicked_CreateImage_EmptyDevice)
+{
+    bool startDumpISOImageCalled = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startDumpISOImage), [&startDumpISOImageCalled] {
+        __DBG_STUB_INVOKE__
+        startDumpISOImageCalled = true;
+    });
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/tmp/test.iso");
+    });
+
+    dialog->curDev = "";   // Empty device
+    dialog->onButtonClicked(1, "Create ISO Image");
+
+    EXPECT_TRUE(startDumpISOImageCalled);   // Should still be called
+}
+
+TEST_F(UT_DumpISOOptDialog, onFileChoosed_ValidPath)
+{
+    QString testPath = "/tmp/testdir";
+
+    // Mock file doesn't exist initially
+    bool fileExists = false;
+    stub.set_lamda(VADDR(SyncFileInfo, exists), [&fileExists] {
+        __DBG_STUB_INVOKE__
+        return fileExists;
+    });
+
+    dialog->onFileChoosed(testPath);
+
+    QString expectedPath = testPath + "/" + dialog->curDiscName + ".iso";
+    EXPECT_EQ(dialog->fileChooser->text(), expectedPath);
+}
+
+TEST_F(UT_DumpISOOptDialog, onFileChoosed_FileExists_GenerateSerial)
+{
+    QString testPath = "/tmp/testdir";
+
+    // Mock file exists for first attempt, then doesn't exist
+    int callCount = 0;
+    stub.set_lamda(VADDR(SyncFileInfo, exists), [&callCount] {
+        __DBG_STUB_INVOKE__
+        return (callCount++ == 0);   // First call returns true, second returns false
+    });
+
+    dialog->onFileChoosed(testPath);
+
+    QString expectedPath = testPath + "/" + dialog->curDiscName + "(1).iso";
+    EXPECT_EQ(dialog->fileChooser->text(), expectedPath);
+}
+
+TEST_F(UT_DumpISOOptDialog, onFileChoosed_MaxSerialReached)
+{
+    QString testPath = "/tmp/testdir";
+
+    // Mock file always exists to trigger max serial scenario.
+    stub.set_lamda(VADDR(SyncFileInfo, exists), [] {
+        __DBG_STUB_INVOKE__
+        return true;   // Always exists
+    });
+
+    dialog->onFileChoosed(testPath);
+
+    // Should handle max serial gracefully (implementation should log warning and return)
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_ValidLocalPath)
+{
+    QString validPath = "/tmp/test.iso";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [&validPath] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile(validPath);
+    });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isRemoteFile), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isSMBFile), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    dialog->onPathChanged(validPath);
+
+    EXPECT_TRUE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_EmptyPath)
+{
+    QString emptyPath = "";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    dialog->onPathChanged(emptyPath);
+
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_InvalidUrl)
+{
+    QString invalidPath = "invalid://path";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        QUrl url("invalid://path");
+        url.setScheme("invalid");
+        return url;
+    });
+
+    dialog->onPathChanged(invalidPath);
+
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_RemoteFile)
+{
+    QString remotePath = "/remote/path/test.iso";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/remote/path/test.iso");
+    });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isRemoteFile), [] {
+        __DBG_STUB_INVOKE__
+        return true;   // Is remote file
+    });
+
+    dialog->onPathChanged(remotePath);
+
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_SMBFile)
+{
+    QString smbPath = "smb://server/share/test.iso";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        return QUrl("smb://server/share/test.iso");
+    });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isRemoteFile), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isSMBFile), [] {
+        __DBG_STUB_INVOKE__
+        return true;   // Is SMB file
+    });
+
+    dialog->onPathChanged(smbPath);
+
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, onPathChanged_NonLocalFile)
+{
+    QString httpPath = "http://example.com/test.iso";
+
+    using FromUserInputFunc = QUrl (*)(const QString &, bool);
+    stub.set_lamda(static_cast<FromUserInputFunc>(&UrlRoute::fromUserInput), [] {
+        __DBG_STUB_INVOKE__
+        QUrl url("http://example.com/test.iso");
+        return url;
+    });
+
+    dialog->onPathChanged(httpPath);
+
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());
+}
+
+TEST_F(UT_DumpISOOptDialog, UI_Components_Existence)
+{
+    // Test that all UI components are properly created
+    EXPECT_TRUE(dialog->contentWidget != nullptr);
+    EXPECT_TRUE(dialog->saveAsImgLabel != nullptr);
+    EXPECT_TRUE(dialog->commentLabel != nullptr);
+    EXPECT_TRUE(dialog->savePathLabel != nullptr);
+    EXPECT_TRUE(dialog->fileChooser != nullptr);
+    EXPECT_TRUE(dialog->createImgBtn != nullptr);
+}
+
+TEST_F(UT_DumpISOOptDialog, UI_DefaultValues)
+{
+    // Test initial UI state
+    EXPECT_FALSE(dialog->createImgBtn->isEnabled());   // Should be disabled initially
+    EXPECT_EQ(dialog->fileChooser->fileMode(), QFileDialog::FileMode::Directory);
+}
+
+TEST_F(UT_DumpISOOptDialog, UI_DefaultDirectory)
+{
+    // Test that default directory is set to Documents
+    QString expectedPath = QStandardPaths::writableLocation(QStandardPaths::StandardLocation::DocumentsLocation);
+    QUrl expectedUrl = QUrl::fromLocalFile(expectedPath);
+
+    // The fileChooser should be set to Documents directory by default
+    EXPECT_EQ(dialog->fileChooser->directoryUrl(), expectedUrl);
+}
+
+TEST_F(UT_DumpISOOptDialog, Dialog_Properties)
+{
+    // Test dialog properties
+    EXPECT_TRUE(dialog->isModal());
+    EXPECT_EQ(dialog->size(), QSize(400, 242));
+}
+
+TEST_F(UT_DumpISOOptDialog, Signal_Connections)
+{
+    // Test that signals are properly connected by emitting them
+    bool buttonClickedConnected = false;
+    bool fileChoosedConnected = false;
+    bool textChangedConnected = false;
+
+    // Connect to test signals
+    QObject::connect(dialog, &DumpISOOptDialog::buttonClicked, [&buttonClickedConnected] {
+        buttonClickedConnected = true;
+    });
+
+    QObject::connect(dialog->fileChooser, &DFileChooserEdit::fileChoosed, [&fileChoosedConnected] {
+        fileChoosedConnected = true;
+    });
+
+    QObject::connect(dialog->fileChooser, &DFileChooserEdit::textChanged, [&textChangedConnected] {
+        textChangedConnected = true;
+    });
+
+    // Emit signals to test connections
+    emit dialog->buttonClicked(0, "test");
+    emit dialog->fileChooser->fileChoosed("/test/path");
+    emit dialog->fileChooser->textChanged("/test/text");
+
+    EXPECT_TRUE(buttonClickedConnected);
+    EXPECT_TRUE(fileChoosedConnected);
+    EXPECT_TRUE(textChangedConnected);
+}
+
+TEST_F(UT_DumpISOOptDialog, Destructor)
+{
+    // Test that destructor doesn't crash
+    DumpISOOptDialog *testDialog = new DumpISOOptDialog("/org/freedesktop/UDisks2/block_devices/sr0");
+    delete testDialog;
+
+    // If we reach here, destructor worked correctly
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_DumpISOOptDialog, initData_DeviceInfoRetrieval)
+{
+    // Test that device info is properly retrieved during initialization
+    EXPECT_FALSE(dialog->curDiscName.isEmpty());
+    EXPECT_FALSE(dialog->curDev.isEmpty());
+    EXPECT_EQ(dialog->curDiscName, "TestDisc");
+    EXPECT_EQ(dialog->curDev, "/dev/sr0");
+}

--- a/autotests/plugins/dfmplugin-burn/test_packetwritingjob.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_packetwritingjob.cpp
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/packetwritingjob.h"
+
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-burn/dpacketwritingcontroller.h>
+
+#include <DDialog>
+
+#include <QTimer>
+#include <QThread>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFM_BURN_USE_NS
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_PacketWritingJob : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Setup common stubs if needed
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_PacketWritingJob, PacketWritingScheduler_instance)
+{
+    PacketWritingScheduler &scheduler1 = PacketWritingScheduler::instance();
+    PacketWritingScheduler &scheduler2 = PacketWritingScheduler::instance();
+
+    EXPECT_EQ(&scheduler1, &scheduler2);   // Should be singleton
+}
+
+TEST_F(UT_PacketWritingJob, PacketWritingScheduler_addJob)
+{
+    bool timerStarted = false;
+
+    // QTimer::start() has overloads, stub the parameterless version
+    stub.set_lamda(static_cast<void (QTimer::*)()>(&QTimer::start), [&timerStarted] {
+        __DBG_STUB_INVOKE__
+        timerStarted = true;
+    });
+
+    PutPacketWritingJob *job = new PutPacketWritingJob("/dev/sr0");
+    PacketWritingScheduler::instance().addJob(job);
+
+    EXPECT_TRUE(timerStarted);
+
+    // Note: Job will be managed by the scheduler, don't delete manually
+}
+
+TEST_F(UT_PacketWritingJob, PacketWritingScheduler_onTimeout)
+{
+    bool jobStarted = false;
+
+    stub.set_lamda(ADDR(QThread, start), [&jobStarted] {
+        __DBG_STUB_INVOKE__
+        jobStarted = true;
+    });
+
+    PutPacketWritingJob *job = new PutPacketWritingJob("/dev/sr0");
+    PacketWritingScheduler::instance().addJob(job);
+
+    // Manually trigger timeout
+    PacketWritingScheduler::instance().onTimeout();
+
+    EXPECT_TRUE(jobStarted);
+
+    // Note: Job will be managed by the scheduler, don't delete manually
+}
+
+TEST_F(UT_PacketWritingJob, AbstractPacketWritingJob_Constructor)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    EXPECT_EQ(job.device(), "/dev/sr0");
+}
+
+TEST_F(UT_PacketWritingJob, AbstractPacketWritingJob_urls2Names)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/file1.txt")
+         << QUrl::fromLocalFile("/tmp/file2.txt")
+         << QUrl::fromLocalFile("/tmp/subdir/file3.txt");
+
+    QStringList names = job.urls2Names(urls);
+
+    EXPECT_EQ(names.size(), 3);
+    EXPECT_TRUE(names.contains("file1.txt"));
+    EXPECT_TRUE(names.contains("file2.txt"));
+    EXPECT_TRUE(names.contains("file3.txt"));
+}
+
+TEST_F(UT_PacketWritingJob, AbstractPacketWritingJob_urls2Names_EmptyList)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> emptyUrls;
+    QStringList names = job.urls2Names(emptyUrls);
+
+    EXPECT_TRUE(names.isEmpty());
+}
+
+TEST_F(UT_PacketWritingJob, PutPacketWritingJob_Constructor)
+{
+    PutPacketWritingJob job("/dev/sr1");
+
+    EXPECT_EQ(job.device(), "/dev/sr1");
+}
+
+TEST_F(UT_PacketWritingJob, PutPacketWritingJob_setPendingUrls)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/file1.txt")
+         << QUrl::fromLocalFile("/tmp/file2.txt");
+
+    job.setPendingUrls(urls);
+
+    QList<QUrl> retrievedUrls = job.getPendingUrls();
+    EXPECT_EQ(retrievedUrls.size(), 2);
+    EXPECT_EQ(retrievedUrls[0], QUrl::fromLocalFile("/tmp/file1.txt"));
+    EXPECT_EQ(retrievedUrls[1], QUrl::fromLocalFile("/tmp/file2.txt"));
+}
+
+TEST_F(UT_PacketWritingJob, PutPacketWritingJob_work_Success)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/file1.txt");
+    job.setPendingUrls(urls);
+
+    bool putCalled = false;
+    stub.set_lamda(ADDR(DFMBURN::DPacketWritingController, put), [&putCalled] {
+        __DBG_STUB_INVOKE__
+        putCalled = true;
+        return true;
+    });
+
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+
+    bool result = job.work();
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(putCalled);
+}
+
+TEST_F(UT_PacketWritingJob, PutPacketWritingJob_work_Failure)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/file1.txt");
+    job.setPendingUrls(urls);
+
+    stub.set_lamda(ADDR(DFMBURN::DPacketWritingController, put), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_PacketWritingJob, PutPacketWritingJob_work_EmptyUrls)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    // Don't set any URLs
+    bool result = job.work();
+    EXPECT_FALSE(result);   // Should fail with empty URLs
+}
+
+TEST_F(UT_PacketWritingJob, RemovePacketWritingJob_Constructor)
+{
+    RemovePacketWritingJob job("/dev/sr2");
+
+    EXPECT_EQ(job.device(), "/dev/sr2");
+}
+
+TEST_F(UT_PacketWritingJob, RemovePacketWritingJob_setPendingUrls)
+{
+    RemovePacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/sr0/file1.txt")
+         << QUrl::fromLocalFile("/media/sr0/file2.txt");
+
+    job.setPendingUrls(urls);
+
+    QList<QUrl> retrievedUrls = job.getPendingUrls();
+    EXPECT_EQ(retrievedUrls.size(), 2);
+    EXPECT_EQ(retrievedUrls[0], QUrl::fromLocalFile("/media/sr0/file1.txt"));
+    EXPECT_EQ(retrievedUrls[1], QUrl::fromLocalFile("/media/sr0/file2.txt"));
+}
+
+TEST_F(UT_PacketWritingJob, RemovePacketWritingJob_work_Success)
+{
+    RemovePacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+    job.setPendingUrls(urls);
+
+    bool removeCalled = false;
+    stub.set_lamda(ADDR(DFMBURN::DPacketWritingController, rm), [&removeCalled] {
+        __DBG_STUB_INVOKE__
+        removeCalled = true;
+        return true;
+    });
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(removeCalled);
+}
+
+TEST_F(UT_PacketWritingJob, RemovePacketWritingJob_work_Failure)
+{
+    RemovePacketWritingJob job("/dev/sr0");
+
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+    job.setPendingUrls(urls);
+
+    stub.set_lamda(ADDR(DFMBURN::DPacketWritingController, rm), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_Constructor)
+{
+    RenamePacketWritingJob job("/dev/sr3");
+
+    EXPECT_EQ(job.device(), "/dev/sr3");
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_setSrcUrl)
+{
+    RenamePacketWritingJob job("/dev/sr0");
+
+    QUrl srcUrl = QUrl::fromLocalFile("/media/sr0/oldname.txt");
+    job.setSrcUrl(srcUrl);
+
+    EXPECT_EQ(job.getSrcUrl(), srcUrl);
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_setDestUrl)
+{
+    RenamePacketWritingJob job("/dev/sr0");
+
+    QUrl destUrl = QUrl::fromLocalFile("/media/sr0/newname.txt");
+    job.setDestUrl(destUrl);
+
+    EXPECT_EQ(job.getDestUrl(), destUrl);
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_work_Success)
+{
+    RenamePacketWritingJob job("/dev/sr0");
+
+    QUrl srcUrl = QUrl::fromLocalFile("/media/sr0/oldname.txt");
+    QUrl destUrl = QUrl::fromLocalFile("/media/sr0/newname.txt");
+    job.setSrcUrl(srcUrl);
+    job.setDestUrl(destUrl);
+
+    bool renameCalled = false;
+    stub.set_lamda(ADDR(DPacketWritingController, mv), [&renameCalled] {
+        __DBG_STUB_INVOKE__
+        renameCalled = true;
+        return true;
+    });
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(renameCalled);
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_work_Failure)
+{
+    RenamePacketWritingJob job("/dev/sr0");
+
+    QUrl srcUrl = QUrl::fromLocalFile("/media/sr0/oldname.txt");
+    QUrl destUrl = QUrl::fromLocalFile("/media/sr0/newname.txt");
+    job.setSrcUrl(srcUrl);
+    job.setDestUrl(destUrl);
+
+    stub.set_lamda(ADDR(DPacketWritingController, mv), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_PacketWritingJob, RenamePacketWritingJob_work_EmptyUrls)
+{
+    RenamePacketWritingJob job("/dev/sr0");
+    stub.set_lamda(ADDR(DPacketWritingController, mv), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    // Don't set any URLs
+    job.pwController.reset(new DPacketWritingController { "curDevice", "mnt" });
+    bool result = job.work();
+    EXPECT_FALSE(result);   // Should fail with empty URLs
+}
+
+TEST_F(UT_PacketWritingJob, AbstractPacketWritingJob_run)
+{
+    PutPacketWritingJob job("/dev/sr0");
+
+    bool workCalled = false;
+
+    job.run();
+
+    EXPECT_FALSE(workCalled);
+
+    bool finishedEmitted = false;
+
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return "/tmp";
+    });
+
+    job.run();
+
+    EXPECT_FALSE(workCalled);
+
+    stub.set_lamda(ADDR(DPacketWritingController, open), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(PutPacketWritingJob, work), [&workCalled] {
+        __DBG_STUB_INVOKE__
+        workCalled = true;
+        return true;
+    });
+    job.run();
+
+    EXPECT_TRUE(workCalled);
+}
+
+TEST_F(UT_PacketWritingJob, PacketWritingScheduler_addJob_NullJob)
+{
+    // Should handle null job gracefully
+    // PacketWritingScheduler::instance().addJob(nullptr);
+    // Should not crash
+}
+
+TEST_F(UT_PacketWritingJob, PacketWritingScheduler_onTimeout_EmptyQueue)
+{
+    // Should handle empty queue gracefully
+    PacketWritingScheduler::instance().onTimeout();
+    // Should not crash
+}

--- a/autotests/plugins/dfmplugin-burn/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_realevents.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run Burn::initialize() with REAL bindEvents() (NOT stubbed)
+// so production EventHelper<M> subscribe template instantiations execute.
+// bindEvents uses GlobalEventType (always valid, no registration needed).
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "burn.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_burn;
+
+class BurnRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override { dfmtest_hooks::registerAllHookEvents(); ins = new Burn(); }
+    void TearDown() override { delete ins; }
+    Burn *ins { nullptr };
+};
+
+TEST_F(BurnRealEventsTest, Initialize_RunsRealBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}

--- a/autotests/plugins/dfmplugin-burn/test_sendtodiscmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_sendtodiscmenuscene.cpp
@@ -1,0 +1,657 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+#include "plugins/common/dfmplugin-burn/events/burneventreceiver.h"
+#include "plugins/common/dfmplugin-burn/events/burneventcaller.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+
+#include <QMenu>
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_SendToDiscMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+
+        scene = new SendToDiscMenuScene();
+        menu = new QMenu();
+
+        // Setup test parameters
+        params[MenuParamKey::kWindowId] = QVariant::fromValue(12345ULL);
+        params[MenuParamKey::kCurrentDir] = QUrl::fromLocalFile("/tmp");
+        params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << QUrl::fromLocalFile("/tmp/test.txt"));
+        params[MenuParamKey::kIsEmptyArea] = false;
+        params[MenuParamKey::kIsDDEDesktopFileIncluded] = false;
+    }
+
+    virtual void TearDown() override
+    {
+        delete scene;
+        delete menu;
+        scene = nullptr;
+        menu = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    SendToDiscMenuScene *scene = nullptr;
+    QMenu *menu = nullptr;
+    QVariantHash params;
+};
+
+TEST_F(UT_SendToDiscMenuScene, name)
+{
+    QString sceneName = scene->name();
+    EXPECT_EQ(sceneName, SendToDiscMenuCreator::name());
+}
+
+TEST_F(UT_SendToDiscMenuScene, initialize_ValidParams)
+{
+    // Mock BurnHelper::discDataGroup to return some optical devices
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        device1[DeviceProperty::kOptical] = true;
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = scene->initialize(params);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SendToDiscMenuScene, initialize_EmptySelectFiles)
+{
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>());
+
+    bool result = scene->initialize(params);
+    EXPECT_FALSE(result);   // Should return false for empty select files
+}
+
+TEST_F(UT_SendToDiscMenuScene, initialize_NonFileScheme)
+{
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << QUrl("burn://test"));
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return false;   // Cannot transform to local
+    });
+
+    bool result = scene->initialize(params);
+    EXPECT_FALSE(result);   // Should return false for non-file scheme
+}
+
+TEST_F(UT_SendToDiscMenuScene, initialize_DDEDesktopFileIncluded)
+{
+    params[MenuParamKey::kIsDDEDesktopFileIncluded] = true;
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        return QList<QVariantMap>();
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = scene->initialize(params);
+    EXPECT_TRUE(result);   // Should still initialize successfully
+}
+
+TEST_F(UT_SendToDiscMenuScene, create_ValidMenu)
+{
+    // Initialize first
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        device1[DeviceProperty::kOptical] = true;
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    scene->initialize(params);
+
+    bool result = scene->create(menu);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SendToDiscMenuScene, create_NullMenu)
+{
+    bool result = scene->create(nullptr);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SendToDiscMenuScene, create_DDEDesktopFileIncluded)
+{
+    params[MenuParamKey::kIsDDEDesktopFileIncluded] = true;
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        return QList<QVariantMap>();
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    scene->initialize(params);
+
+    bool result = scene->create(menu);
+    EXPECT_TRUE(result);   // Should still create menu
+}
+
+TEST_F(UT_SendToDiscMenuScene, create_WithOpticalDevices)
+{
+    // Mock optical devices
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        device1[DeviceProperty::kOptical] = true;
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    scene->initialize(params);
+    bool result = scene->create(menu);
+
+    EXPECT_TRUE(result);
+    EXPECT_GT(menu->actions().size(), 0);   // Should have actions
+}
+
+TEST_F(UT_SendToDiscMenuScene, create_MountableImageFile)
+{
+    // Set focus file as ISO image
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << QUrl::fromLocalFile("/tmp/test.iso"));
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        return QList<QVariantMap>();
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(SyncFileInfo, nameOf),
+                   [](FileInfo *, NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-iso9660-image";
+                       return {};
+                   });
+
+    scene->initialize(params);
+    bool result = scene->create(menu);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SendToDiscMenuScene, triggered_StageAction)
+{
+    // Setup and initialize
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    bool handlePasteToCalledCalled = false;
+    stub.set_lamda(ADDR(BurnEventReceiver, handlePasteTo), [&handlePasteToCalledCalled] {
+        __DBG_STUB_INVOKE__
+        handlePasteToCalledCalled = true;
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, isPWOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return false;   // Not packet writing device
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Use the stage sub-action created by create(): the top-level action has no
+    // device data, while the sub-action carries kStagePrex+dev id and the device
+    QAction *stageAction = nullptr;
+    for (auto act : menu->actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == ActionId::kStageKey
+            && act->menu() && !act->menu()->actions().isEmpty()) {
+            stageAction = act->menu()->actions().first();
+            break;
+        }
+    }
+    ASSERT_TRUE(stageAction);
+
+    bool result = scene->triggered(stageAction);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(handlePasteToCalledCalled);
+}
+
+TEST_F(UT_SendToDiscMenuScene, triggered_PacketWritingAction)
+{
+    // Setup for packet writing device
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, isPWOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;   // Is packet writing device
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/media/sr0");
+    });
+
+    bool sendPasteFilesCalled = false;
+    stub.set_lamda(ADDR(BurnEventCaller, sendPasteFiles), [&sendPasteFilesCalled] {
+        __DBG_STUB_INVOKE__
+        sendPasteFilesCalled = true;
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Use the stage sub-action created by create(): it is registered in
+    // predicateAction and carries the device in its data
+    QAction *pwAction = nullptr;
+    for (auto act : menu->actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == ActionId::kStageKey
+            && act->menu() && !act->menu()->actions().isEmpty()) {
+            pwAction = act->menu()->actions().first();
+            break;
+        }
+    }
+    ASSERT_TRUE(pwAction);
+
+    bool result = scene->triggered(pwAction);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(sendPasteFilesCalled);
+}
+
+TEST_F(UT_SendToDiscMenuScene, triggered_MountImageAction)
+{
+    bool handleMountImageCalled = false;
+
+    stub.set_lamda(ADDR(BurnEventReceiver, handleMountImage), [&handleMountImageCalled] {
+        __DBG_STUB_INVOKE__
+        handleMountImageCalled = true;
+    });
+
+    // No burn devices so only the mount-image action is created
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        return QList<QVariantMap>();
+    });
+
+    // Make the focus file recognized as a mountable ISO image
+    stub.set_lamda(VADDR(SyncFileInfo, nameOf),
+                   [](FileInfo *, NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-iso9660-image";
+                       return {};
+                   });
+
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << QUrl::fromLocalFile("/tmp/test.iso"));
+    scene->initialize(params);
+    scene->create(menu);
+
+    // The mount-image action must be created by create() so it is registered
+    // in predicateAction
+    QAction *mountAction = nullptr;
+    for (auto act : menu->actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == ActionId::kMountImageKey)
+            mountAction = act;
+    }
+    ASSERT_TRUE(mountAction);
+
+    bool result = scene->triggered(mountAction);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(handleMountImageCalled);
+}
+
+TEST_F(UT_SendToDiscMenuScene, triggered_UnknownAction)
+{
+    scene->initialize(params);
+
+    // Create a test action that's not handled
+    QAction *testAction = new QAction("Test", menu);
+    testAction->setProperty(ActionPropertyKey::kActionID, "unknown_action");
+
+    bool result = scene->triggered(testAction);
+    EXPECT_FALSE(result);
+
+    delete testAction;
+}
+
+TEST_F(UT_SendToDiscMenuScene, scene_ValidAction)
+{
+    // create() only adds the stage action when dest devices are available;
+    // provide a mocked device list so predicateAction gets populated
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc2 = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc2>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // scene() only returns this scene for actions registered by create()
+    QAction *stageAction = nullptr;
+    for (auto act : menu->actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == ActionId::kStageKey
+            && act->menu() && !act->menu()->actions().isEmpty()) {
+            stageAction = act->menu()->actions().first();
+            break;
+        }
+    }
+    ASSERT_TRUE(stageAction);
+
+    AbstractMenuScene *resultScene = scene->scene(stageAction);
+    EXPECT_EQ(resultScene, scene);
+}
+
+TEST_F(UT_SendToDiscMenuScene, scene_NullAction)
+{
+    AbstractMenuScene *resultScene = scene->scene(nullptr);
+    EXPECT_EQ(resultScene, nullptr);
+}
+
+TEST_F(UT_SendToDiscMenuScene, scene_UnknownAction)
+{
+    QAction *testAction = new QAction("Test", menu);
+    testAction->setProperty(ActionPropertyKey::kActionID, "unknown_action");
+
+    AbstractMenuScene *resultScene = scene->scene(testAction);
+    EXPECT_NE(resultScene, scene);   // Should delegate to parent
+
+    delete testAction;
+}
+
+TEST_F(UT_SendToDiscMenuScene, updateState)
+{
+    // Mock burn enabled
+    stub.set_lamda(ADDR(BurnHelper, isBurnEnabled), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Should not crash
+    scene->updateState(menu);
+}
+
+TEST_F(UT_SendToDiscMenuScene, updateState_BurnDisabled)
+{
+    // Mock burn disabled
+    stub.set_lamda(ADDR(BurnHelper, isBurnEnabled), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Should disable actions when burn is disabled
+    scene->updateState(menu);
+}
+
+TEST_F(UT_SendToDiscMenuScene, updateState_WorkingDevice)
+{
+    stub.set_lamda(ADDR(BurnHelper, isBurnEnabled), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    stub.set_lamda(ADDR(DeviceUtils, isWorkingOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;   // Device is working
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Should disable actions for working devices
+    scene->updateState(menu);
+}
+
+TEST_F(UT_SendToDiscMenuScene, SendToDiscMenuCreator_create)
+{
+    SendToDiscMenuCreator creator;
+    AbstractMenuScene *createdScene = creator.create();
+
+    EXPECT_TRUE(createdScene != nullptr);
+    EXPECT_TRUE(dynamic_cast<SendToDiscMenuScene *>(createdScene) != nullptr);
+
+    delete createdScene;
+}
+
+TEST_F(UT_SendToDiscMenuScene, Private_initDestDevices)
+{
+    // Test filtering of self disc
+    QUrl currentDir;
+    currentDir.setScheme("burn");
+    currentDir.setPath("/dev/sr0/disc_files/");
+    params[MenuParamKey::kCurrentDir] = currentDir;
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        QVariantMap device2;
+        device2[DeviceProperty::kDevice] = "/dev/sr1";
+        devices << device2;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, burnDestDevice), [](const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        if (url.path().contains("/dev/sr0/"))
+            return QString("/dev/sr0");
+        return QString();
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = scene->initialize(params);
+    EXPECT_TRUE(result);
+
+    // Should filter out self disc and only have sr1
+}
+
+TEST_F(UT_SendToDiscMenuScene, Private_addToSendto)
+{
+    // Create a menu with send-to action
+    QAction *sendToAction = menu->addAction("Send To");
+    sendToAction->setProperty(ActionPropertyKey::kActionID, "send-to");
+    QMenu *sendToSubMenu = new QMenu();
+    sendToAction->setMenu(sendToSubMenu);
+
+    stub.set_lamda(ADDR(BurnHelper, discDataGroup), [] {
+        __DBG_STUB_INVOKE__
+        QList<QVariantMap> devices;
+        QVariantMap device1;
+        device1[DeviceProperty::kDevice] = "/dev/sr0";
+        devices << device1;
+        return devices;
+    });
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    using ConvertDisplayNameFunc = QString (*)(const QVariantMap &);
+    stub.set_lamda(static_cast<ConvertDisplayNameFunc>(&DeviceUtils::convertSuitableDisplayName), [] {
+        __DBG_STUB_INVOKE__
+        return QString("DVD Drive");
+    });
+
+    scene->initialize(params);
+    scene->create(menu);
+
+    // Should add items to send-to submenu
+    EXPECT_GT(sendToSubMenu->actions().size(), 0);
+}


### PR DESCRIPTION
Port burn plugin tests from autotests/old, covering burn jobs,
job manager and staging logic.

从 autotests/old 移植刻录插件测试，覆盖刻录任务、任务管理
与暂存逻辑。

Log: 新增 dfmplugin-burn 单元测试
Influence: 仅新增测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.