### PR TITLE
test: extend unit tests for dfmplugin-fileoperations

### DIFF
--- a/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
@@ -50,26 +50,20 @@ public:
 
     void TearDown() override
     {
-        // The constructor already started the thread for real (AbstractJob::start()
-        // is called from the ctor). Do NOT stub quit/wait here: stubbing them makes
-        // ~AbstractJob believe the thread stopped while it is still running, which
-        // crashes when the QThread member is destroyed. The real quit() + wait()
-        // pair exits the idle event loop within milliseconds.
-        //
-        // worker lives on the job's QThread (moveToThread in the AbstractJob ctor).
-        // Qt requires objects moved to a thread to be pulled back before that
-        // thread is destroyed, so move it to the main thread first. Deleting job
-        // afterwards stops the thread AND releases the QSharedPointer<AbstractWorker>
-        // doWorker member, which deletes worker automatically. Do NOT delete
-        // worker explicitly here - that would double-free it.
-        // Guard against null: some tests (e.g. Destructor_StopsThread) delete job
-        // and null worker in the test body, so TearDown must not dereference it.
-        if (worker)
-            worker->moveToThread(QThread::currentThread());
+        // Drop stubs FIRST: otherwise stubs set inside a test body (e.g. a
+        // no-op QThread::quit) would still be in effect when ~AbstractJob
+        // runs below, leaving the thread alive while its QThread member is
+        // destroyed, which aborts the process.
+        stub.clear();
+        // worker lives on the job's QThread (moveToThread in the AbstractJob
+        // ctor). Qt6 rejects cross-thread moveToThread calls, so the worker
+        // cannot be pulled back from here; it is released by ~AbstractJob
+        // (QSharedPointer doWorker) AFTER the real quit()+wait() pair has
+        // exited the thread, which is safe. Do NOT delete worker explicitly
+        // here - that would double-free it.
         delete job;
         job = nullptr;
         worker = nullptr;
-        stub.clear();
     }
 
 protected:
@@ -101,10 +95,8 @@ TEST_F(TestAbstractJob, Destructor_StopsThread)
     // Let the real ~AbstractJob run: real quit() + real wait() must stop the
     // thread (the event loop is idle, so wait returns almost immediately).
     // Stubbing wait/quit here would leave a live thread behind and crash on
-    // QThread destruction. Follow the same safe teardown order as TearDown:
-    // pull worker back to the main thread, then delete job - its QSharedPointer
-    // doWorker member deletes worker automatically (do NOT delete twice).
-    worker->moveToThread(QThread::currentThread());
+    // QThread destruction. worker is released by ~AbstractJob automatically
+    // (QSharedPointer doWorker; do NOT delete twice).
     delete job;
     job = nullptr;
     worker = nullptr;
@@ -113,18 +105,25 @@ TEST_F(TestAbstractJob, Destructor_StopsThread)
 
 TEST_F(TestAbstractJob, Destructor_ThreadTimeout)
 {
-    stub.set_lamda(&QThread::quit, [](QThread *) {
-        __DBG_STUB_INVOKE__
-    });
+    // Destroying a QThread that is still running aborts the process, so the
+    // thread must be dead before ~AbstractJob runs. Exit it for real here,
+    // then fake a wait() timeout return value to cover the warning branch
+    // of ~AbstractJob. Delete inside the test body while the stub is active
+    // (TearDown's stub.clear() would be too late).
+    ASSERT_TRUE(job);
+    job->thread.quit();
+    ASSERT_TRUE(job->thread.wait());
 
     using WaitFuncPtr = bool (QThread::*)(QDeadlineTimer);
-    stub.set_lamda(static_cast<WaitFuncPtr>(&QThread::wait), [&](QThread *, QDeadlineTimer) {
+    stub.set_lamda(static_cast<WaitFuncPtr>(&QThread::wait), [](QThread *, QDeadlineTimer) {
         __DBG_STUB_INVOKE__
         return false;
     });
 
-    // delete job;
-    // job = nullptr;
+    delete job;
+    job = nullptr;
+    worker = nullptr;
+    stub.clear();
 
     SUCCEED();
 }
@@ -464,6 +463,16 @@ TEST_F(TestAbstractJob, HandleFileAdded_EmitsSignal)
 
 TEST_F(TestAbstractJob, EdgeCase_NullWorker)
 {
+    AbstractJob *nullJob = new AbstractJob(nullptr, nullptr);
+    EXPECT_TRUE(nullJob);
+
+    // The ctor starts the thread even with a null worker. A live thread
+    // aborts the process when the QThread member is destroyed, so exit it
+    // for real first, then fake a successful wait() return value to cover
+    // the destructor's normal-exit branch.
+    nullJob->thread.quit();
+    ASSERT_TRUE(nullJob->thread.wait());
+
     stub.set_lamda(&QThread::quit, [](QThread *) {
         __DBG_STUB_INVOKE__
     });
@@ -473,8 +482,6 @@ TEST_F(TestAbstractJob, EdgeCase_NullWorker)
         return true;
     });
 
-    AbstractJob *nullJob = new AbstractJob(nullptr, nullptr);
-    EXPECT_TRUE(nullJob);
     delete nullJob;
 }
 

--- a/autotests/plugins/dfmplugin-fileoperations/test_abstractworker_impl.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_abstractworker_impl.cpp
@@ -1,0 +1,532 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QUrl>
+#include <QThread>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "stubext.h"
+
+#include "fileoperations/fileoperationutils/abstractworker.h"
+#include "fileoperations/fileoperationutils/workerdata.h"
+#include "fileoperations/fileoperationutils/fileoperationsutils.h"
+#include <dfm-io/dfmio_utils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+DFMBASE_USE_NAMESPACE
+DPFILEOPERATIONS_USE_NAMESPACE
+
+// Concrete test worker for AbstractWorkerImpl
+class TestAbstractWorkerImplWorker : public AbstractWorker
+{
+public:
+    TestAbstractWorkerImplWorker(QObject *parent = nullptr)
+        : AbstractWorker(parent) { }
+
+    virtual ~TestAbstractWorkerImplWorker() override { }
+
+    // Expose protected methods for testing
+    using AbstractWorker::setWorkArgs;
+    using AbstractWorker::stop;
+    using AbstractWorker::pause;
+    using AbstractWorker::resume;
+    using AbstractWorker::setStat;
+    using AbstractWorker::stateCheck;
+    using AbstractWorker::workerWait;
+    using AbstractWorker::statisticsFilesSize;
+    using AbstractWorker::initArgs;
+    using AbstractWorker::endWork;
+    using AbstractWorker::emitStateChangedNotify;
+    using AbstractWorker::emitCurrentTaskNotify;
+    using AbstractWorker::emitProgressChangedNotify;
+    using AbstractWorker::emitErrorNotify;
+    using AbstractWorker::createCopyJobInfo;
+    using AbstractWorker::resumeAllThread;
+    using AbstractWorker::resumeThread;
+    using AbstractWorker::pauseAllThread;
+    using AbstractWorker::stopAllThread;
+    using AbstractWorker::checkRetry;
+    using AbstractWorker::parentUrl;
+    using AbstractWorker::syncFilesToDevice;
+    using AbstractWorker::startAsyncStatistics;
+    using AbstractWorker::getAction;
+    using AbstractWorker::doOperateWork;
+    using AbstractWorker::startCountProccess;
+    using AbstractWorker::doWork;
+    using AbstractWorker::saveOperations;
+    using AbstractWorker::formatFileName;
+
+protected:
+    bool doWork() override { return true; }
+    // NOTE: initArgs() is intentionally NOT overridden here so tests hit the
+    // real AbstractWorker::initArgs() (e.g. InitArgs_ResetsState). If a test
+    // needs to isolate side effects, stub the product function with stubext.
+    bool statisticsFilesSize() override { return true; }
+};
+
+class AbstractWorkerImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        worker = new TestAbstractWorkerImplWorker();
+        ASSERT_TRUE(worker);
+
+        handle.reset(new AbstractJobHandler);
+        worker->setWorkArgs(handle, {}, QUrl(), AbstractJobHandler::JobFlag::kNoHint);
+
+        // Avoid blocking on workerWait
+        using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
+        stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),
+                       [](QWaitCondition *, QMutex *, QDeadlineTimer) -> bool { return true; });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        if (worker) {
+            worker->stopAllThread();
+            delete worker;
+            worker = nullptr;
+        }
+        tempDir.reset();
+    }
+
+protected:
+    QUrl createTestFile(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QFile file(path);
+        if (file.open(QIODevice::WriteOnly)) {
+            file.write("test");
+            file.close();
+        }
+        return QUrl::fromLocalFile(path);
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    TestAbstractWorkerImplWorker *worker { nullptr };
+    JobHandlePointer handle;
+};
+
+// ========== setWorkArgs ==========
+TEST_F(AbstractWorkerImpl, SetWorkArgs_NullHandle)
+{
+    TestAbstractWorkerImplWorker *w = new TestAbstractWorkerImplWorker();
+    w->setWorkArgs(nullptr, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"));
+    EXPECT_EQ(w->handle, nullptr);
+    delete w;
+}
+
+TEST_F(AbstractWorkerImpl, SetWorkArgs_ValidHandle)
+{
+    JobHandlePointer h(new AbstractJobHandler);
+    QList<QUrl> sources = { QUrl::fromLocalFile("/tmp/a") };
+    QUrl target = QUrl::fromLocalFile("/tmp/b");
+
+    worker->setWorkArgs(h, sources, target);
+
+    EXPECT_EQ(worker->handle, h);
+    EXPECT_EQ(worker->sourceUrls, sources);
+    EXPECT_EQ(worker->targetUrl, target);
+    EXPECT_NE(worker->workData, nullptr);
+}
+
+// ========== doOperateWork ==========
+TEST_F(AbstractWorkerImpl, DoOperateWork_Stop)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->doOperateWork(AbstractJobHandler::SupportAction::kStopAction);
+    EXPECT_TRUE(worker->isStopped());
+}
+
+TEST_F(AbstractWorkerImpl, DoOperateWork_Pause)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->doOperateWork(AbstractJobHandler::SupportAction::kPauseAction);
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kPauseState);
+}
+
+TEST_F(AbstractWorkerImpl, DoOperateWork_Resume)
+{
+    worker->setStat(AbstractJobHandler::JobState::kPauseState);
+    worker->doOperateWork(AbstractJobHandler::SupportAction::kResumAction);
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
+}
+
+TEST_F(AbstractWorkerImpl, DoOperateWork_Skip)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->doOperateWork(AbstractJobHandler::SupportAction::kSkipAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kSkipAction);
+}
+
+// ========== stop / pause / resume ==========
+TEST_F(AbstractWorkerImpl, Stop_SetsState)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->stop();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kStopState);
+}
+
+TEST_F(AbstractWorkerImpl, Pause_RunningToPaused)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->pause();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kPauseState);
+}
+
+TEST_F(AbstractWorkerImpl, Resume_PausedToRunning)
+{
+    worker->setStat(AbstractJobHandler::JobState::kPauseState);
+    worker->resume();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
+}
+
+// ========== setStat ==========
+TEST_F(AbstractWorkerImpl, SetStat_Running)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
+}
+
+TEST_F(AbstractWorkerImpl, SetStat_Stop)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->setStat(AbstractJobHandler::JobState::kStopState);
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kStopState);
+}
+
+// ========== stateCheck ==========
+TEST_F(AbstractWorkerImpl, StateCheck_Running)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    EXPECT_TRUE(worker->stateCheck());
+}
+
+TEST_F(AbstractWorkerImpl, StateCheck_Stopped)
+{
+    worker->setStat(AbstractJobHandler::JobState::kStopState);
+    EXPECT_FALSE(worker->stateCheck());
+}
+
+// ========== workerWait ==========
+TEST_F(AbstractWorkerImpl, WorkerWait_ReturnsState)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    bool result = worker->workerWait();
+    EXPECT_TRUE(result);
+}
+
+// ========== initArgs ==========
+TEST_F(AbstractWorkerImpl, InitArgs_ResetsState)
+{
+    worker->sourceFilesTotalSize = 100;
+    bool result = worker->initArgs();
+    EXPECT_TRUE(result);
+    EXPECT_EQ(worker->sourceFilesTotalSize, 0);
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
+}
+
+// ========== endWork ==========
+TEST_F(AbstractWorkerImpl, EndWork_EmitsFinished)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+
+    bool finishedEmitted = false;
+    QObject::connect(worker, &AbstractWorker::finishedNotify,
+                     [&finishedEmitted](const JobInfoPointer &) { finishedEmitted = true; });
+
+    worker->endWork();
+    EXPECT_TRUE(finishedEmitted);
+}
+
+// ========== emitStateChangedNotify ==========
+TEST_F(AbstractWorkerImpl, EmitStateChangedNotify_Signal)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+
+    bool emitted = false;
+    QObject::connect(worker, &AbstractWorker::stateChangedNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitStateChangedNotify();
+    EXPECT_TRUE(emitted);
+}
+
+// ========== emitCurrentTaskNotify ==========
+TEST_F(AbstractWorkerImpl, EmitCurrentTaskNotify_Signal)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+
+    bool emitted = false;
+    QObject::connect(worker, &AbstractWorker::currentTaskNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitCurrentTaskNotify(QUrl::fromLocalFile("/tmp/from"), QUrl::fromLocalFile("/tmp/to"));
+    // Throttle may coalesce; test that method doesn't crash
+    SUCCEED();
+}
+
+// ========== emitProgressChangedNotify ==========
+TEST_F(AbstractWorkerImpl, EmitProgressChangedNotify_CopyType)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->sourceFilesTotalSize = 1000;
+
+    bool emitted = false;
+    QObject::connect(worker, &AbstractWorker::progressChangedNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitProgressChangedNotify(500);
+    EXPECT_TRUE(emitted);
+}
+
+TEST_F(AbstractWorkerImpl, EmitProgressChangedNotify_DeleteType)
+{
+    worker->jobType = AbstractJobHandler::JobType::kDeleteType;
+    worker->sourceUrls = { QUrl::fromLocalFile("/tmp/a") };
+
+    bool emitted = false;
+    QObject::connect(worker, &AbstractWorker::progressChangedNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitProgressChangedNotify(1);
+    EXPECT_TRUE(emitted);
+}
+
+// ========== emitErrorNotify ==========
+TEST_F(AbstractWorkerImpl, EmitErrorNotify_Signal)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+
+    bool emitted = false;
+    QObject::connect(worker, &AbstractWorker::errorNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitErrorNotify(QUrl::fromLocalFile("/tmp/from"), QUrl::fromLocalFile("/tmp/to"),
+                            AbstractJobHandler::JobErrorType::kOpenError);
+    EXPECT_TRUE(emitted);
+}
+
+// ========== createCopyJobInfo ==========
+TEST_F(AbstractWorkerImpl, CreateCopyJobInfo_Valid)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    auto info = worker->createCopyJobInfo(QUrl::fromLocalFile("/tmp/from"),
+                                          QUrl::fromLocalFile("/tmp/to"));
+    EXPECT_NE(info, nullptr);
+    EXPECT_TRUE(info->contains(AbstractJobHandler::NotifyInfoKey::kSourceUrlKey));
+    EXPECT_TRUE(info->contains(AbstractJobHandler::NotifyInfoKey::kTargetUrlKey));
+}
+
+// ========== resumeAllThread / pauseAllThread / stopAllThread ==========
+TEST_F(AbstractWorkerImpl, ResumeAllThread_RunningState)
+{
+    worker->setStat(AbstractJobHandler::JobState::kPauseState);
+    worker->resumeAllThread();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
+}
+
+TEST_F(AbstractWorkerImpl, PauseAllThread_PauseState)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->pauseAllThread();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kPauseState);
+}
+
+TEST_F(AbstractWorkerImpl, StopAllThread_StopState)
+{
+    worker->setStat(AbstractJobHandler::JobState::kRunningState);
+    worker->stopAllThread();
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kStopState);
+}
+
+// ========== getAction ==========
+TEST_F(AbstractWorkerImpl, GetAction_Cancel)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kCancelAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kCancelAction);
+}
+
+TEST_F(AbstractWorkerImpl, GetAction_Replace)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kReplaceAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kReplaceAction);
+}
+
+TEST_F(AbstractWorkerImpl, GetAction_Merge)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kMergeAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kMergeAction);
+}
+
+TEST_F(AbstractWorkerImpl, GetAction_Enforce)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kEnforceAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kEnforceAction);
+}
+
+TEST_F(AbstractWorkerImpl, GetAction_PermanentlyDelete)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kPermanentlyDelete);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kPermanentlyDelete);
+}
+
+TEST_F(AbstractWorkerImpl, GetAction_NoAction)
+{
+    worker->getAction(AbstractJobHandler::SupportAction::kNoAction);
+    EXPECT_EQ(worker->currentAction, AbstractJobHandler::SupportAction::kNoAction);
+}
+
+// ========== parentUrl ==========
+TEST_F(AbstractWorkerImpl, ParentUrl_HasParent)
+{
+    QUrl child = QUrl::fromLocalFile("/tmp/subdir/child.txt");
+    QUrl parent = worker->parentUrl(child);
+    EXPECT_TRUE(parent.isValid());
+    EXPECT_EQ(parent.path(), "/tmp/subdir");
+}
+
+TEST_F(AbstractWorkerImpl, ParentUrl_RootDirectory)
+{
+    QUrl root = QUrl::fromLocalFile("/");
+    QUrl parent = worker->parentUrl(root);
+    EXPECT_FALSE(parent.isValid());
+}
+
+// ========== syncFilesToDevice ==========
+TEST_F(AbstractWorkerImpl, SyncFilesToDevice_NoSyncNeeded)
+{
+    worker->workData->exBlockSyncEveryWrite = false;
+    worker->syncFilesToDevice();
+    SUCCEED();
+}
+
+// ========== startAsyncStatistics ==========
+TEST_F(AbstractWorkerImpl, StartAsyncStatistics_CreatesThread)
+{
+    QUrl file = createTestFile("stats.txt");
+
+    stub.set_lamda(&FileScanner::scanSyncWithCallback,
+                   [](const QList<QUrl> &, FileScanner::ScanOptions,
+                      FileScanner::ProgressCallback) -> FileScanner::ScanResult {
+                       return { 100, 0, 1, 0, QList<QUrl>() };
+                   });
+
+    worker->startAsyncStatistics({ file });
+    EXPECT_NE(worker->statisticsThread, nullptr);
+
+    // The fixture stubs QWaitCondition::wait (to keep workerWait() from
+    // blocking), which QThread::wait() calls internally: its loop would spin
+    // forever on a faked "already done" condition while the real thread is
+    // still finishing. QThread::create runs a plain lambda (no event loop,
+    // quit() is a no-op), so just poll isFinished() instead. The thread MUST
+    // be done before the fixture deletes worker - the scan lambda captures
+    // 'this'.
+    if (worker->statisticsThread) {
+        ASSERT_TRUE(QTest::qWaitFor([&]() {
+            return worker->statisticsThread->isFinished();
+        }, 10000));
+    }
+}
+
+// ========== doWork ==========
+TEST_F(AbstractWorkerImpl, DoWork_Success)
+{
+    bool result = worker->doWork();
+    EXPECT_TRUE(result);
+}
+
+// ========== startCountProccess ==========
+TEST_F(AbstractWorkerImpl, StartCountProccess_NoTimer)
+{
+    worker->updateProgressTimer.reset();
+    worker->startCountProccess();
+    SUCCEED();
+}
+
+// ========== formatFileName ==========
+TEST_F(AbstractWorkerImpl, FormatFileName_Default)
+{
+    worker->targetUrl = QUrl::fromLocalFile("/tmp/test");
+    QString result = worker->formatFileName("normal.txt");
+    EXPECT_EQ(result, "normal.txt");
+}
+
+TEST_F(AbstractWorkerImpl, FormatFileName_Vfat)
+{
+    worker->targetUrl = QUrl::fromLocalFile(tempDir->path());
+
+    stub.set_lamda(&dfmio::DFMUtils::fsTypeFromUrl, [](const QUrl &) -> QString { return "ext4"; });
+
+    QString result = worker->formatFileName("normal.txt");
+    EXPECT_EQ(result, "normal.txt");
+}
+
+// ========== saveOperations ==========
+TEST_F(AbstractWorkerImpl, SaveOperations_CopyType)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->sourceUrls = { QUrl::fromLocalFile("/tmp/source.txt") };
+    worker->targetUrl = QUrl::fromLocalFile("/tmp/dest");
+    worker->completeSourceFiles = { QUrl::fromLocalFile("/tmp/source.txt") };
+    worker->completeTargetFiles = { QUrl::fromLocalFile("/tmp/dest/source.txt") };
+
+    worker->saveOperations();
+    SUCCEED();
+}
+
+TEST_F(AbstractWorkerImpl, SaveOperations_InvalidUrls)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->sourceUrls.clear();
+    worker->targetUrl = QUrl();
+
+    worker->saveOperations();
+    SUCCEED();
+}
+
+// ========== isStopped ==========
+TEST_F(AbstractWorkerImpl, IsStopped_Initial)
+{
+    EXPECT_FALSE(worker->isStopped());
+}
+
+TEST_F(AbstractWorkerImpl, IsStopped_AfterStop)
+{
+    worker->setStat(AbstractJobHandler::JobState::kStopState);
+    EXPECT_TRUE(worker->isStopped());
+}
+
+// ========== checkRetry ==========
+TEST_F(AbstractWorkerImpl, CheckRetry_NoRetry)
+{
+    worker->retry = false;
+    worker->checkRetry();
+    SUCCEED();
+}
+
+// ========== resumeThread with ids ==========
+TEST_F(AbstractWorkerImpl, ResumeThread_WithId)
+{
+    worker->setStat(AbstractJobHandler::JobState::kPauseState);
+    worker->resumeThread({ quintptr(worker) });
+    // Worker itself is in list, so it should remain paused
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kPauseState);
+}
+

