### PR TITLE
test: add unit tests for dfmplugin-detailspace

### DIFF
--- a/autotests/plugins/dfmplugin-detailspace/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-detailspace/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# dfmplugin-detailspace unit tests — recompile the plugin's own sources.
+# No custom dependencies.cmake -> default plugin config (DFM6::base/framework).
+
+dfm_create_plugin_test("dfmplugin-detailspace" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-detailspace")
+
+target_include_directories(ut-dfmplugin-detailspace PRIVATE
+    "${DFM_SOURCE_DIR}/plugins/filemanager"
+)

--- a/autotests/plugins/dfmplugin-detailspace/main.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/main.cpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_detailspace)

--- a/autotests/plugins/dfmplugin-detailspace/test_detailview.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailview.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QUrl>
+#include <QResizeEvent>
+#include <QPixmap>
+
+#include "stubext.h"
+
+#include "views/detailview.h"
+
+using namespace dfmplugin_detailspace;
+
+class DetailViewTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        view = new DetailView();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        delete view;
+    }
+
+    DetailView *view = nullptr;
+};
+
+// --- construction (covers initInfoUI) ---
+
+TEST_F(DetailViewTest, Constructor_CreatesView)
+{
+    EXPECT_NE(view, nullptr);
+}
+
+// --- setUrl with empty url (early return, m_currentUrl is empty) ---
+
+TEST_F(DetailViewTest, SetUrl_EmptyUrl_EarlyReturn)
+{
+    EXPECT_NO_FATAL_FAILURE(view->setUrl(QUrl()));
+}
+
+// --- setUrl with a real file url (covers updateHeadUI, updateBasicWidget, updateExtensionWidgets) ---
+
+TEST_F(DetailViewTest, SetUrl_FileUrl_UpdatesView)
+{
+    QUrl url("file:///tmp");
+    EXPECT_NO_FATAL_FAILURE(view->setUrl(url));
+}
+
+TEST_F(DetailViewTest, SetUrl_SameUrlTwice_EarlyReturnSecond)
+{
+    QUrl url("file:///tmp");
+    view->setUrl(url);
+    EXPECT_NO_FATAL_FAILURE(view->setUrl(url));
+}
+
+TEST_F(DetailViewTest, SetUrl_DifferentUrls_UpdatesEach)
+{
+    view->setUrl(QUrl("file:///tmp"));
+    EXPECT_NO_FATAL_FAILURE(view->setUrl(QUrl("file:///")));
+}
+
+// --- resizeEvent ---
+
+TEST_F(DetailViewTest, ResizeEvent_NoCrash)
+{
+    view->resize(400, 600);
+    QResizeEvent event(QSize(400, 600), QSize(200, 300));
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &event));
+}
+
+// --- onPreviewReady with a pixmap ---
+
+TEST_F(DetailViewTest, OnPreviewReady_MatchingUrl_UpdatesPreview)
+{
+    view->setUrl(QUrl("file:///tmp"));
+    QPixmap pix(64, 64);
+    pix.fill(Qt::red);
+    EXPECT_NO_FATAL_FAILURE(view->onPreviewReady(QUrl("file:///tmp"), pix));
+}
+
+TEST_F(DetailViewTest, OnPreviewReady_NonMatchingUrl_Ignored)
+{
+    view->setUrl(QUrl("file:///tmp"));
+    QPixmap pix(64, 64);
+    pix.fill(Qt::blue);
+    EXPECT_NO_FATAL_FAILURE(view->onPreviewReady(QUrl("file:///nonexistent"), pix));
+}
+
+// --- onAnimatedImageReady ---
+
+TEST_F(DetailViewTest, OnAnimatedImageReady_MatchingUrl_NoCrash)
+{
+    view->setUrl(QUrl("file:///tmp"));
+    EXPECT_NO_FATAL_FAILURE(view->onAnimatedImageReady(QUrl("file:///tmp"), "/tmp/test.gif"));
+}
+
+TEST_F(DetailViewTest, OnAnimatedImageReady_NonMatchingUrl_Ignored)
+{
+    view->setUrl(QUrl("file:///tmp"));
+    EXPECT_NO_FATAL_FAILURE(view->onAnimatedImageReady(QUrl("file:///nonexistent"), "/tmp/test.gif"));
+}


### PR DESCRIPTION
Add a new test binary for the detailspace plugin, covering the
detail view.

为详情栏插件新增测试二进制，覆盖详情视图。

Log: 新增 dfmplugin-detailspace 单元测试
Influence: 仅新增测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.

## Summary by Sourcery

Add unit-test coverage for the dfmplugin-detailspace detail view.

Build:
- Add CMake configuration for the dfmplugin-detailspace unit-test target.

Tests:
- Add unit coverage for DetailView construction, URL updates, resizing, and preview or animated-image callbacks.