--- a/autotests/plugins/dfmplugin-fileoperations/test_docleantrashfilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_docleantrashfilesworker.cpp
@@ -145,9 +145,10 @@ TEST_F(TestDoCleanTrashFilesWorker, StatisticsFilesSize_EmptySources)
 {
     worker->sourceUrls.clear();
 
+    // Product returns false when the source list is empty
     bool result = worker->statisticsFilesSize();
 
-    EXPECT_TRUE(result);
+    EXPECT_FALSE(result);
 }
 
 TEST_F(TestDoCleanTrashFilesWorker, StatisticsFilesSize_WithSources)
@@ -242,6 +243,14 @@ TEST_F(TestDoCleanTrashFilesWorker, CleanAllTrashFiles_WithFiles)
                        __DBG_STUB_INVOKE__
                        return true;
                    });
+    // Non-trash scheme urls trigger the error path; skip them to keep looping
+    stub.set_lamda(&DoCleanTrashFilesWorker::doHandleErrorAndWait,
+                   [](DoCleanTrashFilesWorker *, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &,
+                      const bool, const QString &) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
     stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),
                    [](QWaitCondition *, QMutex *, QDeadlineTimer) -> bool {
@@ -314,7 +323,7 @@ TEST_F(TestDoCleanTrashFilesWorker, ClearTrashFile_Directory)
     EXPECT_TRUE(result);
 }
 
-TEST_F(TestDoCleanTrashFilesWorker, ClearTrashFile_StateCheckFails)
+TEST_F(TestDoCleanTrashFilesWorker, ClearTrashFile_DeleteSuccess)
 {
     auto testFile = createTestFile("state_fail.txt");
     FileInfoPointer fileInfo = testFile;
@@ -324,8 +333,11 @@ TEST_F(TestDoCleanTrashFilesWorker, ClearTrashFile_StateCheckFails)
         return false;
     });
 
+    // clearTrashFile() never checks the state; deleting a real file succeeds
+    // and returns true (action == kNoAction)
     bool result = worker->clearTrashFile(fileInfo);
-    EXPECT_FALSE(result);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(QFile::exists(tempDirPath + QDir::separator() + "state_fail.txt"));
 }
 
 // ========== deleteFile Tests ==========
@@ -360,16 +372,10 @@ TEST_F(TestDoCleanTrashFilesWorker, DeleteFile_Failure)
                        return "Permission denied";
                    });
 
-    stub.set_lamda(&DoCleanTrashFilesWorker::doHandleErrorAndWait,
-                   [](DoCleanTrashFilesWorker *, const QUrl &,
-                      const AbstractJobHandler::JobErrorType &,
-                      const bool, const QString &) -> AbstractJobHandler::SupportAction {
-                       __DBG_STUB_INVOKE__
-                       return AbstractJobHandler::SupportAction::kSkipAction;
-                   });
-
+    // Product deleteFile() simply forwards the handler result: a failed
+    // delete returns false (error handling is done by clearTrashFile)
     bool result = worker->deleteFile(fileUrl);
-    EXPECT_TRUE(result);   // Should return true when skipped
+    EXPECT_FALSE(result);
 }
 
 // ========== doHandleErrorAndWait Tests ==========
@@ -475,6 +481,14 @@ TEST_F(TestDoCleanTrashFilesWorker, EdgeCase_MultipleTrashDirectories)
                        __DBG_STUB_INVOKE__
                        return true;
                    });
+    // Non-trash scheme urls are skipped via the error path
+    stub.set_lamda(&DoCleanTrashFilesWorker::doHandleErrorAndWait,
+                   [](DoCleanTrashFilesWorker *, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &,
+                      const bool, const QString &) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
     stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),
                    [](QWaitCondition *, QMutex *, QDeadlineTimer) -> bool {
@@ -494,6 +508,14 @@ TEST_F(TestDoCleanTrashFilesWorker, EdgeCase_EmptyTrash)
         __DBG_STUB_INVOKE__
         return true;
     });
+    // Non-trash scheme url is skipped via the error path
+    stub.set_lamda(&DoCleanTrashFilesWorker::doHandleErrorAndWait,
+                   [](DoCleanTrashFilesWorker *, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &,
+                      const bool, const QString &) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
     stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),
                    [](QWaitCondition *, QMutex *, QDeadlineTimer) -> bool {
@@ -529,8 +551,9 @@ TEST_F(TestDoCleanTrashFilesWorker, EdgeCase_DeleteFileFails_ThenSkip)
                        return AbstractJobHandler::SupportAction::kSkipAction;
                    });
 
+    // deleteFile() forwards the handler result; failed delete returns false
     bool result = worker->deleteFile(fileUrl);
-    EXPECT_TRUE(result);
+    EXPECT_FALSE(result);
 }
 
 TEST_F(TestDoCleanTrashFilesWorker, EdgeCase_DeleteFileFails_ThenCancel)

--- a/autotests/plugins/dfmplugin-fileoperations/test_docopyfileworker_impl.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_docopyfileworker_impl.cpp
@@ -1,0 +1,549 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QUrl>
+#include <QDir>
+
+#include "stubext.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-io/dfile.h>
+
+#include "fileoperations/fileoperationutils/docopyfileworker.h"
+#include "fileoperations/fileoperationutils/workerdata.h"
+
+DFMBASE_USE_NAMESPACE
+DPFILEOPERATIONS_USE_NAMESPACE
+
+class DoCopyFileWorkerImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        tempDirPath = tempDir->path();
+
+        workData.reset(new WorkerData);
+        worker = new DoCopyFileWorker(workData);
+        ASSERT_TRUE(worker);
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        if (worker) {
+            worker->stop();
+            delete worker;
+            worker = nullptr;
+        }
+        workData.reset();
+        tempDir.reset();
+    }
+
+protected:
+    FileInfoPointer createTestFile(const QString &fileName, const QString &content = "test content")
+    {
+        QString filePath = tempDirPath + QDir::separator() + fileName;
+        QFile file(filePath);
+        if (file.open(QIODevice::WriteOnly)) {
+            QTextStream stream(&file);
+            stream << content;
+            file.close();
+        }
+        QUrl fileUrl = QUrl::fromLocalFile(filePath);
+        return InfoFactory::create<FileInfo>(fileUrl);
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    QString tempDirPath;
+    QSharedPointer<WorkerData> workData;
+    DoCopyFileWorker *worker { nullptr };
+};
+
+// ========== Constructor / Destructor ==========
+TEST_F(DoCopyFileWorkerImpl, Constructor_InitializesCorrectly)
+{
+    EXPECT_TRUE(worker);
+    EXPECT_EQ(worker->workData, workData);
+}
+
+TEST_F(DoCopyFileWorkerImpl, Destructor_WakesWaitingThreads)
+{
+    delete worker;
+    worker = nullptr;
+    SUCCEED();
+}
+
+// ========== State management ==========
+TEST_F(DoCopyFileWorkerImpl, Pause_SetsStateToPaused)
+{
+    worker->pause();
+    // State should be paused
+    SUCCEED();
+}
+
+TEST_F(DoCopyFileWorkerImpl, Resume_ResumesExecution)
+{
+    worker->pause();
+    worker->resume();
+    SUCCEED();
+}
+
+TEST_F(DoCopyFileWorkerImpl, Stop_SetsStateToStopped)
+{
+    worker->stop();
+    SUCCEED();
+}
+
+TEST_F(DoCopyFileWorkerImpl, OperateAction_SetsCurrentAction)
+{
+    worker->operateAction(AbstractJobHandler::SupportAction::kSkipAction);
+    SUCCEED();
+}
+
+TEST_F(DoCopyFileWorkerImpl, OperateAction_Retry)
+{
+    workData->singleThread = false;
+    worker->operateAction(AbstractJobHandler::SupportAction::kRetryAction);
+    SUCCEED();
+}
+
+// ========== progressCallback ==========
+TEST_F(DoCopyFileWorkerImpl, ProgressCallback_UpdatesProgress)
+{
+    DoCopyFileWorker::ProgressData data;
+    data.data = workData;
+    data.copyFile = QUrl::fromLocalFile("/test/file.txt");
+
+    qint64 initialWriteSize = workData->currentWriteSize;
+
+    DoCopyFileWorker::progressCallback(1000, 2000, &data);
+
+    EXPECT_GT(workData->currentWriteSize, initialWriteSize);
+}
+
+TEST_F(DoCopyFileWorkerImpl, ProgressCallback_ZeroTotalSize)
+{
+    DoCopyFileWorker::ProgressData data;
+    data.data = workData;
+    data.copyFile = QUrl::fromLocalFile("/test/file.txt");
+
+    qint64 initialZeroSize = workData->zeroOrlinkOrDirWriteSize;
+
+    DoCopyFileWorker::progressCallback(0, 0, &data);
+
+    EXPECT_GT(workData->zeroOrlinkOrDirWriteSize, initialZeroSize);
+}
+
+// ========== doFileCopy ==========
+TEST_F(DoCopyFileWorkerImpl, DoFileCopy_CallsCopy)
+{
+    auto sourceFile = createTestFile("source.txt");
+    auto targetFile = createTestFile("target.txt");
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetFile->urlOf(UrlInfoType::kUrl)));
+
+    stub.set_lamda(&DoCopyFileWorker::doCopyFileByRange,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyNext;
+                   });
+
+    worker->doFileCopy(fromInfo, toInfo);
+    EXPECT_EQ(workData->completeFileCount, 1);
+}
+
+// ========== doDfmioFileCopy ==========
+TEST_F(DoCopyFileWorkerImpl, DoDfmioFileCopy_Success)
+{
+    auto sourceFile = createTestFile("dfmio_source.txt");
+    QString targetPath = tempDirPath + "/dfmio_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    fromInfo->initQuerier();
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    stub.set_lamda(&DoCopyFileWorker::readAheadSourceFile,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &) { });
+
+    stub.set_lamda(ADDR(dfmio::DOperator, copyFile),
+                   [](dfmio::DOperator *, const QUrl &, DFile::CopyFlags,
+                      DOperator::ProgressCallbackFunc, void *) -> bool { return true; });
+
+    bool skip = false;
+    bool result = worker->doDfmioFileCopy(fromInfo, toInfo, &skip);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(DoCopyFileWorkerImpl, DoDfmioFileCopy_Stopped)
+{
+    auto sourceFile = createTestFile("dfmio_stopped.txt");
+    QString targetPath = tempDirPath + "/dfmio_stopped_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    worker->stop();
+
+    bool skip = false;
+    bool result = worker->doDfmioFileCopy(fromInfo, toInfo, &skip);
+    EXPECT_FALSE(result);
+}
+
+// ========== openFileBySys ==========
+TEST_F(DoCopyFileWorkerImpl, OpenFileBySys_OpenSuccess)
+{
+    auto testFile = createTestFile("open_test.txt");
+    auto fromInfo = DFileInfoPointer(new DFileInfo(testFile->urlOf(UrlInfoType::kUrl)));
+    fromInfo->initQuerier();
+    auto toInfo = DFileInfoPointer(new DFileInfo(testFile->urlOf(UrlInfoType::kUrl)));
+
+    bool skip = false;
+    int fd = worker->openFileBySys(fromInfo, toInfo, O_RDONLY, &skip, true);
+
+    if (fd >= 0) {
+        close(fd);
+        EXPECT_GE(fd, 0);
+    }
+    SUCCEED();
+}
+
+// ========== doCopyFilePractically ==========
+TEST_F(DoCopyFileWorkerImpl, DoCopyFilePractically_Stopped)
+{
+    auto sourceFile = createTestFile("practical_stopped.txt");
+    QString targetPath = tempDirPath + "/practical_stopped_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    worker->stop();
+
+    bool skip = false;
+    auto result = worker->doCopyFilePractically(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel);
+}
+
+TEST_F(DoCopyFileWorkerImpl, DoCopyFilePractically_DirectMode)
+{
+    auto sourceFile = createTestFile("direct_mode.txt");
+    QString targetPath = tempDirPath + "/direct_mode_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    workData->exBlockSyncEveryWrite = true;
+    workData->isTargetFileLocal = false;
+
+    stub.set_lamda(&DoCopyFileWorker::doCopyFileWithDirectIO,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyNext;
+                   });
+
+    bool skip = false;
+    auto result = worker->doCopyFilePractically(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyNext);
+}
+
+TEST_F(DoCopyFileWorkerImpl, DoCopyFilePractically_TraditionalMode)
+{
+    auto sourceFile = createTestFile("traditional.txt");
+    QString targetPath = tempDirPath + "/traditional_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    workData->exBlockSyncEveryWrite = false;
+
+    stub.set_lamda(&DoCopyFileWorker::doCopyFileTraditional,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyNext;
+                   });
+
+    bool skip = false;
+    auto result = worker->doCopyFilePractically(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyNext);
+}
+
+// ========== doCopyFileTraditional ==========
+TEST_F(DoCopyFileWorkerImpl, DoCopyFileTraditional_Success)
+{
+    auto sourceFile = createTestFile("traditional_source.txt", "test data");
+    QString targetPath = tempDirPath + "/traditional_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    fromInfo->initQuerier();
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    stub.set_lamda(&DoCopyFileWorker::readAheadSourceFile,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &) { });
+
+    stub.set_lamda(ADDR(dfmio::DOperator, copyFile),
+                   [](dfmio::DOperator *, const QUrl &, DFile::CopyFlags,
+                      DOperator::ProgressCallbackFunc, void *) -> bool { return true; });
+
+    bool skip = false;
+    auto result = worker->doCopyFileTraditional(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyNext);
+}
+
+TEST_F(DoCopyFileWorkerImpl, DoCopyFileTraditional_Stopped)
+{
+    auto sourceFile = createTestFile("trad_stopped.txt");
+    QString targetPath = tempDirPath + "/trad_stopped_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    worker->stop();
+
+    bool skip = false;
+    auto result = worker->doCopyFileTraditional(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel);
+}
+
+// ========== doCopyFileByRange ==========
+TEST_F(DoCopyFileWorkerImpl, DoCopyFileByRange_Stopped)
+{
+    auto sourceFile = createTestFile("range_stopped.txt");
+    QString targetPath = tempDirPath + "/range_stopped_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    worker->stop();
+
+    bool skip = false;
+    auto result = worker->doCopyFileByRange(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel);
+}
+
+TEST_F(DoCopyFileWorkerImpl, DoCopyFileByRange_Fallback)
+{
+    auto sourceFile = createTestFile("range_fallback.txt");
+    QString targetPath = tempDirPath + "/range_fallback_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    fromInfo->initQuerier();
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    stub.set_lamda(&DoCopyFileWorker::shouldFallbackFromCopyFileRange,
+                   [](DoCopyFileWorker *, int) -> bool { return true; });
+
+    // Force copy_file_range failure so the fallback branch is exercised;
+    // otherwise the copy succeeds on tmpfs and the fallback path is never reached.
+    stub.set_lamda(copy_file_range,
+                   [](int, off_t *, int, off_t *, size_t, unsigned int) -> ssize_t {
+                       errno = EXDEV;
+                       return -1;
+                   });
+
+    bool skip = false;
+    auto result = worker->doCopyFileByRange(fromInfo, toInfo, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyFallback);
+}
+
+// ========== openDestinationFile ==========
+TEST_F(DoCopyFileWorkerImpl, OpenDestinationFile_NormalMode)
+{
+    QString targetPath = tempDirPath + "/dest_new.txt";
+
+    auto result = worker->openDestinationFile(targetPath, DoCopyFileWorker::WriteMode::Normal);
+
+    if (result.fd >= 0) {
+        close(result.fd);
+        EXPECT_GE(result.fd, 0);
+    }
+    SUCCEED();
+}
+
+TEST_F(DoCopyFileWorkerImpl, OpenDestinationFile_DirectMode)
+{
+    QString targetPath = tempDirPath + "/dest_direct.txt";
+
+    auto result = worker->openDestinationFile(targetPath, DoCopyFileWorker::WriteMode::Direct);
+
+    if (result.fd >= 0) {
+        close(result.fd);
+    }
+    SUCCEED();
+}
+
+// ========== reopenDestinationFileForResume ==========
+TEST_F(DoCopyFileWorkerImpl, ReopenDestinationFileForResume_ExistingFile)
+{
+    auto targetFile = createTestFile("reopen_target.txt", "existing content");
+    QString targetPath = targetFile->urlOf(UrlInfoType::kUrl).toLocalFile();
+
+    auto result = worker->reopenDestinationFileForResume(targetPath, DoCopyFileWorker::WriteMode::Normal);
+
+    if (result.fd >= 0) {
+        close(result.fd);
+    }
+    SUCCEED();
+}
+
+// ========== allocateAlignedBuffer ==========
+TEST_F(DoCopyFileWorkerImpl, AllocateAlignedBuffer_4KAlignment)
+{
+    char *buffer = worker->allocateAlignedBuffer(4096, 4096);
+
+    if (buffer) {
+        EXPECT_NE(buffer, nullptr);
+        EXPECT_EQ(reinterpret_cast<uintptr_t>(buffer) % 4096, 0);
+        free(buffer);
+    }
+    SUCCEED();
+}
+
+// ========== actionToNextDo / actionOperating ==========
+TEST_F(DoCopyFileWorkerImpl, ActionToNextDo_NoAction)
+{
+    bool skip = false;
+    auto result = worker->actionToNextDo(AbstractJobHandler::SupportAction::kNoAction, 100, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyNext);
+}
+
+TEST_F(DoCopyFileWorkerImpl, ActionToNextDo_Skip)
+{
+    bool skip = false;
+    auto result = worker->actionToNextDo(AbstractJobHandler::SupportAction::kSkipAction, 100, &skip);
+    EXPECT_EQ(result, DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel);
+    EXPECT_TRUE(skip);
+}
+
+// ========== shouldFallbackFromCopyFileRange ==========
+TEST_F(DoCopyFileWorkerImpl, ShouldFallbackFromCopyFileRange_EINVAL)
+{
+    bool result = worker->shouldFallbackFromCopyFileRange(EINVAL);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(DoCopyFileWorkerImpl, ShouldFallbackFromCopyFileRange_EXDEV)
+{
+    bool result = worker->shouldFallbackFromCopyFileRange(EXDEV);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(DoCopyFileWorkerImpl, ShouldFallbackFromCopyFileRange_ENOSYS)
+{
+    bool result = worker->shouldFallbackFromCopyFileRange(ENOSYS);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(DoCopyFileWorkerImpl, ShouldFallbackFromCopyFileRange_Success)
+{
+    bool result = worker->shouldFallbackFromCopyFileRange(0);
+    EXPECT_FALSE(result);
+}
+
+// ========== mapSystemErrorToJobError ==========
+TEST_F(DoCopyFileWorkerImpl, MapSystemErrorToJobError_NoSpace)
+{
+    auto result = worker->mapSystemErrorToJobError(ENOSPC, true);
+    EXPECT_EQ(result, AbstractJobHandler::JobErrorType::kNotEnoughSpaceError);
+}
+
+TEST_F(DoCopyFileWorkerImpl, MapSystemErrorToJobError_Permission)
+{
+    // The implementation maps EACCES/EPERM to kPermissionDeniedError
+    auto result = worker->mapSystemErrorToJobError(EACCES, true);
+    EXPECT_EQ(result, AbstractJobHandler::JobErrorType::kPermissionDeniedError);
+    result = worker->mapSystemErrorToJobError(EPERM, true);
+    EXPECT_EQ(result, AbstractJobHandler::JobErrorType::kPermissionDeniedError);
+}
+
+// ========== Signal emission ==========
+TEST_F(DoCopyFileWorkerImpl, CurrentTask_SignalEmitted)
+{
+    bool signalEmitted = false;
+    QUrl receivedSource, receivedTarget;
+
+    QObject::connect(worker, &DoCopyFileWorker::currentTask,
+                   [&signalEmitted, &receivedSource, &receivedTarget](const QUrl &source, const QUrl &target) {
+                       signalEmitted = true;
+                       receivedSource = source;
+                       receivedTarget = target;
+                   });
+
+    auto sourceFile = createTestFile("signal_source.txt");
+    QString targetPath = tempDirPath + "/signal_target.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    fromInfo->initQuerier();
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    stub.set_lamda(&DoCopyFileWorker::readAheadSourceFile,
+                   [](DoCopyFileWorker *, const DFileInfoPointer &) { });
+
+    stub.set_lamda(ADDR(dfmio::DOperator, copyFile),
+                   [](dfmio::DOperator *, const QUrl &, DFile::CopyFlags,
+                      DOperator::ProgressCallbackFunc, void *) -> bool { return true; });
+
+    bool skip = false;
+    worker->doDfmioFileCopy(fromInfo, toInfo, &skip);
+
+    EXPECT_TRUE(signalEmitted);
+}
+
+// ========== createFileDevice / createFileDevices ==========
+TEST_F(DoCopyFileWorkerImpl, CreateFileDevice_Stopped)
+{
+    auto sourceFile = createTestFile("create_dev.txt");
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+
+    worker->stop();
+
+    QSharedPointer<DFMIO::DFile> file;
+    bool skip = false;
+    bool result = worker->createFileDevice(fromInfo, toInfo, fromInfo, file, &skip);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(DoCopyFileWorkerImpl, CreateFileDevices_Stopped)
+{
+    auto sourceFile = createTestFile("create_devs.txt");
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+
+    worker->stop();
+
+    QSharedPointer<DFMIO::DFile> fromFile, toFile;
+    bool skip = false;
+    bool result = worker->createFileDevices(fromInfo, toInfo, fromFile, toFile, &skip);
+    EXPECT_FALSE(result);
+}
+
+// ========== verifyFileIntegrity ==========
+TEST_F(DoCopyFileWorkerImpl, VerifyFileIntegrity_ZeroSize)
+{
+    auto sourceFile = createTestFile("verify.txt");
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+
+    QSharedPointer<DFMIO::DFile> toFile;
+    bool result = worker->verifyFileIntegrity(1024, 0, fromInfo, toInfo, toFile);
+    EXPECT_TRUE(result);
+}

--- a/autotests/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
@@ -24,6 +24,7 @@
 #include <dfm-base/utils/fileutils.h>
 
 #include "fileoperations/deletefiles/dodeletefilesworker.h"
+#include "fileoperations/fileoperationutils/fileoperationsutils.h"
 
 DFMBASE_USE_NAMESPACE
 DPFILEOPERATIONS_USE_NAMESPACE
@@ -424,6 +425,13 @@ TEST_F(TestDoDeleteFilesWorker, DeleteAllFiles_LocalDevice)
 {
     worker->isSourceFileLocal = true;
 
+    // Disable the FTS path (DConfig default true) so the local-device
+    // branch is actually taken
+    stub.set_lamda(&FileOperationsUtils::useFtsDelete, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
     stub.set_lamda(&DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice,
                    [](DoDeleteFilesWorker *) -> bool {
                        __DBG_STUB_INVOKE__
@@ -437,6 +445,13 @@ TEST_F(TestDoDeleteFilesWorker, DeleteAllFiles_LocalDevice)
 TEST_F(TestDoDeleteFilesWorker, DeleteAllFiles_OtherDevice)
 {
     worker->isSourceFileLocal = false;
+
+    // Disable the FTS path (DConfig default true) so the other-device
+    // branch is actually taken
+    stub.set_lamda(&FileOperationsUtils::useFtsDelete, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
 
     stub.set_lamda(&DoDeleteFilesWorker::deleteFilesOnOtherDevice,
                    [](DoDeleteFilesWorker *) -> bool {

--- a/autotests/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
@@ -13,6 +13,7 @@
 #include "stubext.h"
 
 #include "fileoperations/trashfiles/domovetotrashfilesworker.h"
+#include <dfm-io/trashhelper.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/file/local/syncfileinfo.h>
 #include <dfm-base/file/local/asyncfileinfo.h>
@@ -310,7 +311,21 @@ TEST_F(TestDoMoveToTrashFilesWorker, IsCanMoveToTrash_TrashIsEmpty)
 
 TEST_F(TestDoMoveToTrashFilesWorker, TrashTargetUrl_ValidUrl)
 {
+    // Product requires a trash url carrying "startTime-endTime" user info;
+    // the actual trash name resolution is done by dfm-io TrashHelper which
+    // depends on the real trash dir, so stub it
     QUrl sourceUrl = QUrl::fromLocalFile("/tmp/test.txt");
+    sourceUrl.setUserInfo("1720000000-1720000001");
+
+    stub.set_lamda(&DFMIO::TrashHelper::getTrashUrls,
+                   [](DFMIO::TrashHelper *, QList<QUrl> *trashUrls, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (trashUrls)
+                           trashUrls->append(QUrl::fromLocalFile(
+                                   "/home/user/.local/share/Trash/files/test.txt"));
+                       return true;
+                   });
+
     QUrl trashUrl = worker->trashTargetUrl(sourceUrl);
 
     EXPECT_TRUE(trashUrl.isValid());
@@ -319,6 +334,17 @@ TEST_F(TestDoMoveToTrashFilesWorker, TrashTargetUrl_ValidUrl)
 TEST_F(TestDoMoveToTrashFilesWorker, TrashTargetUrl_DuplicateName)
 {
     QUrl sourceUrl = QUrl::fromLocalFile("/tmp/duplicate.txt");
+    sourceUrl.setUserInfo("1720000000-1720000001");
+
+    // Duplicate names are resolved inside TrashHelper (e.g. "duplicate.2.txt")
+    stub.set_lamda(&DFMIO::TrashHelper::getTrashUrls,
+                   [](DFMIO::TrashHelper *, QList<QUrl> *trashUrls, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (trashUrls)
+                           trashUrls->append(QUrl::fromLocalFile(
+                                   "/home/user/.local/share/Trash/files/duplicate.2.txt"));
+                       return true;
+                   });
 
     QUrl trashUrl = worker->trashTargetUrl(sourceUrl);
 
@@ -353,7 +379,7 @@ TEST_F(TestDoMoveToTrashFilesWorker, DoHandleErrorNoSpace_UserAction)
 
 // ========== Signal Emission Tests ==========
 
-TEST_F(TestDoMoveToTrashFilesWorker, SignalEmission_FileDeleted)
+TEST_F(TestDoMoveToTrashFilesWorker, SignalEmission_FileRenamed)
 {
     auto testFile = createTestFile("signal_test.txt");
     worker->sourceUrls.append(testFile->urlOf(UrlInfoType::kUrl));
@@ -376,9 +402,17 @@ TEST_F(TestDoMoveToTrashFilesWorker, SignalEmission_FileDeleted)
                        return QUrl::fromLocalFile("/tmp/.Trash/file.txt");
                    });
 
+    // Product emits fileRenamed (not fileDeleted) after a successful
+    // trashFile(); stub it to avoid touching the real trash
+    stub.set_lamda(&LocalFileHandler::trashFile,
+                   [](LocalFileHandler *, const QUrl &) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("1720000000-1720000001");
+                   });
+
     bool signalEmitted = false;
-    QObject::connect(worker, &DoMoveToTrashFilesWorker::fileDeleted,
-                     [&signalEmitted](const QList<QUrl> &) {
+    QObject::connect(worker, &DoMoveToTrashFilesWorker::fileRenamed,
+                     [&signalEmitted](const QUrl &, const QUrl &) {
                          signalEmitted = true;
                      });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
@@ -454,7 +488,9 @@ TEST_F(TestDoMoveToTrashFilesWorker, EdgeCase_CannotMoveToTrash)
                    });
 
     bool result = worker->doMoveToTrash();
-    EXPECT_TRUE(result);   // Should continue even if can't trash
+    // Product aborts (returns false) when the file cannot be trashed and
+    // the skip flag is not set
+    EXPECT_FALSE(result);
 }
 
 TEST_F(TestDoMoveToTrashFilesWorker, EdgeCase_RenameFileFails)
@@ -478,6 +514,21 @@ TEST_F(TestDoMoveToTrashFilesWorker, EdgeCase_RenameFileFails)
                    [](DoMoveToTrashFilesWorker *, const QUrl &) -> QUrl {
                        __DBG_STUB_INVOKE__
                        return QUrl::fromLocalFile("/tmp/.Trash/file.txt");
+                   });
+    // Force the trash (rename) failure path
+    stub.set_lamda(&LocalFileHandler::trashFile,
+                   [](LocalFileHandler *, const QUrl &) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString();
+                   });
+    // User chooses cancel on the error dialog
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &,
+                      const bool, const QString &,
+                      const bool) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kCancelAction;
                    });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
     stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),

--- a/autotests/plugins/dfmplugin-fileoperations/test_dorestoretrashfilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_dorestoretrashfilesworker.cpp
@@ -118,19 +118,18 @@ TEST_F(TestDoRestoreTrashFilesWorker, Destructor_CallsStop)
 
 // ========== initArgs Tests ==========
 
-TEST_F(TestDoRestoreTrashFilesWorker, InitArgs_ClearsHandleSourceFiles)
+TEST_F(TestDoRestoreTrashFilesWorker, InitArgs_ClearsCompleteTargetFiles)
 {
-    worker->handleSourceFiles.append(QUrl::fromLocalFile("/tmp/test.txt"));
-
-    stub.set_lamda(VADDR(DoRestoreTrashFilesWorker, initArgs), [](FileOperateBaseWorker *) -> bool {
-        __DBG_STUB_INVOKE__
-        return true;
-    });
+    // Product initArgs() clears completeTargetFiles (and delegates to
+    // AbstractWorker::initArgs); it never touches handleSourceFiles, so call
+    // the real implementation instead of stubbing the function under test
+    worker->completeTargetFiles.append(QUrl::fromLocalFile("/tmp/test.txt"));
 
     bool result = worker->initArgs();
 
     EXPECT_TRUE(result);
-    EXPECT_TRUE(worker->handleSourceFiles.isEmpty());
+    EXPECT_TRUE(worker->completeTargetFiles.isEmpty());
+    EXPECT_EQ(worker->currentState, AbstractJobHandler::JobState::kRunningState);
 }
 
 // ========== statisticsFilesSize Tests ==========
@@ -139,9 +138,10 @@ TEST_F(TestDoRestoreTrashFilesWorker, StatisticsFilesSize_EmptySources)
 {
     worker->sourceUrls.clear();
 
+    // Product returns false when the source list is empty
     bool result = worker->statisticsFilesSize();
 
-    EXPECT_TRUE(result);
+    EXPECT_FALSE(result);
 }
 
 TEST_F(TestDoRestoreTrashFilesWorker, StatisticsFilesSize_WithSources)
@@ -234,14 +234,21 @@ TEST_F(TestDoRestoreTrashFilesWorker, TranslateUrls_Success)
     EXPECT_TRUE(result);
 }
 
-TEST_F(TestDoRestoreTrashFilesWorker, TranslateUrls_StateCheckFails)
+TEST_F(TestDoRestoreTrashFilesWorker, TranslateUrls_ParseErrorCancel)
 {
+    // A file-scheme url without "startTime-endTime" user info hits the
+    // parse-error path; translateUrls() itself has no stateCheck, so exercise
+    // the real failure path: user chooses cancel on the error dialog
     worker->sourceUrls.append(QUrl::fromLocalFile("/tmp/test.txt"));
 
-    stub.set_lamda(VADDR(AbstractWorker, stateCheck), [](AbstractWorker *) -> bool {
-        __DBG_STUB_INVOKE__
-        return false;
-    });
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &,
+                      const bool, const QString &,
+                      const bool) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kCancelAction;
+                   });
 
     bool result = worker->translateUrls();
 
@@ -292,6 +299,15 @@ TEST_F(TestDoRestoreTrashFilesWorker, DoRestoreTrashFiles_WithFiles)
     stub.set_lamda(&FileOperateBaseWorker::doCopyFile,
                    [](FileOperateBaseWorker *, const DFileInfoPointer &,
                       const DFileInfoPointer &, bool *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    // The actual restore uses LocalFileHandler::moveFile; stub it so the
+    // real trash/target filesystem is not touched
+    stub.set_lamda(&LocalFileHandler::moveFile,
+                   [](LocalFileHandler *, const QUrl &, const QUrl &,
+                      DFMIO::DFile::CopyFlag) -> bool {
                        __DBG_STUB_INVOKE__
                        return true;
                    });
@@ -370,15 +386,19 @@ TEST_F(TestDoRestoreTrashFilesWorker, MergeDir_Success)
     SUCCEED();   // Just verify it doesn't crash
 }
 
-TEST_F(TestDoRestoreTrashFilesWorker, MergeDir_StateCheckFails)
+TEST_F(TestDoRestoreTrashFilesWorker, MergeDir_CopyFails)
 {
     auto sourceDir = createTestDir("merge_source_fail");
     auto targetDir = createTestDir("merge_target_fail");
 
-    stub.set_lamda(VADDR(AbstractWorker, stateCheck), [](AbstractWorker *) -> bool {
-        __DBG_STUB_INVOKE__
-        return false;
-    });
+    // mergeDir() delegates to copyFileFromTrash(); no stateCheck involved.
+    // Make the underlying copy fail to verify the false return
+    stub.set_lamda(&FileOperateBaseWorker::copyFileFromTrash,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      DFile::CopyFlag) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
 
     bool result = worker->mergeDir(sourceDir->urlOf(UrlInfoType::kUrl),
                                    targetDir->urlOf(UrlInfoType::kUrl),
@@ -389,7 +409,7 @@ TEST_F(TestDoRestoreTrashFilesWorker, MergeDir_StateCheckFails)
 
 // ========== Signal Emission Tests ==========
 
-TEST_F(TestDoRestoreTrashFilesWorker, SignalEmission_FileAdded)
+TEST_F(TestDoRestoreTrashFilesWorker, SignalEmission_FileRenamed)
 {
     auto testFile = createTestFile("signal_added.txt");
     worker->sourceUrls.append(testFile->urlOf(UrlInfoType::kUrl));
@@ -426,9 +446,17 @@ TEST_F(TestDoRestoreTrashFilesWorker, SignalEmission_FileAdded)
                        return true;
                    });
 
+    // Product emits fileRenamed (not fileAdded) after a successful restore
+    stub.set_lamda(&LocalFileHandler::moveFile,
+                   [](LocalFileHandler *, const QUrl &, const QUrl &,
+                      DFMIO::DFile::CopyFlag) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
     bool signalEmitted = false;
-    QObject::connect(worker, &DoRestoreTrashFilesWorker::fileAdded,
-                     [&signalEmitted](const QUrl &) {
+    QObject::connect(worker, &DoRestoreTrashFilesWorker::fileRenamed,
+                     [&signalEmitted](const QUrl &, const QUrl &) {
                          signalEmitted = true;
                      });
 
@@ -470,8 +498,11 @@ TEST_F(TestDoRestoreTrashFilesWorker, EdgeCase_MultipleFiles)
                        return DFileInfoPointer(new DFileInfo(tempDirUrl));
                    });
 
-    stub.set_lamda(&FileOperateBaseWorker::doCopyFile,
-                   []() -> bool {
+    // The actual restore uses LocalFileHandler::moveFile (doCopyFile is not
+    // involved); stub it so all three files restore successfully
+    stub.set_lamda(&LocalFileHandler::moveFile,
+                   [](LocalFileHandler *, const QUrl &, const QUrl &,
+                      DFMIO::DFile::CopyFlag) -> bool {
                        __DBG_STUB_INVOKE__
                        return true;
                    });

--- a/autotests/plugins/dfmplugin-fileoperations/test_errormessageandaction.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_errormessageandaction.cpp
@@ -78,9 +78,12 @@ TEST_F(TestErrorMessageAndAction, ErrorMsg_WithCustomErrorMsg)
     QUrl to = QUrl::fromLocalFile("/tmp/dest.txt");
     QString customMsg = "Custom error message";
 
-    QString msg = ErrorMessageAndAction::errorMsg(from, to, AbstractJobHandler::JobErrorType::kProrogramError, false, customMsg);
+    // errorToStringByCause only has a custom-message branch for concrete error types;
+    // kProrogramError falls to default and returns an empty string.
+    QString msg = ErrorMessageAndAction::errorMsg(from, to, AbstractJobHandler::JobErrorType::kWriteError, false, customMsg);
 
     EXPECT_FALSE(msg.isEmpty());
+    EXPECT_TRUE(msg.contains(customMsg));
 }
 
 TEST_F(TestErrorMessageAndAction, ErrorMsg_IsToFlagTrue)
@@ -182,9 +185,12 @@ TEST_F(TestErrorMessageAndAction, SrcAndDestString_EmptyUrls)
 
 TEST_F(TestErrorMessageAndAction, SupportActions_NoError)
 {
+    // For kNoError the implementation falls to the default branch and only offers cancel
     AbstractJobHandler::SupportActions actions = ErrorMessageAndAction::supportActions(AbstractJobHandler::JobErrorType::kNoError);
 
-    EXPECT_EQ(actions, AbstractJobHandler::SupportAction::kNoAction);
+    EXPECT_TRUE(actions & AbstractJobHandler::SupportAction::kCancelAction);
+    EXPECT_FALSE(actions & AbstractJobHandler::SupportAction::kSkipAction);
+    EXPECT_FALSE(actions & AbstractJobHandler::SupportAction::kRetryAction);
 }
 
 TEST_F(TestErrorMessageAndAction, SupportActions_PermissionError)

--- a/autotests/plugins/dfmplugin-fileoperations/test_filenameutils.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_filenameutils.cpp
@@ -527,7 +527,10 @@ TEST_F(TestFileNameUtils, Integration_CompleteWorkflow_HiddenFileWithMultipleExt
     QString result = FileNamingUtils::generateNonConflictingName(hiddenFile, targetDirInfo);
     EXPECT_TRUE(result.contains(".backup"));
     EXPECT_TRUE(result.contains("copy"));
-    EXPECT_TRUE(result.endsWith(".data.gz"));
+    // QMimeDatabase only recognizes ".gz" as the extension for ".backup.data.gz",
+    // so the generated name keeps ".backup.data" as base name and appends ".gz"
+    EXPECT_TRUE(result.endsWith(".gz"));
+    EXPECT_TRUE(result.startsWith(".backup.data"));
 
     // Verify it doesn't exist
     EXPECT_FALSE(FileExistenceChecker::fileExists(targetDirInfo, result));

--- a/autotests/plugins/dfmplugin-fileoperations/test_fileoperatebaseworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_fileoperatebaseworker.cpp
@@ -20,6 +20,7 @@
 #include <dfm-base/interfaces/fileinfo.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/file/local/localdiriterator.h>
 #include <dfm-io/dfile.h>
 #include <dfm-io/denumerator.h>
 #include <dfm-io/dfmio_utils.h>
@@ -41,6 +42,7 @@ public:
         UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
         InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
         InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+        DirIteratorFactory::regClass<LocalDirIterator>(Global::Scheme::kFile);
 
         // Create temporary directory
         tempDir = std::make_unique<QTemporaryDir>();
@@ -555,13 +557,15 @@ TEST_F(TestFileOperateBaseWorker, DoCheckFile_Stopped)
     auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
     auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
 
+    // stopWork has no short-circuit in doCheckFile: the check completes and
+    // returns the new target info.
     worker->stopWork = true;
 
     QString fileName = "test.txt";
     bool skip = false;
 
     auto result = worker->doCheckFile(fromInfo, toInfo, fileName, &skip);
-    EXPECT_FALSE(result);
+    EXPECT_TRUE(result);
 }
 
 // ========== doCheckNewFile Tests ==========
@@ -572,14 +576,11 @@ TEST_F(TestFileOperateBaseWorker, DoCheckNewFile_NonExistentTarget)
     auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
 
     bool skip = false;
-    QString name;
-    auto result = worker->doCheckNewFile(toInfo, nullptr, name, &skip);
-
-    if (result) {
-        EXPECT_NE(result, nullptr);
-    } else {
-        SUCCEED();   // May return null on some systems
-    }
+    QString name = "new_file.txt";
+    // Signature is (fromInfo, toInfo, ...): the non-existent target goes
+    // into the toInfo slot and is returned directly as the new target.
+    auto result = worker->doCheckNewFile(nullptr, toInfo, name, &skip);
+    EXPECT_NE(result, nullptr);
 }
 
 TEST_F(TestFileOperateBaseWorker, DoCheckNewFile_ExistingTarget)
@@ -765,9 +766,31 @@ TEST_F(TestFileOperateBaseWorker, CopyAndDeleteFile_Success)
     QString targetPath = tempDirPath + "/move_target/moved.txt";
     auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
     auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+    fromInfo->initQuerier();
+    toInfo->initQuerier();
+
+    // Diagnostic stubs: verify which branch copyAndDeleteFile takes.
+    stub.set_lamda(&FileOperateBaseWorker::checkFileSize,
+                   [](FileOperateBaseWorker *, qint64, const QUrl &, const QUrl &, bool *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    // Stub the copy stage to succeed so the cut bookkeeping is exercised.
+    // checkDiskSpaceAvailable is stubbed because doHandleErrorAndWait's pause()
+    // side effect makes it return false in the test environment.
+    stub.set_lamda(&FileOperateBaseWorker::checkDiskSpaceAvailable,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &, bool *) -> bool { return true; });
+    stub.set_lamda(VADDR(DoCopyFileWorker, doDfmioFileCopy),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return true; });
+    stub.set_lamda(VADDR(DoCopyFileWorker, doCopyFilePractically),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyNext;
+                   });
 
     bool skip = false;
-    bool result = worker->copyAndDeleteFile(fromInfo, toInfo, {}, &skip);
+    bool result = worker->copyAndDeleteFile(fromInfo, toInfo, toInfo, &skip);
     EXPECT_TRUE(result);
 }
 
@@ -775,12 +798,21 @@ TEST_F(TestFileOperateBaseWorker, CopyAndDeleteFile_CopyFails)
 {
     auto sourceFile = createTestFile("copy_fail_source.txt");
     auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
-    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile("/tmp/target.txt")));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(tempDirPath + "/copy_fail_target/target.txt")));
+
+    // Force the copy stage to fail so the failure propagates.
+    stub.set_lamda(VADDR(DoCopyFileWorker, doDfmioFileCopy),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return false; });
+    stub.set_lamda(VADDR(DoCopyFileWorker, doCopyFilePractically),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel;
+                   });
 
     bool skip = false;
     bool result = worker->copyAndDeleteFile(fromInfo, toInfo, {}, &skip);
     EXPECT_FALSE(result);
-    EXPECT_TRUE(skip);
 }
 
 // ========== doCopyFile Tests ==========
@@ -790,16 +822,15 @@ TEST_F(TestFileOperateBaseWorker, DoCopyFile_SmallFile)
     auto sourceFile = createTestFile("docopy_source.txt");
     auto targetDir = createTestDir("docopy_target");
 
-    QString targetPath = tempDirPath + "/docopy_target/copied.txt";
+    // doCopyFile expects toInfo to be the existing parent dir; the new
+    // target file is derived from it inside doCheckFile.
     auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
-    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
 
     fromInfo->initQuerier();
     toInfo->initQuerier();
 
     worker->jobType = AbstractJobHandler::JobType::kCopyType;
-    worker->isSourceFileLocal = true;
-    worker->isTargetFileLocal = true;
 
     stub.set_lamda(&FileOperateBaseWorker::doCopyOtherFile,
                    [](FileOperateBaseWorker *, const DFileInfoPointer &,

--- a/autotests/plugins/dfmplugin-fileoperations/test_fileoperatebaseworker_impl.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_fileoperatebaseworker_impl.cpp
@@ -1,0 +1,786 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QUrl>
+#include <QDir>
+#include <QThread>
+#include <QDBusAbstractInterface>
+
+#include "stubext.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/file/local/localdiriterator.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-io/dfile.h>
+#include <dfm-io/denumerator.h>
+#include <dfm-io/dfmio_utils.h>
+
+#include "fileoperations/fileoperationutils/fileoperatebaseworker.h"
+#include "fileoperations/fileoperationutils/workerdata.h"
+#include "fileoperations/copyfiles/docopyfilesworker.h"
+
+DFMBASE_USE_NAMESPACE
+DPFILEOPERATIONS_USE_NAMESPACE
+
+class FileOperateBaseWorkerImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+        DirIteratorFactory::regClass<LocalDirIterator>(Global::Scheme::kFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        tempDirPath = tempDir->path();
+        tempDirUrl = QUrl::fromLocalFile(tempDirPath);
+
+        worker = new DoCopyFilesWorker();
+        ASSERT_TRUE(worker);
+
+        worker->workData.reset(new WorkerData);
+        worker->localFileHandler.reset(new LocalFileHandler);
+
+        // Stub QWaitCondition::wait to avoid blocking in doHandleErrorAndWait
+        using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);
+        stub.set_lamda(static_cast<WaitFunc>(&QWaitCondition::wait),
+                       [](QWaitCondition *, QMutex *, QDeadlineTimer) -> bool {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        if (worker) {
+            worker->stopAllThread();
+            delete worker;
+            worker = nullptr;
+        }
+        tempDir.reset();
+    }
+
+protected:
+    FileInfoPointer createTestFile(const QString &fileName, const QString &content = "test content")
+    {
+        QString filePath = tempDirPath + QDir::separator() + fileName;
+        QFile file(filePath);
+        if (file.open(QIODevice::WriteOnly)) {
+            QTextStream stream(&file);
+            stream << content;
+            file.close();
+        }
+        QUrl fileUrl = QUrl::fromLocalFile(filePath);
+        return InfoFactory::create<FileInfo>(fileUrl);
+    }
+
+    FileInfoPointer createTestDir(const QString &dirName)
+    {
+        QString dirPath = tempDirPath + QDir::separator() + dirName;
+        QDir().mkpath(dirPath);
+        QUrl dirUrl = QUrl::fromLocalFile(dirPath);
+        return InfoFactory::create<FileInfo>(dirUrl);
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    QString tempDirPath;
+    QUrl tempDirUrl;
+    DoCopyFilesWorker *worker { nullptr };
+};
+
+// ========== Constructor / Destructor ==========
+TEST_F(FileOperateBaseWorkerImpl, Constructor_CreatesInstance)
+{
+    FileOperateBaseWorker *baseWorker = new DoCopyFilesWorker();
+    EXPECT_NE(baseWorker, nullptr);
+    delete baseWorker;
+}
+
+TEST_F(FileOperateBaseWorkerImpl, Destructor_CleansUp)
+{
+    FileOperateBaseWorker *baseWorker = new DoCopyFilesWorker();
+    delete baseWorker;
+    SUCCEED();
+}
+
+// ========== doHandleErrorAndWait ==========
+TEST_F(FileOperateBaseWorkerImpl, DoHandleErrorAndWait_NoWorkData)
+{
+    worker->workData.reset();
+    auto action = worker->doHandleErrorAndWait(QUrl(), QUrl(),
+                                              AbstractJobHandler::JobErrorType::kNoError);
+    EXPECT_EQ(action, AbstractJobHandler::SupportAction::kNoAction);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, DoHandleErrorAndWait_CachedAction)
+{
+    worker->workData->errorOfAction[AbstractJobHandler::JobErrorType::kNoError] =
+            AbstractJobHandler::SupportAction::kSkipAction;
+
+    auto action = worker->doHandleErrorAndWait(QUrl(), QUrl(),
+                                              AbstractJobHandler::JobErrorType::kNoError);
+    EXPECT_EQ(action, AbstractJobHandler::SupportAction::kSkipAction);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, DoHandleErrorAndWait_SameFile)
+{
+    auto testFile = createTestFile("same.txt");
+    auto action = worker->doHandleErrorAndWait(testFile->urlOf(UrlInfoType::kUrl),
+                                              testFile->urlOf(UrlInfoType::kUrl),
+                                              AbstractJobHandler::JobErrorType::kNoError);
+    EXPECT_EQ(action, AbstractJobHandler::SupportAction::kCoexistAction);
+}
+
+// ========== emitSpeedUpdatedNotify ==========
+TEST_F(FileOperateBaseWorkerImpl, EmitSpeedUpdatedNotify_Running)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->currentState = AbstractJobHandler::JobState::kRunningState;
+    worker->sourceFilesTotalSize = 1000;
+
+    bool signalEmitted = false;
+    QObject::connect(worker, &DoCopyFilesWorker::speedUpdatedNotify,
+                     [&signalEmitted](const JobInfoPointer &) { signalEmitted = true; });
+
+    worker->emitSpeedUpdatedNotify(500);
+    EXPECT_TRUE(signalEmitted);
+}
+
+// ========== checkDiskSpaceAvailable ==========
+TEST_F(FileOperateBaseWorkerImpl, CheckDiskSpaceAvailable_Sufficient)
+{
+    worker->targetOrgUrl = tempDirUrl;
+
+    stub.set_lamda(&DeviceUtils::deviceBytesFree, [](const QUrl &) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 1024LL * 1024 * 1024;
+    });
+
+    stub.set_lamda(&FileOperationsUtils::isFilesSizeOutLimit,
+                   [](const QUrl &, qint64) -> bool { return false; });
+
+    bool skip = false;
+    bool result = worker->checkDiskSpaceAvailable(QUrl(), QUrl(), &skip);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(skip);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CheckDiskSpaceAvailable_Insufficient)
+{
+    worker->targetOrgUrl = tempDirUrl;
+
+    stub.set_lamda(&DeviceUtils::deviceBytesFree, [](const QUrl &) -> qint64 { return 100; });
+
+    stub.set_lamda(&FileOperationsUtils::isFilesSizeOutLimit,
+                   [](const QUrl &, qint64) -> bool { return true; });
+
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &, const bool,
+                      const QString &, const bool) -> AbstractJobHandler::SupportAction {
+                       __DBG_STUB_INVOKE__
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
+
+    bool skip = false;
+    bool result = worker->checkDiskSpaceAvailable(QUrl(), QUrl(), &skip);
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(skip);
+}
+
+// ========== checkFileSize ==========
+TEST_F(FileOperateBaseWorkerImpl, CheckFileSize_SmallFile)
+{
+    worker->targetUrl = tempDirUrl;
+
+    bool skip = false;
+    bool result = worker->checkFileSize(1024, QUrl(), QUrl(), &skip);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(skip);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CheckFileSize_LargeFileOnVfat)
+{
+    worker->targetUrl = tempDirUrl;
+
+    stub.set_lamda(&dfmio::DFMUtils::fsTypeFromUrl, [](const QUrl &) -> QString { return "vfat"; });
+
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &, const bool,
+                      const QString &, const bool) -> AbstractJobHandler::SupportAction {
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
+
+    bool skip = false;
+    qint64 largeSize = 5LL * 1024 * 1024 * 1024;
+    bool result = worker->checkFileSize(largeSize, QUrl(), QUrl(), &skip);
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(skip);
+}
+
+// ========== checkTotalDiskSpaceAvailable ==========
+TEST_F(FileOperateBaseWorkerImpl, CheckTotalDiskSpaceAvailable_Sufficient)
+{
+    worker->targetOrgUrl = tempDirUrl;
+    worker->sourceFilesTotalSize = 100 * 1024 * 1024;
+
+    stub.set_lamda(&DeviceUtils::deviceBytesFree, [](const QUrl &) -> qint64 { return 1024LL * 1024 * 1024 * 10; });
+
+    bool skip = false;
+    bool result = worker->checkTotalDiskSpaceAvailable(QUrl(), QUrl(), &skip);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(skip);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CheckTotalDiskSpaceAvailable_Insufficient)
+{
+    worker->targetOrgUrl = tempDirUrl;
+    worker->sourceFilesTotalSize = 10LL * 1024 * 1024 * 1024;
+
+    stub.set_lamda(&DeviceUtils::deviceBytesFree, [](const QUrl &) -> qint64 { return 100 * 1024 * 1024; });
+
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &, const bool,
+                      const QString &, const bool) -> AbstractJobHandler::SupportAction {
+                       return AbstractJobHandler::SupportAction::kSkipAction;
+                   });
+
+    bool skip = false;
+    bool result = worker->checkTotalDiskSpaceAvailable(QUrl(), QUrl(), &skip);
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(skip);
+}
+
+// ========== setAllDirPermisson ==========
+TEST_F(FileOperateBaseWorkerImpl, SetAllDirPermisson_EmptyList)
+{
+    worker->supportSetPermission = true;
+    worker->setAllDirPermisson();
+    SUCCEED();
+}
+
+TEST_F(FileOperateBaseWorkerImpl, SetAllDirPermisson_WithPermissions)
+{
+    auto testDir = createTestDir("perm_dir");
+    worker->supportSetPermission = true;
+
+    QSharedPointer<FileOperateBaseWorker::DirSetPermissonInfo> permInfo(
+            new FileOperateBaseWorker::DirSetPermissonInfo);
+    permInfo->target = testDir->urlOf(UrlInfoType::kUrl);
+    permInfo->permission = QFileDevice::ReadUser | QFileDevice::WriteUser;
+
+    worker->dirPermissonList.appendByLock(permInfo);
+    worker->setAllDirPermisson();
+    SUCCEED();
+}
+
+// ========== getWriteDataSize / getTidWriteSize / getSectorsWritten ==========
+TEST_F(FileOperateBaseWorkerImpl, GetWriteDataSize_CustomizeType)
+{
+    worker->countWriteType = AbstractWorker::CountWriteSizeType::kCustomizeType;
+    worker->workData->currentWriteSize = 1000;
+    worker->workData->skipWriteSize = 200;
+    worker->workData->zeroOrlinkOrDirWriteSize = 100;
+
+    qint64 size = worker->getWriteDataSize();
+    EXPECT_EQ(size, 1300);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, GetTidWriteSize_ValidDevice)
+{
+    worker->workData->isBlockDevice = true;
+    qint64 size = worker->getTidWriteSize();
+    EXPECT_GE(size, 0);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, GetTidWriteSize_NoWorkData)
+{
+    worker->workData.reset();
+    qint64 size = worker->getTidWriteSize();
+    EXPECT_EQ(size, 0);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, GetSectorsWritten_BlockDevice)
+{
+    worker->workData->isBlockDevice = true;
+    qint64 sectors = worker->getSectorsWritten();
+    EXPECT_GE(sectors, 0);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, GetSectorsWritten_NoBlockDevice)
+{
+    worker->workData->isBlockDevice = false;
+    qint64 sectors = worker->getSectorsWritten();
+    EXPECT_EQ(sectors, 0);
+}
+
+// ========== determineCountProcessType ==========
+TEST_F(FileOperateBaseWorkerImpl, DetermineCountProcessType_LocalFile)
+{
+    worker->targetOrgUrl = tempDirUrl;
+
+    stub.set_lamda(&dfmio::DFMUtils::mountPathFromUrl, [](const QUrl &) -> QString { return "/tmp"; });
+    stub.set_lamda(&dfmio::DFMUtils::deviceNameFromUrl, [](const QUrl &) -> QString { return "/dev/sda1"; });
+    stub.set_lamda(&FileOperationsUtils::isFileOnDisk, [](const QUrl &) -> bool { return true; });
+
+    worker->determineCountProcessType();
+    EXPECT_TRUE(worker->isTargetFileLocal);
+}
+
+// ========== needsSync / performSync / performAsyncSync ==========
+TEST_F(FileOperateBaseWorkerImpl, NeedsSync_NoWorker)
+{
+    worker->copyOtherFileWorker.reset();
+    bool result = worker->needsSync();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, NeedsSync_LocalTarget)
+{
+    worker->isTargetFileLocal = true;
+    worker->targetUrl = tempDirUrl;
+    bool result = worker->needsSync();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, PerformSync_ValidTarget)
+{
+    worker->targetOrgUrl = tempDirUrl;
+    worker->isTargetFileLocal = true;
+
+    stub.set_lamda(&dfmio::DFMUtils::fsTypeFromUrl, [](const QUrl &) -> QString { return "ext4"; });
+
+    worker->performSync();
+    SUCCEED();
+}
+
+TEST_F(FileOperateBaseWorkerImpl, PerformAsyncSync_ValidTarget)
+{
+    worker->targetOrgUrl = tempDirUrl;
+
+    using IsValidFunc = bool (QDBusAbstractInterface::*)() const;
+    stub.set_lamda(static_cast<IsValidFunc>(&QDBusAbstractInterface::isValid), []() -> bool { return false; });
+
+    worker->performAsyncSync();
+    SUCCEED();
+}
+
+// ========== copyFileFromTrash ==========
+TEST_F(FileOperateBaseWorkerImpl, CopyFileFromTrash_NonExistent)
+{
+    auto fromInfo = QUrl::fromLocalFile("/tmp/nonexistent_trash_file.txt");
+    auto toInfo = QUrl::fromLocalFile(tempDir->path() + "/restored.txt");
+
+    worker->stopWork = true;
+    bool result = worker->copyFileFromTrash(fromInfo, toInfo, {});
+    EXPECT_FALSE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CopyFileFromTrash_Stopped)
+{
+    auto fromInfo = QUrl::fromLocalFile("/tmp/test.txt");
+    auto toInfo = QUrl::fromLocalFile("/tmp/target.txt");
+
+    worker->stopWork = true;
+    bool result = worker->copyFileFromTrash(fromInfo, toInfo, {});
+    EXPECT_FALSE(result);
+}
+
+// ========== createSystemLink ==========
+TEST_F(FileOperateBaseWorkerImpl, CreateSystemLink_NoFollowNoCopy)
+{
+    auto sourceFile = createTestFile("link_src.txt");
+    QString linkPath = tempDirPath + "/link_no_follow.lnk";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(linkPath)));
+
+    bool skip = false;
+    bool result = worker->createSystemLink(fromInfo, toInfo, false, false, &skip);
+    EXPECT_TRUE(result || skip);
+}
+
+// ========== doCheckFile ==========
+TEST_F(FileOperateBaseWorkerImpl, DoCheckFile_NonExistentSource)
+{
+    auto fromInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile("/tmp/nonexistent_src.txt")));
+    auto targetDir = createTestDir("docheck_target");
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
+
+    worker->workData->errorOfAction[AbstractJobHandler::JobErrorType::kNonexistenceError] =
+            AbstractJobHandler::SupportAction::kSkipAction;
+
+    bool skip = false;
+    auto result = worker->doCheckFile(fromInfo, toInfo, "test.txt", &skip);
+    EXPECT_TRUE(result.isNull());
+    EXPECT_TRUE(skip);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, DoCheckFile_Stopped)
+{
+    auto sourceFile = createTestFile("stopped.txt");
+    auto targetDir = createTestDir("stopped_target");
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
+
+    // stopWork has no short-circuit in doCheckFile: it only affects the
+    // error-waiting path, so the check completes and returns the new target.
+    worker->stopWork = true;
+
+    bool skip = false;
+    auto result = worker->doCheckFile(fromInfo, toInfo, "test.txt", &skip);
+    EXPECT_TRUE(result);
+}
+
+// ========== doCheckNewFile ==========
+TEST_F(FileOperateBaseWorkerImpl, DoCheckNewFile_NonExistentTarget)
+{
+    QString targetPath = tempDirPath + "/new_file.txt";
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    bool skip = false;
+    QString name = "new_file.txt";
+    // Signature is (fromInfo, toInfo, ...): the non-existent target goes
+    // into the toInfo slot, fromInfo is only used on conflict paths.
+    auto result = worker->doCheckNewFile(nullptr, toInfo, name, &skip);
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, DoCheckNewFile_ExistingTargetReplace)
+{
+    auto existingFile = createTestFile("existing_target.txt");
+    auto toInfo = DFileInfoPointer(new DFileInfo(existingFile->urlOf(UrlInfoType::kUrl)));
+
+    stub.set_lamda(&FileOperateBaseWorker::doHandleErrorAndWait,
+                   [](FileOperateBaseWorker *, const QUrl &, const QUrl &,
+                      const AbstractJobHandler::JobErrorType &, const bool,
+                      const QString &, const bool) -> AbstractJobHandler::SupportAction {
+                       return AbstractJobHandler::SupportAction::kReplaceAction;
+                   });
+
+    bool skip = false;
+    QString name;
+    auto result = worker->doCheckNewFile(toInfo, nullptr, name, &skip);
+    SUCCEED();
+}
+
+// ========== checkAndCopyFile ==========
+TEST_F(FileOperateBaseWorkerImpl, CheckAndCopyFile_SmallFile)
+{
+    auto sourceFile = createTestFile("copy_source.txt");
+    auto targetDir = createTestDir("copy_target");
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
+
+    fromInfo->initQuerier();
+    toInfo->initQuerier();
+
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->targetUrl = targetDir->urlOf(UrlInfoType::kUrl);
+    worker->isSourceFileLocal = true;
+    worker->isTargetFileLocal = true;
+
+    stub.set_lamda(&FileOperateBaseWorker::doCopyOtherFile,
+                   [](FileOperateBaseWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return true; });
+
+    bool skip = false;
+    bool result = worker->checkAndCopyFile(fromInfo, toInfo, &skip);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CheckAndCopyFile_CopyFails)
+{
+    auto sourceFile = createTestFile("copy_stopped.txt");
+    auto targetDir = createTestDir("copy_stopped_target");
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
+
+    // Local flags are left false so the synchronous doCopyOtherFile branch
+    // is taken; stub it to fail and expect false.
+    stub.set_lamda(&FileOperateBaseWorker::doCopyOtherFile,
+                   [](FileOperateBaseWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return false; });
+
+    bool skip = false;
+    bool result = worker->checkAndCopyFile(fromInfo, toInfo, &skip);
+    EXPECT_FALSE(result);
+}
+
+// ========== checkAndCopyDir ==========
+TEST_F(FileOperateBaseWorkerImpl, CheckAndCopyDir_EmptyDir)
+{
+    auto sourceDir = createTestDir("source_dir");
+    auto targetBase = createTestDir("target_base");
+
+    QString targetPath = tempDirPath + "/target_base/copied_dir";
+    QUrl targetUrl = QUrl::fromLocalFile(targetPath);
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceDir->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetUrl));
+
+    fromInfo->initQuerier();
+
+    worker->targetUrl = targetBase->urlOf(UrlInfoType::kUrl);
+    worker->isTargetFileLocal = true;
+    worker->isSourceFileLocal = true;
+
+    bool skip = false;
+    bool result = worker->checkAndCopyDir(fromInfo, toInfo, &skip);
+    EXPECT_TRUE(result || skip);
+}
+
+// ========== copyAndDeleteFile ==========
+TEST_F(FileOperateBaseWorkerImpl, CopyAndDeleteFile_NonExistentTarget)
+{
+    auto sourceFile = createTestFile("move_source.txt");
+    QString targetPath = tempDirPath + "/move_target/nonexistent_dir/moved.txt";
+
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(targetPath)));
+
+    // Copy stage fails (parent dir does not exist) and must propagate.
+    stub.set_lamda(VADDR(DoCopyFileWorker, doDfmioFileCopy),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return false; });
+    stub.set_lamda(VADDR(DoCopyFileWorker, doCopyFilePractically),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel;
+                   });
+
+    bool skip = false;
+    bool result = worker->copyAndDeleteFile(fromInfo, toInfo, toInfo, &skip);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, CopyAndDeleteFile_CopyFails)
+{
+    auto sourceFile = createTestFile("copy_fail_source.txt");
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(tempDirPath + "/copy_fail_target/target.txt")));
+
+    // Force the copy stage to fail so the failure propagates.
+    stub.set_lamda(VADDR(DoCopyFileWorker, doDfmioFileCopy),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return false; });
+    stub.set_lamda(VADDR(DoCopyFileWorker, doCopyFilePractically),
+                   [](DoCopyFileWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> DoCopyFileWorker::NextDo {
+                       return DoCopyFileWorker::NextDo::kDoCopyErrorAddCancel;
+                   });
+
+    bool skip = false;
+    bool result = worker->copyAndDeleteFile(fromInfo, toInfo, toInfo, &skip);
+    EXPECT_FALSE(result);
+}
+
+// ========== doCopyFile ==========
+TEST_F(FileOperateBaseWorkerImpl, DoCopyFile_SmallFile)
+{
+    auto sourceFile = createTestFile("docopy_source.txt");
+    auto targetDir = createTestDir("docopy_target");
+
+    // doCopyFile expects toInfo to be the existing parent dir; the new
+    // target file is derived from it inside doCheckFile.
+    auto fromInfo = DFileInfoPointer(new DFileInfo(sourceFile->urlOf(UrlInfoType::kUrl)));
+    auto toInfo = DFileInfoPointer(new DFileInfo(targetDir->urlOf(UrlInfoType::kUrl)));
+
+    fromInfo->initQuerier();
+    toInfo->initQuerier();
+
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+
+    stub.set_lamda(&FileOperateBaseWorker::doCopyOtherFile,
+                   [](FileOperateBaseWorker *, const DFileInfoPointer &,
+                      const DFileInfoPointer &, bool *) -> bool { return true; });
+
+    bool skip = false;
+    bool result = worker->doCopyFile(fromInfo, toInfo, &skip);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, DoCopyFile_Stopped)
+{
+    auto fromInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile("/tmp/src.txt")));
+    auto toInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile("/tmp/dst.txt")));
+
+    worker->stopWork = true;
+
+    bool skip = false;
+    bool result = worker->doCopyFile(fromInfo, toInfo, &skip);
+    EXPECT_FALSE(result);
+}
+
+// ========== trashInfo / fileOriginName / removeTrashInfo ==========
+TEST_F(FileOperateBaseWorkerImpl, TrashInfo_ValidTrashFile)
+{
+    QString trashFilesPath = tempDirPath + "/.local/share/Trash/files";
+    QDir().mkpath(trashFilesPath);
+
+    QString testFilePath = trashFilesPath + "/test.txt";
+    QFile file(testFilePath);
+    file.open(QIODevice::WriteOnly);
+    file.close();
+
+    auto fileInfo = DFileInfoPointer(new DFileInfo(QUrl::fromLocalFile(testFilePath)));
+
+    QUrl result = worker->trashInfo(fileInfo);
+    EXPECT_TRUE(result.isValid());
+    EXPECT_TRUE(result.path().contains("info"));
+}
+
+TEST_F(FileOperateBaseWorkerImpl, TrashInfo_NonTrashFile)
+{
+    auto testFile = createTestFile("regular.txt");
+    auto fileInfo = DFileInfoPointer(new DFileInfo(testFile->urlOf(UrlInfoType::kUrl)));
+
+    QUrl result = worker->trashInfo(fileInfo);
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(FileOperateBaseWorkerImpl, FileOriginName_InvalidUrl)
+{
+    QString name = worker->fileOriginName(QUrl());
+    EXPECT_TRUE(name.isEmpty());
+}
+
+TEST_F(FileOperateBaseWorkerImpl, FileOriginName_ValidTrashInfo)
+{
+    QString trashInfoPath = tempDirPath + "/test.trashinfo";
+    QFile file(trashInfoPath);
+    if (file.open(QIODevice::WriteOnly)) {
+        QTextStream stream(&file);
+        stream << "[Trash Info] Path=%E6%B5%8B%E8%AF%95.txt DeletionDate=2025-01-01T00:00:00";
+        file.close();
+    }
+
+    QString name = worker->fileOriginName(QUrl::fromLocalFile(trashInfoPath));
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST_F(FileOperateBaseWorkerImpl, RemoveTrashInfo_ValidUrl)
+{
+    QString trashInfoPath = tempDirPath + "/trashinfo_remove.trashinfo";
+    QFile file(trashInfoPath);
+    file.open(QIODevice::WriteOnly);
+    file.write("[Trash Info]");
+    file.close();
+
+    QUrl infoUrl = QUrl::fromLocalFile(trashInfoPath);
+
+    stub.set_lamda(&LocalFileHandler::deleteFile,
+                   [](LocalFileHandler *, const QUrl &) -> bool { return true; });
+
+    worker->removeTrashInfo(infoUrl);
+    SUCCEED();
+}
+
+TEST_F(FileOperateBaseWorkerImpl, RemoveTrashInfo_InvalidUrl)
+{
+    QUrl invalidUrl;
+    worker->removeTrashInfo(invalidUrl);
+    SUCCEED();
+}
+
+// ========== setSkipValue / initCopyWay / shouldUseBlockWriteType ==========
+TEST_F(FileOperateBaseWorkerImpl, SetSkipValue_SkipAction)
+{
+    bool skip = false;
+    worker->setSkipValue(&skip, AbstractJobHandler::SupportAction::kSkipAction);
+    EXPECT_TRUE(skip);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, SetSkipValue_NullPointer)
+{
+    worker->setSkipValue(nullptr, AbstractJobHandler::SupportAction::kSkipAction);
+    SUCCEED();
+}
+
+TEST_F(FileOperateBaseWorkerImpl, InitCopyWay_LocalToLocal)
+{
+    worker->isSourceFileLocal = true;
+    worker->isTargetFileLocal = true;
+    worker->sourceFilesCount = 10;
+    worker->sourceFilesTotalSize = 100 * 1024 * 1024;
+
+    stub.set_lamda(&FileUtils::getCpuProcessCount, []() -> int { return 8; });
+
+    worker->initCopyWay();
+    EXPECT_EQ(worker->countWriteType, AbstractWorker::CountWriteSizeType::kCustomizeType);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, ShouldUseBlockWriteType_NotRemovable)
+{
+    worker->targetIsRemovable = false;
+    bool result = worker->shouldUseBlockWriteType();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(FileOperateBaseWorkerImpl, ShouldUseBlockWriteType_Fuse)
+{
+    worker->targetIsRemovable = true;
+    worker->workData->isBlockDevice = true;
+    worker->workData->exBlockSyncEveryWrite = true;
+    worker->targetOrgUrl = tempDirUrl;
+
+    stub.set_lamda(&dfmio::DFMUtils::fsTypeFromUrl, [](const QUrl &) -> QString { return "fuse.sshfs"; });
+
+    bool result = worker->shouldUseBlockWriteType();
+    EXPECT_TRUE(result);
+}
+
+// ========== waitThreadPoolOver ==========
+TEST_F(FileOperateBaseWorkerImpl, WaitThreadPoolOver_NoThreadPool)
+{
+    worker->waitThreadPoolOver();
+    SUCCEED();
+}
+
+// ========== emitCurrentTaskNotify ==========
+TEST_F(FileOperateBaseWorkerImpl, EmitCurrentTaskNotify_Signal)
+{
+    worker->jobType = AbstractJobHandler::JobType::kCopyType;
+    worker->sourceFilesTotalSize = 100;
+
+    bool emitted = false;
+    QObject::connect(worker, &DoCopyFilesWorker::currentTaskNotify,
+                     [&emitted](const JobInfoPointer &) { emitted = true; });
+
+    worker->emitCurrentTaskNotify(QUrl::fromLocalFile("/tmp/from"), QUrl::fromLocalFile("/tmp/to"));
+    SUCCEED();
+}
+
+// ========== doHandleErrorAndWait with errorMsgAll ==========
+TEST_F(FileOperateBaseWorkerImpl, DoHandleErrorAndWait_ErrorMsgAll)
+{
+    worker->workData->errorOfAction[AbstractJobHandler::JobErrorType::kNoError] =
+            AbstractJobHandler::SupportAction::kSkipAction;
+
+    auto action = worker->doHandleErrorAndWait(QUrl(), QUrl(),
+                                              AbstractJobHandler::JobErrorType::kNoError,
+                                              false, QString(), true);
+    EXPECT_EQ(action, AbstractJobHandler::SupportAction::kSkipAction);
+}

--- a/autotests/plugins/dfmplugin-fileoperations/test_fileoperationseventreceiver_impl.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_fileoperationseventreceiver_impl.cpp
@@ -1,0 +1,756 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QUrl>
+#include <QDir>
+#include <QMimeData>
+#include <QClipboard>
+
+#include "stubext.h"
+
+#include "fileoperationsevent/fileoperationseventreceiver.h"
+#include "fileoperationsevent/fileoperationseventhandler.h"
+#include "fileoperations/fileoperationsservice.h"
+#include "fileoperations/filecopymovejob.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/fileutils.h>
+
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+using namespace dfmplugin_fileoperations;
+
+class FileOpsEventReceiverImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        receiver = FileOperationsEventReceiver::instance();
+        ASSERT_TRUE(receiver);
+
+        // Never block on modal error dialogs (QDialog::exec() would hang the
+        // whole test run offscreen); let the operation result speak instead.
+        stub.set_lamda(&dfmbase::DialogManager::showErrorDialog,
+                       [](dfmbase::DialogManager *, const QString &, const QString &) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        // Confirm dialogs must return Accepted so the tested code path
+        // actually runs; failure/info popups become no-ops.
+        stub.set_lamda(&dfmbase::DialogManager::showDeleteFilesDialog,
+                       [](dfmbase::DialogManager *, const QList<QUrl> &, bool) -> int {
+                           __DBG_STUB_INVOKE__
+                           return QDialog::Accepted;
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showRestoreDeleteFilesDialog,
+                       [](dfmbase::DialogManager *, const QList<QUrl> &) -> int {
+                           __DBG_STUB_INVOKE__
+                           return QDialog::Accepted;
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showNormalDeleteConfirmDialog,
+                       [](dfmbase::DialogManager *, const QList<QUrl> &) -> int {
+                           __DBG_STUB_INVOKE__
+                           return QDialog::Accepted;
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showNoPermissionDialog,
+                       [](dfmbase::DialogManager *, const QList<QUrl> &) {
+                           __DBG_STUB_INVOKE__
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showRestoreFailedDialog,
+                       [](dfmbase::DialogManager *, int) {
+                           __DBG_STUB_INVOKE__
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showOperationFailedDialog,
+                       [](dfmbase::DialogManager *, const QMap<QUrl, QString> &) {
+                           __DBG_STUB_INVOKE__
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showCopyMoveToSelfDialog,
+                       [](dfmbase::DialogManager *) {
+                           __DBG_STUB_INVOKE__
+                       });
+        stub.set_lamda(&dfmbase::DialogManager::showRenameBusyErrDialog,
+                       [](dfmbase::DialogManager *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        // Clipboard: handing QMimeData to the real offscreen clipboard across
+        // suites leaves dangling ownership (some cases delete the data after
+        // handing it over), which crashes the next setMimeData call. Intercept
+        // all clipboard writes so no test data ever reaches it.
+        stub.set_lamda(&dfmbase::ClipBoard::setDataToClipboard,
+                       [](QMimeData *data) {
+                           __DBG_STUB_INVOKE__
+                           delete data;
+                       });
+        stub.set_lamda(&dfmbase::ClipBoard::setUrlsToClipboard,
+                       [](const QList<QUrl> &, dfmbase::ClipBoard::ClipboardAction, QMimeData *data) {
+                           __DBG_STUB_INVOKE__
+                           delete data;
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+    }
+
+    QUrl createTestFile(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QFile file(path);
+        if (file.open(QIODevice::WriteOnly)) {
+            file.write("test");
+            file.close();
+        }
+        return QUrl::fromLocalFile(path);
+    }
+
+    QUrl createTestDir(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QDir().mkpath(path);
+        return QUrl::fromLocalFile(path);
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    FileOperationsEventReceiver *receiver { nullptr };
+};
+
+// ========== newDocmentName ==========
+TEST_F(FileOpsEventReceiverImpl, NewDocmentName_Folder)
+{
+    QUrl dir = createTestDir("newfolder");
+    QString name = receiver->newDocmentName(dir, QString(), CreateFileType::kCreateFileTypeFolder);
+    EXPECT_FALSE(name.isEmpty());
+    EXPECT_TRUE(name.contains("New Folder") || name.contains("NewFolder") || name.contains(QObject::tr("New Folder")));
+}
+
+TEST_F(FileOpsEventReceiverImpl, NewDocmentName_Text)
+{
+    QUrl dir = createTestDir("newtext");
+    QString name = receiver->newDocmentName(dir, QString(), CreateFileType::kCreateFileTypeText);
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST_F(FileOpsEventReceiverImpl, NewDocmentName_InvalidUrl)
+{
+    QString name = receiver->newDocmentName(QUrl(), "txt", CreateFileType::kCreateFileTypeDefault);
+    EXPECT_TRUE(name.isEmpty());
+}
+
+TEST_F(FileOpsEventReceiverImpl, NewDocmentName_ByBaseName)
+{
+    QUrl dir = createTestDir("bybasename");
+    QString name = receiver->newDocmentName(dir, "MyBase", "txt");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+// ========== handleOperationCopy / Cut / Deletes overloads ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCopy_Basic)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doCopyFile),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &, const QUrl &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationCopy(1, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"),
+                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCopy_WithCallback)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doCopyFile),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &, const QUrl &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationCopy(1, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"),
+                                  AbstractJobHandler::JobFlag::kNoHint, nullptr, QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCut_Basic)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doCutFile),
+                   [](FileOperationsEventReceiver *, quint64, const QList<QUrl> &, const QUrl &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback, const bool) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationCut(1, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"),
+                                 AbstractJobHandler::JobFlag::kNoHint, nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCut_WithCallback)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doCutFile),
+                   [](FileOperationsEventReceiver *, quint64, const QList<QUrl> &, const QUrl &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback, const bool) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationCut(1, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"),
+                                 AbstractJobHandler::JobFlag::kNoHint, nullptr, QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationDeletes_Basic)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doDeleteFile),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback,
+                      const bool, FileOperationsEventReceiver::DoDeleteErrorType &) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationDeletes(1, { QUrl::fromLocalFile("/tmp/a") },
+                                     AbstractJobHandler::JobFlag::kNoHint, nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationDeletes_WithCallback)
+{
+    stub.set_lamda(VADDR(FileOperationsEventReceiver, doDeleteFile),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &,
+                      const AbstractJobHandler::JobFlags &, AbstractJobHandler::OperatorHandleCallback,
+                      const bool, FileOperationsEventReceiver::DoDeleteErrorType &) -> JobHandlePointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->handleOperationDeletes(1, { QUrl::fromLocalFile("/tmp/a") },
+                                     AbstractJobHandler::JobFlag::kNoHint, nullptr, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Open files ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenFiles_Basic)
+{
+    QUrl file = createTestFile("open.txt");
+    bool result = receiver->handleOperationOpenFiles(1, { file });
+    // Result depends on environment; ensure no crash
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenFiles_WithOk)
+{
+    QUrl file = createTestFile("open2.txt");
+    bool ok = false;
+    bool result = receiver->handleOperationOpenFiles(1, { file }, &ok);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenFiles_Callback)
+{
+    QUrl file = createTestFile("open3.txt");
+    receiver->handleOperationOpenFiles(1, { file }, QVariant(), [](const AbstractJobHandler::CallbackArgus &) {
+        __DBG_STUB_INVOKE__
+    });
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenFilesByApp_Basic)
+{
+    QUrl file = createTestFile("openapp.txt");
+    bool result = receiver->handleOperationOpenFilesByApp(1, { file }, { "deepin-editor" });
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenFilesByApp_Callback)
+{
+    QUrl file = createTestFile("openapp2.txt");
+    receiver->handleOperationOpenFilesByApp(1, { file }, { "deepin-editor" }, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Rename operations ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFile_Basic)
+{
+    QUrl oldUrl = createTestFile("old.txt");
+    QUrl newUrl = QUrl::fromLocalFile(tempDir->path() + "/new.txt");
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, doRenameDesktopFile),
+                   [](FileOperationsEventReceiver *, const quint64, const QUrl, const QUrl,
+                      const AbstractJobHandler::JobFlags) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleOperationRenameFile(1, oldUrl, newUrl,
+                                                       AbstractJobHandler::JobFlag::kNoHint);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFile_Callback)
+{
+    QUrl oldUrl = createTestFile("old2.txt");
+    QUrl newUrl = QUrl::fromLocalFile(tempDir->path() + "/new2.txt");
+
+    receiver->handleOperationRenameFile(1, oldUrl, newUrl,
+                                       AbstractJobHandler::JobFlag::kNoHint, QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFiles_BasicReplace)
+{
+    QUrl file = createTestFile("rename.txt");
+    QPair<QString, QString> pair("a", "b");
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, doRenameFiles),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &,
+                      const QPair<QString, QString> &, const QPair<QString, AbstractJobHandler::FileNameAddFlag> &,
+                      FileOperationsEventReceiver::RenameTypes, QMap<QUrl, QUrl> &, QString &,
+                      const QVariant, AbstractJobHandler::OperatorCallback) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleOperationRenameFiles(1, { file }, pair, true);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFiles_CallbackReplace)
+{
+    QUrl file = createTestFile("rename2.txt");
+    QPair<QString, QString> pair("a", "b");
+
+    receiver->handleOperationRenameFiles(1, { file }, pair, true, QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFiles_BasicAppend)
+{
+    QUrl file = createTestFile("rename3.txt");
+    QPair<QString, AbstractJobHandler::FileNameAddFlag> pair("new", AbstractJobHandler::FileNameAddFlag::kPrefix);
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, doRenameFiles),
+                   [](FileOperationsEventReceiver *, const quint64, const QList<QUrl> &,
+                      const QPair<QString, QString> &, const QPair<QString, AbstractJobHandler::FileNameAddFlag> &,
+                      FileOperationsEventReceiver::RenameTypes, QMap<QUrl, QUrl> &, QString &,
+                      const QVariant, AbstractJobHandler::OperatorCallback) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleOperationRenameFiles(1, { file }, pair);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRenameFiles_CallbackAppend)
+{
+    QUrl file = createTestFile("rename4.txt");
+    QPair<QString, AbstractJobHandler::FileNameAddFlag> pair("new", AbstractJobHandler::FileNameAddFlag::kPrefix);
+
+    receiver->handleOperationRenameFiles(1, { file }, pair, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Mkdir ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationMkdir_Basic)
+{
+    QUrl dir = QUrl::fromLocalFile(tempDir->path() + "/mkdir_basic");
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, doMkdir),
+                   [](FileOperationsEventReceiver *, const quint64, const QUrl &, const QVariant &,
+                      AbstractJobHandler::OperatorCallback, const bool) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleOperationMkdir(1, dir);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationMkdir_Callback)
+{
+    QUrl dir = QUrl::fromLocalFile(tempDir->path() + "/mkdir_callback");
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, doMkdir),
+                   [](FileOperationsEventReceiver *, const quint64, const QUrl &, const QVariant &,
+                      AbstractJobHandler::OperatorCallback, const bool) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    receiver->handleOperationMkdir(1, dir, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Touch file ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationTouchFile_ByType)
+{
+    QUrl dir = createTestDir("touchdir");
+    QUrl url = QUrl::fromLocalFile(dir.path() + "/touch.txt");
+
+    stub.set_lamda(
+            static_cast<QString (FileOperationsEventReceiver::*)(const quint64, const QUrl &, const CreateFileType,
+                                                                 const QString &, const QVariant &,
+                                                                 AbstractJobHandler::OperatorCallback)>(
+                    &FileOperationsEventReceiver::doTouchFilePremature),
+            [](FileOperationsEventReceiver *, const quint64, const QUrl &, const CreateFileType,
+               const QString &, const QVariant &, AbstractJobHandler::OperatorCallback) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("/tmp/stub.txt");
+                   });
+
+    QString result = receiver->handleOperationTouchFile(1, url, CreateFileType::kCreateFileTypeText, "txt");
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationTouchFile_ByTempUrl)
+{
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/touch2.txt");
+    QUrl tempUrl = createTestFile("template.txt");
+
+    stub.set_lamda(
+            static_cast<QString (FileOperationsEventReceiver::*)(const quint64, const QUrl &, const QUrl &,
+                                                                 const QString &, const QVariant &,
+                                                                 AbstractJobHandler::OperatorCallback)>(
+                    &FileOperationsEventReceiver::doTouchFilePremature),
+            [](FileOperationsEventReceiver *, const quint64, const QUrl &, const QUrl &,
+               const QString &, const QVariant &, AbstractJobHandler::OperatorCallback) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("/tmp/stub.txt");
+                   });
+
+    QString result = receiver->handleOperationTouchFile(1, url, tempUrl, "txt");
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationTouchFile_CallbackByType)
+{
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/touch3.txt");
+
+    stub.set_lamda(
+            static_cast<QString (FileOperationsEventReceiver::*)(const quint64, const QUrl &, const CreateFileType,
+                                                                 const QString &, const QVariant &,
+                                                                 AbstractJobHandler::OperatorCallback)>(
+                    &FileOperationsEventReceiver::doTouchFilePremature),
+            [](FileOperationsEventReceiver *, const quint64, const QUrl &, const CreateFileType,
+               const QString &, const QVariant &, AbstractJobHandler::OperatorCallback) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("/tmp/stub.txt");
+                   });
+
+    receiver->handleOperationTouchFile(1, url, CreateFileType::kCreateFileTypeText, "txt", QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationTouchFile_CallbackByTempUrl)
+{
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/touch4.txt");
+    QUrl tempUrl = createTestFile("template2.txt");
+
+    stub.set_lamda(
+            static_cast<QString (FileOperationsEventReceiver::*)(const quint64, const QUrl &, const QUrl &,
+                                                                 const QString &, const QVariant &,
+                                                                 AbstractJobHandler::OperatorCallback)>(
+                    &FileOperationsEventReceiver::doTouchFilePremature),
+            [](FileOperationsEventReceiver *, const quint64, const QUrl &, const QUrl &,
+               const QString &, const QVariant &, AbstractJobHandler::OperatorCallback) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return QString("/tmp/stub.txt");
+                   });
+
+    receiver->handleOperationTouchFile(1, url, tempUrl, "txt", QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Link file ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationLinkFile_Basic)
+{
+    QUrl source = createTestFile("link_source.txt");
+    QUrl link = QUrl::fromLocalFile(tempDir->path() + "/link_basic.lnk");
+
+    stub.set_lamda(ADDR(FileOperationsEventReceiver, determineLinkTarget),
+                   [](FileOperationsEventReceiver *, const QUrl &, const QUrl &, const bool, const quint64) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return QUrl::fromLocalFile("/tmp/stub_target");
+                   });
+
+    bool result = receiver->handleOperationLinkFile(1, source, link, false, true);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationLinkFile_Callback)
+{
+    QUrl source = createTestFile("link_source2.txt");
+    QUrl link = QUrl::fromLocalFile(tempDir->path() + "/link_callback.lnk");
+
+    receiver->handleOperationLinkFile(1, source, link, false, true, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Permission ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationSetPermission_Basic)
+{
+    QUrl file = createTestFile("perm.txt");
+
+    stub.set_lamda(ADDR(LocalFileHandler, setPermissions),
+                   [](LocalFileHandler *, const QUrl &, const QFileDevice::Permissions) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleOperationSetPermission(1, file, QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationSetPermission_Callback)
+{
+    QUrl file = createTestFile("perm2.txt");
+
+    stub.set_lamda(ADDR(LocalFileHandler, setPermissions),
+                   [](LocalFileHandler *, const QUrl &, const QFileDevice::Permissions) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    receiver->handleOperationSetPermission(1, file, QFileDevice::ReadOwner, QVariant(), nullptr);
+    SUCCEED();
+}
+
+// ========== Clipboard operations ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationWriteToClipboard)
+{
+    QUrl file = createTestFile("clipboard.txt");
+    bool result = receiver->handleOperationWriteToClipboard(1, ClipBoard::kCopyAction, { file });
+    // Depends on clipboard state; ensure no crash
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationWriteDataToClipboard)
+{
+    // The fixture stub intercepts setDataToClipboard and deletes the data
+    // itself (never hand QMimeData to the real clipboard here), so no extra
+    // delete below.
+    QMimeData *data = new QMimeData();
+    data->setText("test data");
+    bool result = receiver->handleOperationWriteDataToClipboard(1, data);
+    SUCCEED();
+}
+
+// ========== Open in terminal ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationOpenInTerminal)
+{
+    QUrl dir = createTestDir("terminal");
+    bool result = receiver->handleOperationOpenInTerminal(1, { dir });
+    SUCCEED();
+}
+
+// ========== Save / clean operations stack ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationSaveOperations)
+{
+    QVariantMap values;
+    values.insert("test", "value");
+    receiver->handleOperationSaveOperations(values);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCleanSaveOperationsStack)
+{
+    receiver->handleOperationCleanSaveOperationsStack();
+    SUCCEED();
+}
+
+// ========== Hide files ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationHideFiles_Basic)
+{
+    QUrl file = createTestFile("hide.txt");
+    bool result = receiver->handleOperationHideFiles(1, { file });
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationHideFiles_Callback)
+{
+    QUrl file = createTestFile("hide2.txt");
+    receiver->handleOperationHideFiles(1, { file }, QVariant(), nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationHideFiles_ByParent)
+{
+    QUrl parent = createTestDir("hideparent");
+    QUrl file = createTestFile("hideparent/hide3.txt");
+    bool result = receiver->handleOperationHideFiles(1, parent, { file }, true);
+    SUCCEED();
+}
+
+// ========== ShortCut ==========
+TEST_F(FileOpsEventReceiverImpl, HandleShortCut)
+{
+    QUrl root = createTestDir("shortcutroot");
+    QUrl file = createTestFile("shortcutroot/file.txt");
+    bool result = receiver->handleShortCut(1, { file }, root);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleShortCutPaste)
+{
+    QUrl target = createTestDir("shortcuttarget");
+    bool result = receiver->handleShortCutPaste(1, { QUrl::fromLocalFile("/tmp/a") }, target);
+    SUCCEED();
+}
+
+// ========== Redo / undo / save redo ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationSaveRedoOperations)
+{
+    QVariantMap values;
+    values.insert("undoevent", static_cast<uint16_t>(GlobalEventType::kCopy));
+    values.insert("undosources", QStringList({ "/tmp/a" }));
+    values.insert("undotargets", QStringList({ "/tmp/b" }));
+
+    receiver->handleOperationSaveRedoOperations(values);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationCleanByUrls)
+{
+    receiver->handleOperationCleanByUrls({ QUrl::fromLocalFile("/tmp/a") });
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationUndoDeletes)
+{
+    receiver->handleOperationUndoDeletes(1, { QUrl::fromLocalFile("/tmp/a") },
+                                       AbstractJobHandler::JobFlag::kNoHint, nullptr, QVariantMap());
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationUndoCut)
+{
+    receiver->handleOperationUndoCut(1, { QUrl::fromLocalFile("/tmp/a") }, QUrl::fromLocalFile("/tmp/b"),
+                                   AbstractJobHandler::JobFlag::kNoHint, nullptr, QVariantMap());
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleSaveRedoOpt)
+{
+    receiver->handleSaveRedoOpt("token", 1024);
+    SUCCEED();
+}
+
+// ========== IsSubFile ==========
+TEST_F(FileOpsEventReceiverImpl, HandleIsSubFile)
+{
+    QUrl parent = QUrl::fromLocalFile("/tmp/parent");
+    QUrl child = QUrl::fromLocalFile("/tmp/parent/child.txt");
+    bool result = receiver->handleIsSubFile(parent, child);
+    EXPECT_TRUE(result);
+}
+
+// ========== CopyFilePath ==========
+TEST_F(FileOpsEventReceiverImpl, HandleCopyFilePath)
+{
+    receiver->handleCopyFilePath({ QUrl::fromLocalFile("/tmp/a.txt") });
+    SUCCEED();
+}
+
+// ========== Files preview ==========
+TEST_F(FileOpsEventReceiverImpl, HandleOperationFilesPreview)
+{
+    receiver->handleOperationFilesPreview(1, { QUrl::fromLocalFile("/tmp/a.txt") },
+                                          { QUrl::fromLocalFile("/tmp") });
+    SUCCEED();
+}
+
+// ========== Recovery / revocation ==========
+TEST_F(FileOpsEventReceiverImpl, HandleRecoveryOperationRedoRecovery)
+{
+    receiver->handleRecoveryOperationRedoRecovery(1, nullptr);
+    SUCCEED();
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleOperationRevocation)
+{
+    receiver->handleOperationRevocation(1, nullptr);
+    SUCCEED();
+}
+
+// ========== doRenameFiles internal ==========
+TEST_F(FileOpsEventReceiverImpl, DoRenameFiles_BatchReplaceEmpty)
+{
+    QMap<QUrl, QUrl> successUrls;
+    QString errorMsg;
+    QPair<QString, QString> pair("a", "b");
+    QPair<QString, AbstractJobHandler::FileNameAddFlag> pair2;
+
+    bool result = receiver->doRenameFiles(1, {}, pair, pair2,
+                                          FileOperationsEventReceiver::RenameTypes::kBatchRepalce,
+                                          successUrls, errorMsg, QVariant(), nullptr);
+    // Empty urls produce nothing to deal: doRenameFiles returns false when
+    // the replace result is empty.
+    EXPECT_FALSE(result);
+}
+
+// ========== doMkdir internal ==========
+TEST_F(FileOpsEventReceiverImpl, DoMkdir_ValidPath)
+{
+    QUrl dir = QUrl::fromLocalFile(tempDir->path() + "/do_mkdir");
+    bool result = receiver->doMkdir(1, dir, QVariant(), nullptr, true);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(QFile::exists(dir.path()));
+}
+
+TEST_F(FileOpsEventReceiverImpl, DoMkdir_ExistingPath)
+{
+    QUrl dir = createTestDir("existing_mkdir");
+    // The product does not treat "already exists" as success: mkdir fails.
+    bool result = receiver->doMkdir(1, dir, QVariant(), nullptr, true);
+    EXPECT_FALSE(result);
+}
+
+// ========== determineLinkTarget ==========
+TEST_F(FileOpsEventReceiverImpl, DetermineLinkTarget_LocalFile)
+{
+    QUrl source = createTestFile("linktarget.txt");
+    QUrl link = QUrl::fromLocalFile(tempDir->path() + "/determined_link");
+
+    QUrl result = receiver->determineLinkTarget(source, link, true, 1);
+    SUCCEED();
+}
+
+// ========== handleIsSubFile edge cases ==========
+TEST_F(FileOpsEventReceiverImpl, HandleIsSubFile_SameUrl)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/parent");
+    // Implementation is a plain startsWith: an identical path counts as
+    // "sub" (true).
+    bool result = receiver->handleIsSubFile(url, url);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(FileOpsEventReceiverImpl, HandleIsSubFile_InvalidParent)
+{
+    QUrl child = QUrl::fromLocalFile("/tmp/parent/child.txt");
+    bool result = receiver->handleIsSubFile(QUrl(), child);
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-fileoperations/test_fileoperationsutils.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_fileoperationsutils.cpp
@@ -8,6 +8,7 @@
 #include <QFile>
 #include <QTimer>
 #include <QSignalSpy>
+#include <QTest>
 
 #include "stubext.h"
 
@@ -83,8 +84,9 @@ TEST_F(TestFileOperationsUtils, UpdateProgressTimer_SignalEmission)
 
     timer.doStartTime();
 
-    // Wait for at least one timeout
-    QThread::msleep(600);
+    // QTimer needs a running event loop to fire; QTest::qWait processes events
+    // while waiting, unlike QThread::msleep which blocks the event dispatch.
+    QTest::qWait(700);
 
     // Should have emitted at least one signal
     EXPECT_GT(spy.count(), 0);
@@ -172,7 +174,8 @@ TEST_F(TestFileOperationsUtils, StatisticsFilesSize_MultipleFiles)
 
     ASSERT_NE(sizeInfo, nullptr);
     EXPECT_EQ(sizeInfo->fileCount, 3);
-    EXPECT_GT(sizeInfo->totalSize, 3584);  // At least sum of file sizes
+    // FTS sums the exact logical st_size of each file: 1024 + 2048 + 512
+    EXPECT_EQ(sizeInfo->totalSize, 3584);
 }
 
 TEST_F(TestFileOperationsUtils, StatisticsFilesSize_WithRecordUrl)

--- a/autotests/plugins/dfmplugin-fileoperations/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_realevents.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run FileOperations::initialize() with REAL initEventHandle()
+// and followEvents() (NOT stubbed) so the production EventHelper<M> subscribe/follow
+// template instantiations in fileoperations.cpp actually execute -> cover framework
+// event template functions (eventdispatcher.h / eventsequence.h / eventhelper.h).
+//
+// initEventHandle() subscribes use GlobalEventType (always valid, no registration).
+// followEvents() follows hooks that need DPF_EVENT_REG_HOOK registration from other
+// plugins; we register them via dfm_hookreg.h.
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "dfm_hookreg.h"
+
+#include "fileoperations.h"
+
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_fileoperations;
+
+class FileOpsRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        fileOps = new FileOperations();
+    }
+    void TearDown() override
+    {
+        delete fileOps;
+        fileOps = nullptr;
+    }
+    FileOperations *fileOps { nullptr };
+};
+
+// Run the real initialize() (initEventHandle + followEvents un-stubbed) so the
+// EventHelper<M> template instantiations in fileoperations.cpp execute and get covered.
+TEST_F(FileOpsRealEventsTest, Initialize_RunsRealInitAndFollowEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(fileOps->initialize());
+}

--- a/autotests/plugins/dfmplugin-fileoperations/test_trashfileeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_trashfileeventreceiver.cpp
@@ -19,6 +19,7 @@
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/application/application.h>
 #include <dfm-io/denumerator.h>
 
 DFMBASE_USE_NAMESPACE
@@ -131,6 +132,14 @@ TEST_F(TestTrashFileEventReceiver, DoMoveToTrash_UserCancelsDialog)
     stub.set_lamda(&FileUtils::fileCanTrash, [](const QUrl &) -> bool {
         __DBG_STUB_INVOKE__
         return true;
+    });
+
+    // Other suites may have initialized the DSettings backend, syncing the
+    // template default (false) into the process-wide generic setting, which
+    // would skip the confirm dialog entirely. Force it on.
+    stub.set_lamda(&Application::genericAttribute, [](Application::GenericAttribute ga) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return ga == Application::kShowDeleteConfirmDialog ? QVariant(true) : QVariant();
     });
 
     stub.set_lamda(&DialogManager::showNormalDeleteConfirmDialog, []() -> int {


### PR DESCRIPTION
Extend file-operations plugin tests, fixing and expanding coverage
for copy/delete/trash/restore workers, error handling and name
utils.

扩充文件操作插件测试，修复并扩展复制、删除、入回收站、
还原任务及错误处理与文件名工具的覆盖。

Log: 扩充 dfmplugin-fileoperations 单元测试
Influence: 仅调整测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.

## Summary by Sourcery

Broaden and stabilize dfmplugin-fileoperations unit-test coverage while aligning assertions with the implemented behavior.

Bug Fixes:
- Correct unit-test expectations and setup to match actual file-operation behavior, including deletion, trashing, restoring, error handling, signaling, and filename generation.

Enhancements:
- Expand coverage across abstract workers, copy workers, base operation workers, event receivers, and worker utilities, including state transitions, progress reporting, filesystem branches, retries, and edge cases.
- Improve test isolation and reliability by using temporary filesystems, controlled stubs, event-loop-aware waits, deterministic device and trash behavior, and safe thread teardown.

Tests:
- Add comprehensive unit tests for file-operation worker implementations, event receiver APIs, real event initialization, copy paths, error actions, trash metadata, and utility functions.