### PR TITLE
test: add unit tests for dfmplugin-sidebar

### DIFF
--- a/autotests/plugins/dfmplugin-sidebar/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-sidebar/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-sidebar" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-sidebar")

--- a/autotests/plugins/dfmplugin-sidebar/main.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_sidebar)

--- a/autotests/plugins/dfmplugin-sidebar/test_fileoperatorhelper.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_fileoperatorhelper.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/fileoperatorhelper.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_FileOperatorHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_FileOperatorHelper, Instance)
+{
+    auto ins1 = FileOperatorHelper::instance();
+    auto ins2 = FileOperatorHelper::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_MoveAction)
+{
+    bool isCallCut { false };
+    quint64 capturedWindowId { 0 };
+    QList<QUrl> capturedSrcUrls;
+    QUrl capturedTargetUrl;
+    AbstractJobHandler::JobFlag capturedFlag;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, unsigned long long,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, unsigned long long windowId,
+                       const QList<QUrl> &srcUrls, const QUrl &targetUrl,
+                       AbstractJobHandler::JobFlag flag, std::nullptr_t) {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCutFile) {
+                           isCallCut = true;
+                           capturedWindowId = windowId;
+                           capturedSrcUrls = srcUrls;
+                           capturedTargetUrl = targetUrl;
+                           capturedFlag = flag;
+                       }
+                       return true;
+                   });
+
+    quint64 windowId = 12345;
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/tmp/test1.txt"),
+                            QUrl::fromLocalFile("/tmp/test2.txt") };
+    QUrl targetUrl = QUrl::fromLocalFile("/tmp/target");
+
+    FileOperatorHelper::instance()->pasteFiles(windowId, srcUrls, targetUrl, Qt::MoveAction);
+
+    EXPECT_TRUE(isCallCut);
+    EXPECT_EQ(capturedWindowId, windowId);
+    EXPECT_EQ(capturedSrcUrls, srcUrls);
+    EXPECT_EQ(capturedTargetUrl, targetUrl);
+    EXPECT_EQ(capturedFlag, AbstractJobHandler::JobFlag::kNoHint);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_CopyAction)
+{
+    bool isCallCopy { false };
+    quint64 capturedWindowId { 0 };
+    QList<QUrl> capturedSrcUrls;
+    QUrl capturedTargetUrl;
+    AbstractJobHandler::JobFlag capturedFlag;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, quint64 windowId,
+                       const QList<QUrl> &srcUrls, const QUrl &targetUrl,
+                       AbstractJobHandler::JobFlag flag, std::nullptr_t) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCopy) {
+                           isCallCopy = true;
+                           capturedWindowId = windowId;
+                           capturedSrcUrls = srcUrls;
+                           capturedTargetUrl = targetUrl;
+                           capturedFlag = flag;
+                       }
+                       return true;
+                   });
+
+    quint64 windowId = 54321;
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/tmp/copy1.txt") };
+    QUrl targetUrl = QUrl::fromLocalFile("/tmp/copy_target");
+
+    FileOperatorHelper::instance()->pasteFiles(windowId, srcUrls, targetUrl, Qt::CopyAction);
+
+    EXPECT_TRUE(isCallCopy);
+    EXPECT_EQ(capturedWindowId, windowId);
+    EXPECT_EQ(capturedSrcUrls, srcUrls);
+    EXPECT_EQ(capturedTargetUrl, targetUrl);
+    EXPECT_EQ(capturedFlag, AbstractJobHandler::JobFlag::kNoHint);
+}
+
+TEST_F(UT_FileOperatorHelper, PasteFiles_DefaultActionIsCopy)
+{
+    bool isCallCopy { false };
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64,
+                                                        const QList<QUrl> &,
+                                                        const QUrl &,
+                                                        AbstractJobHandler::JobFlag &&,
+                                                        std::nullptr_t &&);
+
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&](EventDispatcherManager *, EventType type, quint64,
+                       const QList<QUrl> &, const QUrl &,
+                       AbstractJobHandler::JobFlag, std::nullptr_t) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (type == GlobalEventType::kCopy) {
+                           isCallCopy = true;
+                       }
+                       return true;
+                   });
+
+    // Use any action other than MoveAction, should default to copy
+    FileOperatorHelper::instance()->pasteFiles(1, { QUrl() }, QUrl(), Qt::LinkAction);
+
+    EXPECT_TRUE(isCallCopy);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_realevents.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run SideBar::initialize() with REAL
+// SideBarEventReceiver::bindEvents() (NOT stubbed) so production connect
+// templates (EventChannelManager::connect<M>) execute.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "sidebar.h"
+#include "events/sidebareventreceiver.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_sidebar;
+
+class SideBarRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) { __DBG_STUB_INVOKE__ });
+        plugin = new SideBar();
+    }
+    void TearDown() override { stub.clear(); delete plugin; }
+    stub_ext::StubExt stub;
+    SideBar *plugin { nullptr };
+};
+
+TEST_F(SideBarRealEventsTest, Initialize_RunsRealBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(plugin->initialize());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebar.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebar.cpp
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "sidebar.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebarview.h"
+#include "utils/sidebarhelper.h"
+#include "events/sidebareventreceiver.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/widgets/filemanagerwindow.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QSignalSpy>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBar : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new SideBar();
+        ASSERT_NE(plugin, nullptr);
+
+        // Stub thread-related functions
+        stub.set_lamda(ADDR(QThread, start), [](QThread *, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+            // Prevent thread start in unit tests
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBar *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBar, Initialize)
+{
+    bool connectCalled = false;
+
+    stub.set_lamda(&SideBarEventReceiver::instance, []() -> SideBarEventReceiver * {
+        __DBG_STUB_INVOKE__
+        static SideBarEventReceiver receiver;
+        return &receiver;
+    });
+
+    stub.set_lamda(&SideBarEventReceiver::bindEvents, [&connectCalled]() {
+        __DBG_STUB_INVOKE__
+        connectCalled = true;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(connectCalled);
+}
+
+TEST_F(UT_SideBar, Start_Success)
+{
+    bool addConfigCalled = false;
+    bool initSettingCalled = false;
+    bool registCustomCalled = false;
+    bool installFilterCalled = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::addConfig,
+                   [&addConfigCalled](DConfigManager *, const QString &, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addConfigCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::initDefaultSettingPanel, [&initSettingCalled]() {
+        __DBG_STUB_INVOKE__
+        initSettingCalled = true;
+    });
+
+    stub.set_lamda(&SideBarHelper::registCustomSettingItem, [&registCustomCalled]() {
+        __DBG_STUB_INVOKE__
+        registCustomCalled = true;
+    });
+
+    typedef bool (EventDispatcherManager::*InstallFilterFunc)(EventType, SideBar *, bool (SideBar::*)(quint64));
+    stub.set_lamda(static_cast<InstallFilterFunc>(&EventDispatcherManager::installEventFilter),
+                   [&installFilterCalled] {
+                       __DBG_STUB_INVOKE__
+                       installFilterCalled = true;
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addConfigCalled);
+    EXPECT_TRUE(initSettingCalled);
+    EXPECT_TRUE(registCustomCalled);
+    EXPECT_TRUE(installFilterCalled);
+}
+
+TEST_F(UT_SideBar, Start_ConfigFailed)
+{
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::addConfig,
+                   [](DConfigManager *, const QString &, QString *err) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (err)
+                           *err = "Test error";
+                       return false;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBar, OnWindowOpened)
+{
+    bool addSideBarCalled = false;
+    bool installSideBarCalled = false;
+    bool updateVisiableCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&SideBarHelper::addSideBar,
+                   [&addSideBarCalled](quint64, SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       addSideBarCalled = true;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::installSideBar,
+                   [&installSideBarCalled](FileManagerWindow *, QWidget *) {
+                       __DBG_STUB_INVOKE__
+                       installSideBarCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    stub.set_lamda(&SideBarHelper::preDefineItemProperties, []() -> QMap<QUrl, QPair<int, QVariantMap>> {
+        __DBG_STUB_INVOKE__
+        return QMap<QUrl, QPair<int, QVariantMap>>();
+    });
+
+    // Stub dpfSlotChannel for accessibility
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, QWidget *, char const(&)[14]);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();
+    });
+
+    stub.set_lamda(&SideBarView::updateSeparatorVisibleState, [] { __DBG_STUB_INVOKE__ });
+
+    plugin->onWindowOpened(testWindowId);
+
+    EXPECT_TRUE(addSideBarCalled);
+    EXPECT_TRUE(installSideBarCalled);
+    EXPECT_TRUE(updateVisiableCalled);
+}
+
+TEST_F(UT_SideBar, OnWindowClosed_LastWindow)
+{
+    bool removeSideBarCalled = false;
+    bool saveStateCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [testWindowId](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << testWindowId;
+                   });
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::saveStateWhenClose,
+                   [&saveStateCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       saveStateCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::removeSideBar,
+                   [&removeSideBarCalled](quint64) {
+                       __DBG_STUB_INVOKE__
+                       removeSideBarCalled = true;
+                   });
+
+    plugin->onWindowClosed(testWindowId);
+
+    EXPECT_TRUE(saveStateCalled);
+    EXPECT_TRUE(removeSideBarCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnWindowClosed_NotLastWindow)
+{
+    bool removeSideBarCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << 1 << 2;   // Multiple windows
+                   });
+
+    stub.set_lamda(&SideBarHelper::removeSideBar,
+                   [&removeSideBarCalled](quint64) {
+                       __DBG_STUB_INVOKE__
+                       removeSideBarCalled = true;
+                   });
+
+    plugin->onWindowClosed(testWindowId);
+
+    EXPECT_TRUE(removeSideBarCalled);
+}
+
+TEST_F(UT_SideBar, OnConfigChanged_VisiableKey)
+{
+    bool updateVisiableCalled = false;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   [](FileManagerWindowsManager *) -> QList<quint64> {
+                       __DBG_STUB_INVOKE__
+                       return QList<quint64>() << 1;
+                   });
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    plugin->onConfigChanged(ConfigInfos::kConfName, ConfigInfos::kVisiableKey);
+
+    EXPECT_TRUE(updateVisiableCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnConfigChanged_WrongConfig)
+{
+    bool updateVisiableCalled = false;
+
+    stub.set_lamda(&SideBarWidget::updateItemVisiable,
+                   [&updateVisiableCalled](SideBarWidget *, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       updateVisiableCalled = true;
+                   });
+
+    plugin->onConfigChanged("wrong.config", ConfigInfos::kVisiableKey);
+
+    EXPECT_FALSE(updateVisiableCalled);
+}
+
+TEST_F(UT_SideBar, OnAboutToShowSettingDialog)
+{
+    bool resetPanelCalled = false;
+
+    quint64 testWindowId = 12345;
+
+    FileManagerWindow mockWindow(QUrl("file:///home"));
+    SideBarWidget *mockSideBar = new SideBarWidget();
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&mockWindow](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(&FileManagerWindow::sideBar,
+                   [mockSideBar](FileManagerWindow *) {
+                       __DBG_STUB_INVOKE__
+                       return mockSideBar;
+                   });
+
+    stub.set_lamda(&SideBarWidget::resetSettingPanel,
+                   [&resetPanelCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       resetPanelCalled = true;
+                   });
+
+    bool result = plugin->onAboutToShowSettingDialog(testWindowId);
+
+    EXPECT_FALSE(result);   // Always returns false
+    EXPECT_TRUE(resetPanelCalled);
+
+    delete mockSideBar;
+}
+
+TEST_F(UT_SideBar, OnAboutToShowSettingDialog_InvalidWindow)
+{
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    bool result = plugin->onAboutToShowSettingDialog(99999);
+
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebareventcaller.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebareventcaller.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/sidebareventcaller.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarEventCaller : public testing::Test
+{
+protected:
+    virtual void SetUp() override {}
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarEventCaller, SendItemActived)
+{
+    bool isCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedWindowId, &capturedUrl](EventDispatcherManager *, EventType type,
+                                                       quint64 windowId, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kChangeCurrentUrl) {
+            isCalled = true;
+            capturedWindowId = windowId;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    quint64 testWindowId = 12345;
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+
+    SideBarEventCaller::sendItemActived(testWindowId, testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedWindowId, testWindowId);
+    EXPECT_EQ(capturedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendEject)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl](EventDispatcherManager *, const QString &space,
+                                   const QString &topic, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (space == "dfmplugin_sidebar" && topic == "signal_Item_EjectClicked") {
+            isCalled = true;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    QUrl deviceUrl = QUrl::fromLocalFile("/dev/sdb1");
+    SideBarEventCaller::sendEject(deviceUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, deviceUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenWindow_NewWindow)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+    bool capturedIsNew = false;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, QUrl, const bool &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl, &capturedIsNew](EventDispatcherManager *, EventType type,
+                                                    const QUrl &url, bool isNew) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewWindow) {
+            isCalled = true;
+            capturedUrl = url;
+            capturedIsNew = isNew;
+        }
+        return true;
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/newwindow");
+    SideBarEventCaller::sendOpenWindow(testUrl, true);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_TRUE(capturedIsNew);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenWindow_ExistingWindow)
+{
+    bool isCalled = false;
+    QUrl capturedUrl;
+    bool capturedIsNew = true;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, QUrl, const bool &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedUrl, &capturedIsNew](EventDispatcherManager *, EventType type,
+                                                    const QUrl &url, bool isNew) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewWindow) {
+            isCalled = true;
+            capturedUrl = url;
+            capturedIsNew = isNew;
+        }
+        return true;
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/existing");
+    SideBarEventCaller::sendOpenWindow(testUrl, false);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_FALSE(capturedIsNew);
+}
+
+TEST_F(UT_SideBarEventCaller, SendOpenTab)
+{
+    bool isCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    stub_ext::StubExt stub;
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+        [&isCalled, &capturedWindowId, &capturedUrl](EventDispatcherManager *, EventType type,
+                                                       quint64 windowId, const QUrl &url) -> bool {
+        __DBG_STUB_INVOKE__
+        if (type == GlobalEventType::kOpenNewTab) {
+            isCalled = true;
+            capturedWindowId = windowId;
+            capturedUrl = url;
+        }
+        return true;
+    });
+
+    quint64 testWindowId = 54321;
+    QUrl testUrl = QUrl::fromLocalFile("/home/newtab");
+
+    SideBarEventCaller::sendOpenTab(testWindowId, testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedWindowId, testWindowId);
+    EXPECT_EQ(capturedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendShowFilePropertyDialog)
+{
+    bool isCalled = false;
+    QList<QUrl> capturedUrls;
+
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &,
+                                                       QList<QUrl>, QVariantHash &&);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [&isCalled, &capturedUrls](EventChannelManager *, const QString &space,
+                                     const QString &topic, QList<QUrl> urls, QVariantHash) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (space == "dfmplugin_propertydialog" && topic == "slot_PropertyDialog_Show") {
+            isCalled = true;
+            capturedUrls = urls;
+        }
+        return QVariant();
+    });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/properties");
+    SideBarEventCaller::sendShowFilePropertyDialog(testUrl);
+
+    EXPECT_TRUE(isCalled);
+    EXPECT_EQ(capturedUrls.size(), 1);
+    EXPECT_EQ(capturedUrls[0], testUrl);
+}
+
+TEST_F(UT_SideBarEventCaller, SendCheckTabAddable_True)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [](EventChannelManager *, const QString &, const QString &, quint64) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    bool result = SideBarEventCaller::sendCheckTabAddable(99999);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarEventCaller, SendCheckTabAddable_False)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push),
+        [](EventChannelManager *, const QString &, const QString &, quint64) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    bool result = SideBarEventCaller::sendCheckTabAddable(88888);
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebareventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebareventreceiver.cpp
@@ -1,0 +1,420 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/sidebareventreceiver.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "utils/sidebarhelper.h"
+#include "utils/sidebarinfocachemananger.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        receiver = SideBarEventReceiver::instance();
+        ASSERT_NE(receiver, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarEventReceiver, Instance)
+{
+    auto ins1 = SideBarEventReceiver::instance();
+    auto ins2 = SideBarEventReceiver::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarEventReceiver, BindEvents)
+{
+    EXPECT_NO_THROW(receiver->bindEvents());
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSetContextMenuEnable_True)
+{
+    SideBarHelper::contextMenuEnabled = false;
+
+    receiver->handleSetContextMenuEnable(true);
+
+    EXPECT_TRUE(SideBarHelper::contextMenuEnabled);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSetContextMenuEnable_False)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    receiver->handleSetContextMenuEnable(false);
+
+    EXPECT_FALSE(SideBarHelper::contextMenuEnabled);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemHidden)
+{
+    bool setVisiableCalled = false;
+    QUrl capturedUrl;
+    bool capturedVisible = false;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::setItemVisiable,
+                   [&setVisiableCalled, &capturedUrl, &capturedVisible](SideBarWidget *, const QUrl &url, bool visible) {
+                       __DBG_STUB_INVOKE__
+                       setVisiableCalled = true;
+                       capturedUrl = url;
+                       capturedVisible = visible;
+                   });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    receiver->handleItemHidden(testUrl, true);
+
+    EXPECT_TRUE(setVisiableCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_TRUE(capturedVisible);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemTriggerEdit)
+{
+    bool editCalled = false;
+    QUrl capturedUrl;
+
+    quint64 testWindowId = 12345;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [testWindowId](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    stub.set_lamda(&SideBarWidget::editItem,
+                   [&editCalled, &capturedUrl](SideBarWidget *, const QUrl &url) {
+                       __DBG_STUB_INVOKE__
+                       editCalled = true;
+                       capturedUrl = url;
+                   });
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/edit");
+    receiver->handleItemTriggerEdit(testWindowId, testUrl);
+
+    EXPECT_TRUE(editCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleSidebarUpdateSelection)
+{
+    bool updateCalled = false;
+
+    quint64 testWindowId = 54321;
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [testWindowId](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    stub.set_lamda(&SideBarWidget::updateSelection,
+                   [&updateCalled](SideBarWidget *) {
+                       __DBG_STUB_INVOKE__
+                       updateCalled = true;
+                   });
+
+    receiver->handleSidebarUpdateSelection(testWindowId);
+
+    EXPECT_TRUE(updateCalled);
+
+    delete mockWidget;
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_AlreadyExists)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/exists");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;   // Item already exists
+                   });
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_InvalidItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/invalid");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;   // Failed to create item
+    });
+
+    QVariantMap properties;
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemAdd_Success)
+{
+    bool addCacheCalled = false;
+    bool addItemCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/newadd");
+
+    SideBarItem *mockItem = new SideBarItem(testUrl);
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [mockItem](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return mockItem;
+    });
+
+    stub.set_lamda(&SideBarItem::group, []() -> QString {
+        __DBG_STUB_INVOKE__
+        return DefaultGroup::kCommon;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::addItemInfoCache,
+                   [&addCacheCalled](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addCacheCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::addItem,
+                   [&addItemCalled](SideBarWidget *, SideBarItem *, bool) -> int {
+                       __DBG_STUB_INVOKE__
+                       addItemCalled = true;
+                       return 0;   // Success
+                   });
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(VADDR(SideBarWidget, currentUrl), []() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemAdd(testUrl, properties);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addCacheCalled);
+    EXPECT_TRUE(addItemCalled);
+
+    delete mockWidget;
+    // mockItem will be managed by widget, don't delete
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemRemove_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleItemRemove(testUrl);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemRemove_Success)
+{
+    bool removeCacheCalled = false;
+    bool removeRowCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &)>(&SideBarInfoCacheMananger::removeItemInfoCache),
+                   [&removeCacheCalled](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeCacheCalled = true;
+                       return true;
+                   });
+
+    // Mock kSidebarModelIns to be non-null
+    SideBarModel mockModel;
+    SideBarWidget::kSidebarModelIns = QSharedPointer<SideBarModel>(&mockModel, [](SideBarModel *) {});
+
+    stub.set_lamda(&SideBarModel::removeRow,
+                   [&removeRowCalled](SideBarModel *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeRowCalled = true;
+                       return true;
+                   });
+
+    bool result = receiver->handleItemRemove(testUrl);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(removeCacheCalled);
+    EXPECT_TRUE(removeRowCalled);
+
+    // Cleanup
+    SideBarWidget::kSidebarModelIns.reset();
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemUpdate_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/updatenotfound");
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const QUrl &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QVariantMap properties;
+    bool result = receiver->handleItemUpdate(testUrl, properties);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarEventReceiver, HandleItemInsert_Success)
+{
+    bool insertCacheCalled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/insert");
+
+    SideBarItem *mockItem = new SideBarItem(testUrl);
+
+    stub.set_lamda(static_cast<bool (SideBarInfoCacheMananger::*)(const ItemInfo &) const>(&SideBarInfoCacheMananger::contains),
+                   [](SideBarInfoCacheMananger *, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SideBarHelper::createItemByInfo, [mockItem](const ItemInfo &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return mockItem;
+    });
+
+    stub.set_lamda(&SideBarItem::group, []() -> QString {
+        __DBG_STUB_INVOKE__
+        return DefaultGroup::kCommon;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::insertItemInfoCache,
+                   [&insertCacheCalled](SideBarInfoCacheMananger *, int, const ItemInfo &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       insertCacheCalled = true;
+                       return true;
+                   });
+
+    SideBarWidget *mockWidget = new SideBarWidget();
+    QList<SideBarWidget *> widgetList;
+    widgetList << mockWidget;
+
+    stub.set_lamda(&SideBarHelper::allSideBar, [widgetList]() -> QList<SideBarWidget *> {
+        __DBG_STUB_INVOKE__
+        return widgetList;
+    });
+
+    stub.set_lamda(&SideBarWidget::insertItem,
+                   [](SideBarWidget *, int, SideBarItem *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;   // Success
+                   });
+    stub.set_lamda(&SideBarWidget::insertItem, [] {__DBG_STUB_INVOKE__ return true;});
+
+    QVariantMap properties;
+    properties[PropertyKey::kGroup] = DefaultGroup::kCommon;
+
+    bool result = receiver->handleItemInsert(0, testUrl, properties);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(insertCacheCalled);
+
+    delete mockWidget;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarhelper.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarhelper.cpp
@@ -1,0 +1,803 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarhelper.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "treeviews/sidebaritem.h"
+#include "treeviews/sidebarwidget.h"
+#include "events/sidebareventcaller.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/settingdialog/customsettingitemregister.h>
+#include <dfm-base/base/configs/settingbackend.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/utils/networkutils.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QIcon>
+#include <QMutex>
+#include <QMenu>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Clear static map before each test
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    Application app;
+};
+
+TEST_F(UT_SideBarHelper, AllSideBar_Empty)
+{
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    QList<SideBarWidget *> list = SideBarHelper::allSideBar();
+
+    // May be empty or contain widgets
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, AddSideBar)
+{
+    quint64 windowId = 12345;
+    SideBarWidget *widget = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, AddSideBar_Duplicate)
+{
+    quint64 windowId = 54321;
+    SideBarWidget *widget1 = new SideBarWidget();
+    SideBarWidget *widget2 = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget1);
+    SideBarHelper::addSideBar(windowId, widget2);   // Should not add duplicate
+
+    EXPECT_TRUE(true);
+
+    delete widget1;
+    delete widget2;
+}
+
+TEST_F(UT_SideBarHelper, RemoveSideBar)
+{
+    quint64 windowId = 99999;
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::removeSideBar(windowId);
+
+    // Should not crash even if not exists
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RemoveSideBar_Existing)
+{
+    quint64 windowId = 88888;
+    SideBarWidget *widget = new SideBarWidget();
+
+    stub.set_lamda(&SideBarHelper::mutex, []() -> QMutex & {
+        __DBG_STUB_INVOKE__
+        static QMutex m;
+        return m;
+    });
+
+    SideBarHelper::addSideBar(windowId, widget);
+    SideBarHelper::removeSideBar(windowId);
+
+    EXPECT_TRUE(true);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, WindowId)
+{
+    QWidget *widget = new QWidget();
+    quint64 testWindowId = 77777;
+
+    stub.set_lamda(&FileManagerWindowsManager::findWindowId,
+                   [testWindowId](FileManagerWindowsManager *, const QWidget *) -> quint64 {
+                       __DBG_STUB_INVOKE__
+                       return testWindowId;
+                   });
+
+    quint64 result = SideBarHelper::windowId(widget);
+
+    EXPECT_EQ(result, testWindowId);
+
+    delete widget;
+}
+
+TEST_F(UT_SideBarHelper, PreDefineItemProperties_Empty)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObjs,
+                   [](std::function<bool(PluginMetaObjectPointer)>) -> QList<PluginMetaObjectPointer> {
+                       __DBG_STUB_INVOKE__
+                       return QList<PluginMetaObjectPointer>();
+                   });
+
+    QMap<QUrl, QPair<int, QVariantMap>> properties = SideBarHelper::preDefineItemProperties();
+
+    EXPECT_TRUE(properties.isEmpty());
+}
+
+TEST_F(UT_SideBarHelper, CreateItemByInfo_Basic)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.displayName = "TestItem";
+    info.group = DefaultGroup::kCommon;
+    info.icon = QIcon::fromTheme("folder");
+    info.flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    info.isEjectable = false;
+
+    SideBarItem *item = SideBarHelper::createItemByInfo(info);
+
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), info.displayName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarHelper, CreateItemByInfo_WithEjectable)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/media/usb");
+    info.displayName = "USB Drive";
+    info.group = DefaultGroup::kDevice;
+    info.icon = QIcon::fromTheme("drive-removable-media");
+    info.flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    info.isEjectable = true;
+
+    stub.set_lamda(&SideBarEventCaller::sendEject, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    SideBarItem *item = SideBarHelper::createItemByInfo(info);
+
+    ASSERT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), info.displayName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Tag)
+{
+    QString group = DefaultGroup::kTag;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsEnabled);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsDropEnabled);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Common)
+{
+    QString group = DefaultGroup::kCommon;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsEnabled);
+    EXPECT_TRUE(separator->flags() & Qt::ItemIsDropEnabled);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, CreateSeparatorItem_Device)
+{
+    QString group = DefaultGroup::kDevice;
+
+    SideBarItemSeparator *separator = SideBarHelper::createSeparatorItem(group);
+
+    ASSERT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), group);
+    EXPECT_EQ(separator->flags(), Qt::NoItemFlags);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarHelper, MakeItemIdentifier)
+{
+    QString group = DefaultGroup::kCommon;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+
+    QString identifier = SideBarHelper::makeItemIdentifier(group, url);
+
+    EXPECT_FALSE(identifier.isEmpty());
+    EXPECT_TRUE(identifier.contains(group));
+    EXPECT_TRUE(identifier.contains(url.url()));
+}
+
+TEST_F(UT_SideBarHelper, DefaultCdAction_ValidUrl)
+{
+    quint64 windowId = 12345;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendItemActived,
+                   [&sendCalled](quint64, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                   });
+
+    SideBarHelper::defaultCdAction(windowId, url);
+
+    EXPECT_TRUE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, DefaultCdAction_EmptyUrl)
+{
+    quint64 windowId = 12345;
+    QUrl emptyUrl;
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendItemActived,
+                   [&sendCalled](quint64, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                   });
+
+    SideBarHelper::defaultCdAction(windowId, emptyUrl);
+
+    EXPECT_FALSE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, DefaultContextMenu)
+{
+    quint64 windowId = 12345;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+    QPoint globalPos(100, 100);
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenWindow, [](const QUrl &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenTab, [](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendCheckTabAddable, [](quint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarEventCaller::sendShowFilePropertyDialog, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&NetworkUtils::checkFtpOrSmbBusy, [](NetworkUtils *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    using ExecFunc = QAction *(QMenu::*)(const QPoint &, QAction *);
+    stub.set_lamda(static_cast<ExecFunc>(&QMenu::exec), [] {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    // Should create and show menu without crashing
+    SideBarHelper::defaultContextMenu(windowId, url, globalPos);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, BindSetting)
+{
+    QString itemVisiableSettingKey = "test.setting.key";
+    QString itemVisiableControlKey = "test.control.key";
+
+    stub.set_lamda(&SettingBackend::instance, []() -> SettingBackend * {
+        __DBG_STUB_INVOKE__
+        static SettingBackend backend;
+        return &backend;
+    });
+
+    typedef void (SettingBackend::*Func)(const QString &, SettingBackend::GetOptFunc, SettingBackend::SaveOptFunc);
+    stub.set_lamda(static_cast<Func>(&SettingBackend::addSettingAccessor),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::hiddenRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["test.control.key"] = true;
+        return map;
+    });
+
+    SideBarHelper::bindSetting(itemVisiableSettingKey, itemVisiableControlKey);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RemovebindingSetting)
+{
+    QString itemVisiableSettingKey = "test.remove.key";
+
+    stub.set_lamda(&SettingBackend::instance, []() -> SettingBackend * {
+        __DBG_STUB_INVOKE__
+        static SettingBackend backend;
+        return &backend;
+    });
+
+    stub.set_lamda(&SettingBackend::removeSettingAccessor,
+                   [](SettingBackend *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::removebindingSetting(itemVisiableSettingKey);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, InitDefaultSettingPanel)
+{
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::addGroup,
+                   [](SettingJsonGenerator *, const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::initDefaultSettingPanel();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_QuickAccess)
+{
+    QString group = DefaultGroup::kCommon;
+    QString key = "test.quick.key";
+    QString value = "Quick Access Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Device)
+{
+    QString group = DefaultGroup::kDevice;
+    QString key = "test.device.key";
+    QString value = "Device Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Network)
+{
+    QString group = DefaultGroup::kNetwork;
+    QString key = "test.network.key";
+    QString value = "Network Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, AddItemToSettingPannel_Tag)
+{
+    QString group = DefaultGroup::kTag;
+    QString key = "test.tag.key";
+    QString value = "Tag Item";
+    QMap<QString, int> levelMap;
+    levelMap[group] = 0;
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::hasConfig,
+                   [](SettingJsonGenerator *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addConfig,
+                   [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SettingJsonGenerator::addCheckBoxConfig,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::instance, []() -> SideBarInfoCacheMananger * {
+        __DBG_STUB_INVOKE__
+        static SideBarInfoCacheMananger manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarHelper::bindSetting,
+                   [](const QString &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(&SideBarInfoCacheMananger::appendLastSettingBindingKey,
+                   [](SideBarInfoCacheMananger *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    SideBarHelper::addItemToSettingPannel(group, key, value, &levelMap);
+
+    EXPECT_EQ(levelMap[group], 1);
+}
+
+TEST_F(UT_SideBarHelper, RemoveItemFromSetting)
+{
+    QString key = "test.remove.setting.key";
+
+    stub.set_lamda(&SettingJsonGenerator::instance, []() -> SettingJsonGenerator * {
+        __DBG_STUB_INVOKE__
+        static SettingJsonGenerator generator;
+        return &generator;
+    });
+
+    stub.set_lamda(&SettingJsonGenerator::removeConfig,
+                   [](SettingJsonGenerator *, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::removeItemFromSetting(key);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, RegistCustomSettingItem)
+{
+    stub.set_lamda(&CustomSettingItemRegister::instance, []() -> CustomSettingItemRegister * {
+        __DBG_STUB_INVOKE__
+        static CustomSettingItemRegister reg;
+        return &reg;
+    });
+
+    stub.set_lamda(&CustomSettingItemRegister::registCustomSettingItemType,
+                   [](CustomSettingItemRegister *, const QString &, std::function<QPair<QWidget *, QWidget *>(QObject *)>) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    SideBarHelper::registCustomSettingItem();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarHelper, HiddenRules)
+{
+    QVariantMap mockRules;
+    mockRules["key1"] = false;
+    mockRules["key2"] = true;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [mockRules](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(mockRules);
+                   });
+
+    QVariantMap rules = SideBarHelper::hiddenRules();
+
+    EXPECT_EQ(rules.size(), mockRules.size());
+}
+
+TEST_F(UT_SideBarHelper, GroupExpandRules)
+{
+    QVariantMap mockRules;
+    mockRules[DefaultGroup::kCommon] = true;
+    mockRules[DefaultGroup::kDevice] = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [mockRules](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(mockRules);
+                   });
+
+    QVariantMap rules = SideBarHelper::groupExpandRules();
+
+    EXPECT_EQ(rules.size(), mockRules.size());
+}
+
+TEST_F(UT_SideBarHelper, SaveGroupsStateToConfig)
+{
+    QVariantMap inputVar;
+    inputVar[DefaultGroup::kCommon] = true;
+    inputVar[DefaultGroup::kDevice] = false;
+
+    bool setValueCalled = false;
+
+    stub.set_lamda(&DConfigManager::instance, []() -> DConfigManager * {
+        __DBG_STUB_INVOKE__
+        static DConfigManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&DConfigManager::value,
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant(QVariantMap());
+                   });
+
+    stub.set_lamda(&DConfigManager::setValue,
+                   [&setValueCalled](DConfigManager *, const QString &, const QString &, const QVariant &) {
+                       __DBG_STUB_INVOKE__
+                       setValueCalled = true;
+                   });
+
+    SideBarHelper::saveGroupsStateToConfig(inputVar);
+
+    EXPECT_TRUE(setValueCalled);
+}
+
+TEST_F(UT_SideBarHelper, OpenFolderInASeparateProcess)
+{
+    QUrl url = QUrl::fromLocalFile("/home/separate");
+
+    bool sendCalled = false;
+
+    stub.set_lamda(&SideBarEventCaller::sendOpenWindow,
+                   [&sendCalled](const QUrl &, bool isNew) {
+                       __DBG_STUB_INVOKE__
+                       sendCalled = true;
+                       EXPECT_FALSE(isNew);
+                   });
+
+    SideBarHelper::openFolderInASeparateProcess(url);
+
+    EXPECT_TRUE(sendCalled);
+}
+
+TEST_F(UT_SideBarHelper, ContextMenuEnabled_Static)
+{
+    // Test static variable
+    SideBarHelper::contextMenuEnabled = true;
+    EXPECT_TRUE(SideBarHelper::contextMenuEnabled);
+
+    SideBarHelper::contextMenuEnabled = false;
+    EXPECT_FALSE(SideBarHelper::contextMenuEnabled);
+
+    // Restore default
+    SideBarHelper::contextMenuEnabled = true;
+}
+
+TEST_F(UT_SideBarHelper, Mutex)
+{
+    QMutex &m1 = SideBarHelper::mutex();
+    QMutex &m2 = SideBarHelper::mutex();
+
+    // Should return same mutex instance
+    EXPECT_EQ(&m1, &m2);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarinfocachemananger.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarinfocachemananger.cpp
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+
+class UT_SideBarInfoCacheMananger : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = SideBarInfoCacheMananger::instance();
+        ASSERT_NE(manager, nullptr);
+
+        // Clear any existing cache for clean test state
+        manager->clearLastSettingKey();
+        manager->clearLastSettingBindingKey();
+        manager->cacheInfoMap.clear();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarInfoCacheMananger *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarInfoCacheMananger, Instance)
+{
+    auto ins1 = SideBarInfoCacheMananger::instance();
+    auto ins2 = SideBarInfoCacheMananger::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AddItemInfoCache_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "Test";
+
+    bool result = manager->addItemInfoCache(info);
+    EXPECT_TRUE(result);
+
+    EXPECT_TRUE(manager->contains(info));
+    EXPECT_TRUE(manager->contains(info.url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AddItemInfoCache_Duplicate)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/duplicate");
+    info.group = DefaultGroup::kDevice;
+    info.displayName = "Duplicate";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_TRUE(manager->addItemInfoCache(info));
+
+    // Adding same item again should fail
+    bool result = manager->addItemInfoCache(info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_Success)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/first");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "First";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/second");
+    info2.group = DefaultGroup::kCommon;
+    info2.displayName = "Second";
+
+    manager->addItemInfoCache(info1);
+
+    // Insert at index 0
+    bool result = manager->insertItemInfoCache(0, info2);
+    EXPECT_TRUE(result);
+
+    auto cacheList = manager->indexCacheList(DefaultGroup::kCommon);
+    EXPECT_EQ(cacheList.size(), 2);
+    EXPECT_EQ(cacheList[0].url, info2.url);
+    EXPECT_EQ(cacheList[1].url, info1.url);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_InvalidIndex)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/test");
+    info.group = DefaultGroup::kNetwork;
+    info.displayName = "Test";
+
+    // Insert at out-of-range index should append
+    bool result = manager->insertItemInfoCache(999, info);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, InsertItemInfoCache_NegativeIndex)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/negative");
+    info.group = DefaultGroup::kTag;
+    info.displayName = "Negative";
+
+    // Insert at negative index should append
+    bool result = manager->insertItemInfoCache(-1, info);
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByGroupAndUrl_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/remove");
+    info.group = DefaultGroup::kOther;
+    info.displayName = "Remove";
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(info.url));
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->removeItemInfoCache(info.group, info.url);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(manager->contains(info.url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByGroupAndUrl_NotFound)
+{
+    QUrl nonExistentUrl = QUrl::fromLocalFile("/non/existent");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = manager->removeItemInfoCache(DefaultGroup::kCommon, nonExistentUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, RemoveItemInfoCache_ByUrl_Success)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/multi1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Multi1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/multi1");
+    info2.group = DefaultGroup::kDevice;
+    info2.displayName = "Multi2";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1.path() == url2.path();
+    });
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    // Remove by URL should remove from all groups
+    bool result = manager->removeItemInfoCache(info1.url);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByGroupAndUrl_Success)
+{
+    ItemInfo oldInfo;
+    oldInfo.url = QUrl::fromLocalFile("/home/update");
+    oldInfo.group = DefaultGroup::kCommon;
+    oldInfo.displayName = "OldName";
+
+    manager->addItemInfoCache(oldInfo);
+
+    ItemInfo newInfo = oldInfo;
+    newInfo.displayName = "NewName";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->updateItemInfoCache(oldInfo.group, oldInfo.url, newInfo);
+    EXPECT_TRUE(result);
+
+    ItemInfo retrieved = manager->itemInfo(oldInfo.url);
+    EXPECT_EQ(retrieved.displayName, QString("NewName"));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByGroupAndUrl_NotFound)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/non/existent");
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "Test";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = manager->updateItemInfoCache(info.group, info.url, info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, UpdateItemInfoCache_ByUrl_Success)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/updateall");
+    info.group = DefaultGroup::kNetwork;
+    info.displayName = "OldDisplay";
+
+    manager->addItemInfoCache(info);
+
+    ItemInfo newInfo = info;
+    newInfo.displayName = "NewDisplay";
+
+    stub.set_lamda(ADDR(UniversalUtils, urlEquals),
+        [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->updateItemInfoCache(info.url, newInfo);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Contains_ItemInfo)
+{
+    ItemInfo info;
+    info.url = QUrl::fromLocalFile("/home/contains");
+    info.group = DefaultGroup::kTag;
+    info.displayName = "Contains";
+
+    EXPECT_FALSE(manager->contains(info));
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(info));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Contains_Url)
+{
+    QUrl url = QUrl::fromLocalFile("/home/urltest");
+
+    ItemInfo info;
+    info.url = url;
+    info.group = DefaultGroup::kCommon;
+    info.displayName = "UrlTest";
+
+    EXPECT_FALSE(manager->contains(url));
+
+    manager->addItemInfoCache(info);
+    EXPECT_TRUE(manager->contains(url));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, Groups)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/group1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Group1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/group2");
+    info2.group = DefaultGroup::kDevice;
+    info2.displayName = "Group2";
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    QStringList groups = manager->groups();
+    EXPECT_TRUE(groups.contains(DefaultGroup::kCommon));
+    EXPECT_TRUE(groups.contains(DefaultGroup::kDevice));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, IndexCacheList)
+{
+    ItemInfo info1;
+    info1.url = QUrl::fromLocalFile("/home/cache1");
+    info1.group = DefaultGroup::kCommon;
+    info1.displayName = "Cache1";
+
+    ItemInfo info2;
+    info2.url = QUrl::fromLocalFile("/home/cache2");
+    info2.group = DefaultGroup::kCommon;
+    info2.displayName = "Cache2";
+
+    manager->addItemInfoCache(info1);
+    manager->addItemInfoCache(info2);
+
+    auto cacheList = manager->indexCacheList(DefaultGroup::kCommon);
+    EXPECT_GE(cacheList.size(), 2);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ItemInfo)
+{
+    QUrl url = QUrl::fromLocalFile("/home/iteminfo");
+
+    ItemInfo info;
+    info.url = url;
+    info.group = DefaultGroup::kOther;
+    info.displayName = "ItemInfoTest";
+
+    manager->addItemInfoCache(info);
+
+    ItemInfo retrieved = manager->itemInfo(url);
+    EXPECT_EQ(retrieved.url, info.url);
+    EXPECT_EQ(retrieved.displayName, info.displayName);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, GetLastSettingKeys)
+{
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_TRUE(keys.isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingKey)
+{
+    QString key1 = "setting.key1";
+    QString key2 = "setting.key2";
+
+    manager->appendLastSettingKey(key1);
+    manager->appendLastSettingKey(key2);
+
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_EQ(keys.size(), 2);
+    EXPECT_TRUE(keys.contains(key1));
+    EXPECT_TRUE(keys.contains(key2));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingKey_Duplicate)
+{
+    QString key = "duplicate.key";
+
+    manager->appendLastSettingKey(key);
+    manager->appendLastSettingKey(key);
+
+    QStringList keys = manager->getLastSettingKeys();
+    EXPECT_EQ(keys.size(), 1);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ClearLastSettingKey)
+{
+    manager->appendLastSettingKey("key1");
+    manager->appendLastSettingKey("key2");
+
+    EXPECT_FALSE(manager->getLastSettingKeys().isEmpty());
+
+    manager->clearLastSettingKey();
+    EXPECT_TRUE(manager->getLastSettingKeys().isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, GetLastSettingBindingKeys)
+{
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_TRUE(keys.isEmpty());
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingBindingKey)
+{
+    QString key1 = "binding.key1";
+    QString key2 = "binding.key2";
+
+    manager->appendLastSettingBindingKey(key1);
+    manager->appendLastSettingBindingKey(key2);
+
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_EQ(keys.size(), 2);
+    EXPECT_TRUE(keys.contains(key1));
+    EXPECT_TRUE(keys.contains(key2));
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, AppendLastSettingBindingKey_Duplicate)
+{
+    QString key = "duplicate.binding";
+
+    manager->appendLastSettingBindingKey(key);
+    manager->appendLastSettingBindingKey(key);
+
+    QStringList keys = manager->getLastSettingBindingKeys();
+    EXPECT_EQ(keys.size(), 1);
+}
+
+TEST_F(UT_SideBarInfoCacheMananger, ClearLastSettingBindingKey)
+{
+    manager->appendLastSettingBindingKey("binding1");
+    manager->appendLastSettingBindingKey("binding2");
+
+    EXPECT_FALSE(manager->getLastSettingBindingKeys().isEmpty());
+
+    manager->clearLastSettingBindingKey();
+    EXPECT_TRUE(manager->getLastSettingBindingKeys().isEmpty());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebaritem.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebaritem.cpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebaritem.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <DDciIcon>
+
+#include <QUrl>
+#include <QIcon>
+
+using namespace dfmplugin_sidebar;
+DGUI_USE_NAMESPACE
+
+class UT_SideBarItem : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl = QUrl::fromLocalFile("/home/test");
+        testGroup = DefaultGroup::kCommon;
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    QUrl testUrl;
+    QString testGroup;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItem, Constructor_WithUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->url(), testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Constructor_WithFullParameters)
+{
+    QIcon testIcon = QIcon::fromTheme("folder");
+    QString testText = "TestItem";
+
+    SideBarItem *item = new SideBarItem(testIcon, testText, testGroup, testUrl);
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->url(), testUrl);
+    EXPECT_EQ(item->text(), testText);
+    EXPECT_EQ(item->group(), testGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Constructor_CopyConstructor)
+{
+    QIcon testIcon = QIcon::fromTheme("folder");
+    QString testText = "Original";
+
+    SideBarItem *original = new SideBarItem(testIcon, testText, testGroup, testUrl);
+    SideBarItem *copy = new SideBarItem(*original);
+
+    EXPECT_NE(copy, nullptr);
+    EXPECT_EQ(copy->url(), original->url());
+    EXPECT_EQ(copy->text(), original->text());
+    EXPECT_EQ(copy->group(), original->group());
+
+    delete original;
+    delete copy;
+}
+
+TEST_F(UT_SideBarItem, Url_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QUrl newUrl = QUrl::fromLocalFile("/home/newurl");
+    item->setUrl(newUrl);
+
+    EXPECT_EQ(item->url(), newUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, TargetUrl_WithoutFinalUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::itemInfo, [this]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.url = testUrl;
+        info.finalUrl = QUrl();   // Empty final URL
+        return info;
+    });
+
+    QUrl targetUrl = item->targetUrl();
+    EXPECT_EQ(targetUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, TargetUrl_WithFinalUrl)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QUrl finalUrl = QUrl::fromLocalFile("/home/final");
+
+    stub.set_lamda(&SideBarItem::itemInfo, [this, finalUrl]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.url = testUrl;
+        info.finalUrl = finalUrl;
+        return info;
+    });
+
+    QUrl targetUrl = item->targetUrl();
+    EXPECT_EQ(targetUrl, finalUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SetIcon_DciIcon)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QIcon icon = QIcon::fromTheme("folder");
+
+    stub.set_lamda(static_cast<DDciIcon (*)(const QString &)>(&DDciIcon::fromTheme), [] {
+        __DBG_STUB_INVOKE__
+        DDciIcon dciIcon;
+        return dciIcon;
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, []() {
+        __DBG_STUB_INVOKE__
+        return false;   // DCI icon is valid
+    });
+
+    bool dciIconSet = false;
+    using SetDciIconFunc = void (DStandardItem::*)(const DDciIcon &);
+    stub.set_lamda(static_cast<SetDciIconFunc>(&DStandardItem::setDciIcon),
+                   [&dciIconSet](DStandardItem *, const DDciIcon &) {
+                       __DBG_STUB_INVOKE__
+                       dciIconSet = true;
+                   });
+
+    item->setIcon(icon);
+
+    EXPECT_TRUE(dciIconSet);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SetIcon_RegularIcon)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QIcon icon;
+
+    stub.set_lamda(static_cast<DDciIcon (*)(const QString &)>(&DDciIcon::fromTheme), [](const QString &) {
+        __DBG_STUB_INVOKE__
+        DDciIcon dciIcon;
+        return dciIcon;
+    });
+
+    stub.set_lamda(&DDciIcon::isNull, []() {
+        __DBG_STUB_INVOKE__
+        return true;   // DCI icon is null, use regular icon
+    });
+
+    item->setIcon(icon);
+
+    // Verify icon is set through data (Qt::DecorationRole)
+    EXPECT_TRUE(item->icon().isNull());
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Group_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    item->setGroup(testGroup);
+    EXPECT_EQ(item->group(), testGroup);
+
+    QString newGroup = DefaultGroup::kDevice;
+    item->setGroup(newGroup);
+    EXPECT_EQ(item->group(), newGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, SubGroup)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    QString testSubGroup = "SubGroup1";
+
+    stub.set_lamda(&SideBarItem::itemInfo, [testSubGroup]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.subGroup = testSubGroup;
+        return info;
+    });
+
+    EXPECT_EQ(item->subGourp(), testSubGroup);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, Hidden_GetSet)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    item->setHiiden(true);
+    // Note: isHidden() reads from kItemGroupRole which is a bug in original code
+    // We test the actual implementation
+
+    item->setHiiden(false);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItem, ItemInfo)
+{
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    ItemInfo mockInfo;
+    mockInfo.url = testUrl;
+    mockInfo.group = testGroup;
+    mockInfo.displayName = "MockInfo";
+
+    // SideBarItem::itemInfo() calls the two-argument overload
+    // itemInfo(group, url); stub that exact instance.
+    using ItemInfoFunc = ItemInfo (SideBarInfoCacheMananger::*)(const QString &, const QUrl &);
+    stub.set_lamda(static_cast<ItemInfoFunc>(&SideBarInfoCacheMananger::itemInfo),
+                   [mockInfo](SideBarInfoCacheMananger *, const QString &, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       return mockInfo;
+                   });
+
+    ItemInfo info = item->itemInfo();
+    EXPECT_EQ(info.url, mockInfo.url);
+    EXPECT_EQ(info.group, mockInfo.group);
+    EXPECT_EQ(info.displayName, mockInfo.displayName);
+
+    delete item;
+}
+
+// Tests for SideBarItemSeparator
+class UT_SideBarItemSeparator : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testGroup = DefaultGroup::kCommon;
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    QString testGroup;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItemSeparator, Constructor)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_NE(separator, nullptr);
+    EXPECT_EQ(separator->group(), testGroup);
+    EXPECT_EQ(separator->text(), testGroup);
+    EXPECT_TRUE(separator->isExpanded());
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, Expanded_GetSet)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_TRUE(separator->isExpanded());
+
+    separator->setExpanded(false);
+    EXPECT_FALSE(separator->isExpanded());
+
+    separator->setExpanded(true);
+    EXPECT_TRUE(separator->isExpanded());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, Visible_GetSet)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    EXPECT_TRUE(separator->isVisible());
+
+    separator->setVisible(false);
+    EXPECT_FALSE(separator->isVisible());
+
+    separator->setVisible(true);
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, DefaultValues)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator();
+
+    // Test default constructor behavior
+    EXPECT_TRUE(separator->isExpanded());
+    EXPECT_TRUE(separator->isVisible());
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarItemSeparator, MultipleToggles)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(testGroup);
+
+    // Toggle expanded multiple times
+    for (int i = 0; i < 5; ++i) {
+        bool state = (i % 2 == 0);
+        separator->setExpanded(state);
+        EXPECT_EQ(separator->isExpanded(), state);
+    }
+
+    // Toggle visible multiple times
+    for (int i = 0; i < 5; ++i) {
+        bool state = (i % 2 == 0);
+        separator->setVisible(state);
+        EXPECT_EQ(separator->isVisible(), state);
+    }
+
+    delete separator;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebaritemdelegate.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebaritemdelegate.cpp
@@ -1,0 +1,1022 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treemodels/sidebarmodel.h"
+#include "treeviews/sidebaritemdelegate.h"
+#include "treeviews/sidebaritem.h"
+#include "treeviews/sidebarview.h"
+#include "events/sidebareventcaller.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/device/devicealiasmanager.h>
+
+#include <QPainter>
+#include <QStyleOptionViewItem>
+#include <QAbstractItemView>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QHelpEvent>
+#include <QToolTip>
+
+using namespace dfmplugin_sidebar;
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_SideBarItemDelegate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub GUI operations
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        view = new SideBarView();
+        delegate = new SideBarItemDelegate(view);
+        ASSERT_NE(delegate, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete delegate;
+        delegate = nullptr;
+        delete view;
+        view = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarItemDelegate *delegate { nullptr };
+    SideBarView *view { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarItemDelegate, Constructor)
+{
+    EXPECT_NE(delegate, nullptr);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    // Create a mock painter
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, paint),
+                   [](DStyledItemDelegate *, QPainter *, const QStyleOptionViewItem &, const QModelIndex &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should not crash even with invalid index
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SizeHint)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, sizeHint),
+                   [](const DStyledItemDelegate *, const QStyleOptionViewItem &, const QModelIndex &) -> QSize {
+                       __DBG_STUB_INVOKE__
+                       return QSize(100, 30);
+                   });
+
+    QSize size = delegate->sizeHint(option, index);
+
+    EXPECT_GT(size.width(), 0);
+    EXPECT_GT(size.height(), 0);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QWidget *editor = delegate->createEditor(&parent, option, index);
+
+    // Should return nullptr for invalid index
+    EXPECT_EQ(editor, nullptr);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor_ValidIndex)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(Qt::ItemIsEditable);
+    });
+
+    QWidget *editor = delegate->createEditor(&parent, option, index);
+
+    // Editor may or may not be created depending on item type
+    if (editor) {
+        delete editor;
+    }
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData)
+{
+    QLineEdit editor;
+    QModelIndex index;
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant("TestText");
+    });
+
+    delegate->setEditorData(&editor, index);
+
+    // Editor should be populated
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+
+    QAbstractItemModel *model = nullptr;
+    QModelIndex index;
+
+    // Should not crash with null model
+    delegate->setModelData(&editor, model, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, UpdateEditorGeometry)
+{
+    QLineEdit editor;
+    QStyleOptionViewItem option;
+    option.rect = QRect(10, 10, 100, 30);
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, updateEditorGeometry), [] { __DBG_STUB_INVOKE__ });
+
+    delegate->updateEditorGeometry(&editor, option, index);
+
+    // Editor geometry should be updated
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_NullEvent)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] { __DBG_STUB_INVOKE__ return false; });
+
+    bool result = delegate->editorEvent(nullptr, model, option, index);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MousePress)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 100, 30);
+    QModelIndex index;
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress,
+                                         QPointF(10, 10),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = delegate->editorEvent(event, model, option, index);
+
+    delete event;
+
+    // Result depends on implementation
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MouseRelease)
+{
+    QAbstractItemModel *model = nullptr;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 100, 30);
+    QModelIndex index;
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease,
+                                         QPointF(10, 10),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = delegate->editorEvent(event, model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_ToolTip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    QModelIndex index;
+    SideBarModel model;
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, helpEvent),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    typedef QAbstractItemModel *(*fun_type)();
+    stub.set_lamda((fun_type)(&QModelIndex::model), [&] { __DBG_STUB_INVOKE__ return &model; });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Result depends on whether tooltip should be shown
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged)
+{
+    QString newText = "ChangedText";
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::setText, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    delegate->onEditorTextChanged(newText, item);
+
+    // Should update item text
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged_NullItem)
+{
+    QString newText = "ChangedText";
+
+    // Should not crash with null item
+    delegate->onEditorTextChanged(newText, nullptr);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_WithValidData)
+{
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled;
+
+    QModelIndex index;
+
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    typedef bool (*fun_type)();
+    stub.set_lamda((fun_type)&QModelIndex::isValid, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int role) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (role == Qt::DisplayRole)
+            return QVariant("TestItem");
+        return QVariant();
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, paint),
+                   [](DStyledItemDelegate *, QPainter *, const QStyleOptionViewItem &, const QModelIndex &) {
+                       __DBG_STUB_INVOKE__
+                   });
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint successfully
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, SizeHint_Separator)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    stub.set_lamda(&QModelIndex::data, [](const QModelIndex *, int role) -> QVariant {
+        __DBG_STUB_INVOKE__
+        if (role == SideBarItem::kItemTypeRole)
+            return QVariant(SideBarItem::kSeparator);
+        return QVariant();
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, sizeHint),
+                   [](const DStyledItemDelegate *, const QStyleOptionViewItem &, const QModelIndex &) -> QSize {
+                       __DBG_STUB_INVOKE__
+                       return QSize(100, 30);
+                   });
+
+    QSize size = delegate->sizeHint(option, index);
+
+    // Separator might have different size
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_SelectedState)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_Selected;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///test");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with selected background
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_HoverState)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_MouseOver;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with hover background
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_SeparatorItem)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_MouseOver;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    separator->setExpanded(true);
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint separator with expand button
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_EjectableItem)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled;
+    option.widget = &widget;
+    option.features = QStyleOptionViewItem::HasDecoration;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with eject icon
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_ExpandButton_Click)
+{
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    separator->setExpanded(false);
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    // Click on expand button area (right side)
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress,
+                                         QPointF(170, 20),   // Position in expand button area
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(&SideBarView::isExpanded, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool expandSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::changeExpandState,
+                     [&expandSignalEmitted](const QModelIndex &, bool expand) {
+                         expandSignalEmitted = true;
+                         EXPECT_TRUE(expand);
+                     });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(expandSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_EjectButton_Click)
+{
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    info.url = QUrl("file:///media/usb");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    // Click on eject button area (bottom right)
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonRelease,
+                                         QPointF(180, 25),   // Position in eject button area
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    bool ejectCalled = false;
+    stub.set_lamda(&SideBarEventCaller::sendEject, [&ejectCalled](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ejectCalled = true;
+    });
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(ejectCalled);
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_MouseMove_Separator)
+{
+    SideBarModel model;
+    SideBarItemSeparator *separator = new SideBarItemSeparator("TestGroup");
+    model.appendRow(separator);
+    QModelIndex index = separator->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseMove,
+                                         QPointF(100, 20),
+                                         Qt::NoButton,
+                                         Qt::NoButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update), [](SideBarView *, const QModelIndex &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    // Should update view on mouse move over separator
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_ShortText_NoTooltip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    item->setText("Short");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(&QToolTip::hideText, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Short text should hide tooltip
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_LongText_ShowTooltip)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    item->setText("This is a very long text that should trigger tooltip display because it exceeds the available width");
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    bool tooltipShown = false;
+    stub.set_lamda(&QToolTip::showText, [&tooltipShown] {
+        __DBG_STUB_INVOKE__
+        tooltipShown = true;
+    });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(tooltipShown);
+}
+
+TEST_F(UT_SideBarItemDelegate, HelpEvent_EjectableItem)
+{
+    QWidget w;
+    QStyleOptionViewItem option;
+    option.widget = &w;
+    option.rect = QRect(0, 0, 200, 40);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///media/usb"));
+    item->setText("USB Drive with Very Long Name");
+    ItemInfo info = item->itemInfo();
+    info.isEjectable = true;
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QHelpEvent *event = new QHelpEvent(QEvent::ToolTip,
+                                       QPoint(10, 10),
+                                       QPoint(100, 100));
+
+    stub.set_lamda(&QToolTip::showText, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QToolTip::hideText, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    bool result = delegate->helpEvent(event, view, option, index);
+
+    delete event;
+
+    // Ejectable items have less space for text
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData_ValidItem)
+{
+    QLineEdit editor;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    ItemInfo info = item->itemInfo();
+    info.displayName = "DisplayName";
+    info.editDisplayText = "EditText";
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    delegate->setEditorData(&editor, index);
+
+    // Should set edit text if available, otherwise display name
+    EXPECT_EQ(editor.text(), QString("EditText"));
+}
+
+TEST_F(UT_SideBarItemDelegate, SetEditorData_NoEditText)
+{
+    QLineEdit editor;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    ItemInfo info = item->itemInfo();
+    info.displayName = "DisplayName";
+    info.editDisplayText = "";   // Empty edit text
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    delegate->setEditorData(&editor, index);
+
+    // Should use display name when edit text is empty
+    EXPECT_EQ(editor.text(), QString("DisplayName"));
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData_ModifiedEditor)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+    editor.setModified(true);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    bool renameSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::rename,
+                     [&renameSignalEmitted](const QModelIndex &, const QString &text) {
+                         renameSignalEmitted = true;
+                         EXPECT_EQ(text, QString("NewName"));
+                     });
+
+    delegate->setModelData(&editor, &model, index);
+
+    EXPECT_TRUE(renameSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, SetModelData_UnmodifiedEditor)
+{
+    QLineEdit editor;
+    editor.setText("NewName");
+    editor.setModified(false);   // Not modified
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    bool renameSignalEmitted = false;
+    QObject::connect(delegate, &SideBarItemDelegate::rename,
+                     [&renameSignalEmitted](const QModelIndex &, const QString &) {
+                         renameSignalEmitted = true;
+                     });
+
+    delegate->setModelData(&editor, &model, index);
+
+    // Should not emit signal for unmodified editor
+    EXPECT_FALSE(renameSignalEmitted);
+}
+
+TEST_F(UT_SideBarItemDelegate, OnEditorTextChanged_LongText)
+{
+    SideBarItem *item = new SideBarItem(QUrl::fromLocalFile("/home/test"));
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, exists), [](const FileInfo *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, extraProperties), [](const FileInfo *) -> QVariantHash {
+        __DBG_STUB_INVOKE__
+        QVariantHash hash;
+        hash["filesystem"] = "ext4";
+        return hash;
+    });
+
+    stub.set_lamda(&FileUtils::supportedMaxLength, [](const QString &) -> int {
+        __DBG_STUB_INVOKE__
+        return 255;
+    });
+
+    stub.set_lamda(&FileUtils::processLength, [](const QString &, int, int, bool, QString &out, int &) {
+        __DBG_STUB_INVOKE__
+        out = "Truncated";
+        return true;
+    });
+
+    // Simulate text change
+    QString veryLongText = QString("a").repeated(300);
+    delegate->onEditorTextChanged(veryLongText, item);
+
+    delete item;
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarItemDelegate, CreateEditor_WithValidator)
+{
+    QWidget parent;
+    QStyleOptionViewItem option;
+
+    SideBarModel model;
+    QLineEdit edit;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, createEditor),
+                   [&] {
+                       __DBG_STUB_INVOKE__
+                       return &edit;
+                   });
+
+    stub.set_lamda(&NPDeviceAliasManager::canSetAlias, [](NPDeviceAliasManager *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_THROW(delegate->createEditor(&parent, option, index));
+}
+
+TEST_F(UT_SideBarItemDelegate, UpdateEditorGeometry_AdjustedWidth)
+{
+    QLineEdit editor;
+    QStyleOptionViewItem option;
+    option.rect = QRect(10, 10, 100, 30);
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, updateEditorGeometry), [] { __DBG_STUB_INVOKE__ });
+
+    stub.set_lamda(&SideBarView::width, [] {
+        __DBG_STUB_INVOKE__
+        return 200;
+    });
+
+    EXPECT_NO_THROW(delegate->updateEditorGeometry(&editor, option, index));
+}
+
+TEST_F(UT_SideBarItemDelegate, EditorEvent_DoubleClick)
+{
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonDblClick,
+                                         QPointF(100, 20),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+
+    stub.set_lamda(VADDR(QStyledItemDelegate, editorEvent), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = delegate->editorEvent(event, &model, option, index);
+
+    delete event;
+
+    // Double click should be handled
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarItemDelegate, Paint_InactiveWindow)
+{
+    QImage image(200, 40, QImage::Format_ARGB32);
+    QPainter painter(&image);
+
+    QWidget widget;
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 200, 40);
+    option.state = QStyle::State_Enabled | QStyle::State_Selected;
+    option.widget = &widget;
+
+    SideBarModel model;
+    SideBarItem *item = new SideBarItem(QUrl("file:///test"));
+    model.appendRow(item);
+    QModelIndex index = item->index();
+
+    stub.set_lamda(&QWidget::isActiveWindow, [](const QWidget *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;   // Inactive window
+    });
+
+    stub.set_lamda(&SideBarView::currentUrl, [](const SideBarView *) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///test");
+    });
+
+    stub.set_lamda(&SideBarView::isSideBarItemDragged, [](const SideBarView *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarView::isDropTarget, [](const SideBarView *, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(DStyledItemDelegate, initStyleOption), [] { __DBG_STUB_INVOKE__ });
+
+    // Should paint with reduced opacity when window is inactive
+    delegate->paint(&painter, option, index);
+
+    EXPECT_TRUE(true);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarmanager.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarmanager.cpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/sidebarmanager.h"
+#include "utils/sidebarhelper.h"
+#include "treeviews/sidebaritem.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <QUrl>
+#include <QPoint>
+
+using namespace dfmplugin_sidebar;
+
+class UT_SideBarManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = SideBarManager::instance();
+        ASSERT_NE(manager, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    SideBarManager *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarManager, Instance)
+{
+    auto ins1 = SideBarManager::instance();
+    auto ins2 = SideBarManager::instance();
+
+    EXPECT_NE(ins1, nullptr);
+    EXPECT_EQ(ins1, ins2);
+}
+
+TEST_F(UT_SideBarManager, RunCd_NullItem)
+{
+    // Should not crash with null item
+    manager->runCd(nullptr, 123);
+
+    // Test passes if no crash occurs
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunCd_WithClickedCallback)
+{
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    // Mock item->url()
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    // Mock item->itemInfo() to return ItemInfo with callback
+    stub.set_lamda(&SideBarItem::itemInfo, [&callbackInvoked, &capturedWindowId, &capturedUrl]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.clickedCb = [&callbackInvoked, &capturedWindowId, &capturedUrl](quint64 winId, const QUrl &url) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+        };
+        return info;
+    });
+
+    manager->runCd(item, 12345);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 12345u);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunCd_WithoutCallback_UseDefault)
+{
+    bool defaultActionCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/default");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.clickedCb = nullptr;
+        return info;
+    });
+
+    stub.set_lamda(&SideBarHelper::defaultCdAction,
+        [&defaultActionCalled, &capturedWindowId, &capturedUrl](quint64 winId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        defaultActionCalled = true;
+        capturedWindowId = winId;
+        capturedUrl = url;
+    });
+
+    manager->runCd(item, 54321);
+
+    EXPECT_TRUE(defaultActionCalled);
+    EXPECT_EQ(capturedWindowId, 54321u);
+    EXPECT_EQ(capturedUrl, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_ContextMenuDisabled)
+{
+    SideBarHelper::contextMenuEnabled = false;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    // Should return early without calling any menu functions
+    manager->runContextMenu(item, 123, QPoint(0, 0));
+
+    // Test passes if no crash
+    EXPECT_TRUE(true);
+
+    delete item;
+
+    // Restore default state
+    SideBarHelper::contextMenuEnabled = true;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_NullItem)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    // Should not crash with null item
+    manager->runContextMenu(nullptr, 123, QPoint(0, 0));
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_SeparatorItem)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    // Should not show context menu for separator items
+    manager->runContextMenu(separator, 123, QPoint(0, 0));
+
+    EXPECT_TRUE(true);
+
+    delete separator;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_InvalidUrl)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    QUrl invalidUrl;  // Invalid URL
+    SideBarItem *item = new SideBarItem(invalidUrl);
+
+    stub.set_lamda(&SideBarItem::url, [invalidUrl]() {
+        __DBG_STUB_INVOKE__
+        return invalidUrl;
+    });
+
+    // Should return early with invalid URL
+    manager->runContextMenu(item, 123, QPoint(10, 20));
+
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_WithCallback)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QPoint capturedPos;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/context");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo,
+        [&callbackInvoked, &capturedWindowId, &capturedUrl, &capturedPos]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.contextMenuCb = [&](quint64 winId, const QUrl &url, const QPoint &pos) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+            capturedPos = pos;
+        };
+        return info;
+    });
+
+    QPoint menuPos(100, 200);
+    manager->runContextMenu(item, 99999, menuPos);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 99999u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedPos, menuPos);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunContextMenu_WithoutCallback_UseDefault)
+{
+    SideBarHelper::contextMenuEnabled = true;
+
+    bool defaultMenuCalled = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QPoint capturedPos;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/defaultmenu");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.contextMenuCb = nullptr;
+        return info;
+    });
+
+    stub.set_lamda(&SideBarHelper::defaultContextMenu,
+        [&defaultMenuCalled, &capturedWindowId, &capturedUrl, &capturedPos]
+        (quint64 winId, const QUrl &url, const QPoint &pos) {
+        __DBG_STUB_INVOKE__
+        defaultMenuCalled = true;
+        capturedWindowId = winId;
+        capturedUrl = url;
+        capturedPos = pos;
+    });
+
+    QPoint menuPos(50, 75);
+    manager->runContextMenu(item, 11111, menuPos);
+
+    EXPECT_TRUE(defaultMenuCalled);
+    EXPECT_EQ(capturedWindowId, 11111u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedPos, menuPos);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunRename_NullItem)
+{
+    // Should not crash with null item
+    manager->runRename(nullptr, 123, "NewName");
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarManager, RunRename_WithCallback)
+{
+    bool callbackInvoked = false;
+    quint64 capturedWindowId = 0;
+    QUrl capturedUrl;
+    QString capturedName;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/rename");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo,
+        [&callbackInvoked, &capturedWindowId, &capturedUrl, &capturedName]() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.renameCb = [&](quint64 winId, const QUrl &url, const QString &name) {
+            callbackInvoked = true;
+            capturedWindowId = winId;
+            capturedUrl = url;
+            capturedName = name;
+        };
+        return info;
+    });
+
+    QString newName = "RenamedItem";
+    manager->runRename(item, 77777, newName);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedWindowId, 77777u);
+    EXPECT_EQ(capturedUrl, testUrl);
+    EXPECT_EQ(capturedName, newName);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, RunRename_WithoutCallback)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/norename");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarItem::url, [testUrl]() {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.renameCb = nullptr;
+        return info;
+    });
+
+    // Should log warning but not crash
+    manager->runRename(item, 88888, "SomeName");
+
+    EXPECT_TRUE(true);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarManager, OpenFolderInASeparateProcess)
+{
+    bool helperCalled = false;
+    QUrl capturedUrl;
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/separate");
+
+    stub.set_lamda(&SideBarHelper::openFolderInASeparateProcess,
+        [&helperCalled, &capturedUrl](const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        helperCalled = true;
+        capturedUrl = url;
+    });
+
+    manager->openFolderInASeparateProcess(testUrl);
+
+    EXPECT_TRUE(helperCalled);
+    EXPECT_EQ(capturedUrl, testUrl);
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarmodel.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarmodel.cpp
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treemodels/sidebarmodel.h"
+#include "treeviews/sidebaritem.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-framework/event/event.h>
+
+#include <QMimeData>
+#include <QUrl>
+
+using namespace dfmplugin_sidebar;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_SideBarModel : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        model = new SideBarModel();
+        ASSERT_NE(model, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete model;
+        model = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarModel *model { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarModel, Constructor)
+{
+    EXPECT_NE(model, nullptr);
+    EXPECT_EQ(model->rowCount(), 0);
+}
+
+TEST_F(UT_SideBarModel, ItemFromIndex_ValidIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    SideBarItem *item = new SideBarItem(testUrl);
+    separator->appendRow(item);
+
+    QModelIndex index = model->index(0, 0);
+    SideBarItem *retrievedItem = model->itemFromIndex(index);
+
+    EXPECT_NE(retrievedItem, nullptr);
+    EXPECT_EQ(retrievedItem, separator);
+}
+
+TEST_F(UT_SideBarModel, ItemFromIndex_ByRow)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    SideBarItem *retrievedItem = model->itemFromIndex(0);
+
+    EXPECT_NE(retrievedItem, nullptr);
+    EXPECT_EQ(retrievedItem, separator);
+}
+
+TEST_F(UT_SideBarModel, GroupItems)
+{
+    SideBarItemSeparator *separator1 = new SideBarItemSeparator(DefaultGroup::kCommon);
+    SideBarItemSeparator *separator2 = new SideBarItemSeparator(DefaultGroup::kDevice);
+
+    model->appendRow(separator1);
+    model->appendRow(separator2);
+
+    QList<SideBarItemSeparator *> groups = model->groupItems();
+
+    EXPECT_EQ(groups.size(), 2);
+    EXPECT_TRUE(groups.contains(separator1));
+    EXPECT_TRUE(groups.contains(separator2));
+}
+
+TEST_F(UT_SideBarModel, SubItems_All)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl url1 = QUrl::fromLocalFile("/home/test1");
+    QUrl url2 = QUrl::fromLocalFile("/home/test2");
+
+    SideBarItem *item1 = new SideBarItem(url1);
+    SideBarItem *item2 = new SideBarItem(url2);
+    item1->setGroup(DefaultGroup::kCommon);
+    item2->setGroup(DefaultGroup::kCommon);
+
+    separator->appendRow(item1);
+    separator->appendRow(item2);
+
+    QList<SideBarItem *> items = model->subItems();
+
+    EXPECT_EQ(items.size(), 2);
+}
+
+TEST_F(UT_SideBarModel, SubItems_ByGroup)
+{
+    SideBarItemSeparator *separatorCommon = new SideBarItemSeparator(DefaultGroup::kCommon);
+    SideBarItemSeparator *separatorDevice = new SideBarItemSeparator(DefaultGroup::kDevice);
+
+    model->appendRow(separatorCommon);
+    model->appendRow(separatorDevice);
+
+    QUrl url1 = QUrl::fromLocalFile("/home/common1");
+    QUrl url2 = QUrl::fromLocalFile("/dev/device1");
+
+    SideBarItem *item1 = new SideBarItem(url1);
+    SideBarItem *item2 = new SideBarItem(url2);
+    item1->setGroup(DefaultGroup::kCommon);
+    item2->setGroup(DefaultGroup::kDevice);
+
+    separatorCommon->appendRow(item1);
+    separatorDevice->appendRow(item2);
+
+    QList<SideBarItem *> commonItems = model->subItems(DefaultGroup::kCommon);
+
+    EXPECT_EQ(commonItems.size(), 1);
+    EXPECT_EQ(commonItems.first(), item1);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_NullItem)
+{
+    bool result = model->insertRow(0, nullptr);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_InvalidRowIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/invalid");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    bool result = model->insertRow(-5, item);
+    EXPECT_FALSE(result);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarModel, InsertRow_Separator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    bool result = model->insertRow(0, separator);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, InsertRow_SubItem)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/subitem");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    bool result = model->insertRow(0, item);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_NullItem)
+{
+    int result = model->appendRow(nullptr);
+    EXPECT_EQ(result, -1);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_AlreadyExists)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/exists");
+    SideBarItem *item = new SideBarItem(testUrl);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        index.r = 5;
+        index.c = 0;
+        // Simulate found at row 5
+        return index;
+    });
+
+    int result = model->appendRow(item);
+    EXPECT_EQ(result, 5);
+
+    delete item;
+}
+
+TEST_F(UT_SideBarModel, AppendRow_Separator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        return index;   // Not found, row() returns -1
+    });
+
+    int result = model->appendRow(separator);
+
+    EXPECT_GE(result, 0);
+    EXPECT_EQ(model->rowCount(), 1);
+}
+
+TEST_F(UT_SideBarModel, AppendRow_SubItem_WithGroup)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/append");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::findRowByUrl, [](const SideBarModel *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();   // Not found
+    });
+
+    int result = model->appendRow(item, true);
+
+    EXPECT_GE(result, 0);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_InvalidUrl)
+{
+    QUrl invalidUrl;
+    bool result = model->removeRow(invalidUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = model->removeRow(testUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarModel, RemoveRow_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = model->removeRow(testUrl);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarModel, UpdateRow_InvalidUrl)
+{
+    QUrl invalidUrl;
+    ItemInfo info;
+
+    // Should return early without crashing
+    model->updateRow(invalidUrl, info);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarModel, UpdateRow_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/update");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SideBarItem::itemInfo, []() -> ItemInfo {
+        __DBG_STUB_INVOKE__
+        ItemInfo info;
+        info.findMeCb = nullptr;
+        return info;
+    });
+
+    ItemInfo newInfo;
+    newInfo.url = testUrl;
+    newInfo.displayName = "Updated Name";
+    newInfo.icon = QIcon::fromTheme("folder");
+    newInfo.flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    newInfo.group = DefaultGroup::kCommon;
+    newInfo.isEditable = true;
+
+    model->updateRow(testUrl, newInfo);
+
+    // Test passes if no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarModel, FindRowByUrl_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notexist");
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    QModelIndex index = model->findRowByUrl(testUrl);
+    EXPECT_FALSE(index.isValid());
+}
+
+TEST_F(UT_SideBarModel, FindRowByUrl_Success)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/find");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QModelIndex index = model->findRowByUrl(testUrl);
+    EXPECT_TRUE(index.isValid());
+}
+
+TEST_F(UT_SideBarModel, AddEmptyItem)
+{
+    int initialCount = model->rowCount();
+
+    model->addEmptyItem();
+
+    EXPECT_EQ(model->rowCount(), initialCount + 1);
+
+    // Adding again should not add another empty item
+    model->addEmptyItem();
+    EXPECT_EQ(model->rowCount(), initialCount + 1);
+}
+
+TEST_F(UT_SideBarModel, CanDropMimeData_InvalidParameters)
+{
+    QMimeData *data = new QMimeData();
+
+    // Invalid row/column
+    bool canDrop = model->canDropMimeData(data, Qt::MoveAction, -1, -1, QModelIndex());
+    EXPECT_FALSE(canDrop);
+
+    // Null data
+    canDrop = model->canDropMimeData(nullptr, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(canDrop);
+
+    delete data;
+}
+
+TEST_F(UT_SideBarModel, CanDropMimeData_OnSeparator)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QMimeData *data = new QMimeData();
+
+    stub.set_lamda(static_cast<SideBarItem *(SideBarModel::*)(int, const QModelIndex &) const>(&SideBarModel::itemFromIndex),
+                   [separator](const SideBarModel *, int, const QModelIndex &) -> SideBarItem * {
+                       __DBG_STUB_INVOKE__
+                       return separator;
+                   });
+
+    bool canDrop = model->canDropMimeData(data, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(canDrop);   // Cannot drop on separator
+
+    delete data;
+}
+
+TEST_F(UT_SideBarModel, MimeData)
+{
+    SideBarItemSeparator *separator = new SideBarItemSeparator(DefaultGroup::kCommon);
+    model->appendRow(separator);
+
+    QUrl testUrl = QUrl::fromLocalFile("/home/mime");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+    separator->appendRow(item);
+
+    QModelIndex itemIndex = item->index();
+    QModelIndexList indexes;
+    indexes << itemIndex;
+
+    stub.set_lamda(VADDR(QStandardItemModel, mimeData),
+                   [](const QStandardItemModel *, const QModelIndexList &) -> QMimeData * {
+                       __DBG_STUB_INVOKE__
+                       return new QMimeData();
+                   });
+
+    QMimeData *mimeData = model->mimeData(indexes);
+
+    EXPECT_NE(mimeData, nullptr);
+
+    delete mimeData;
+}
+
+TEST_F(UT_SideBarModel, DropMimeData_CannotDrop)
+{
+    QMimeData *data = new QMimeData();
+
+    stub.set_lamda(VADDR(SideBarModel, canDropMimeData),
+                   [](const SideBarModel *, const QMimeData *, Qt::DropAction, int, int, const QModelIndex &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = model->dropMimeData(data, Qt::MoveAction, 0, 0, QModelIndex());
+    EXPECT_FALSE(result);
+
+    delete data;
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarview.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarview.cpp
@@ -1,0 +1,1131 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebarview.h"
+#include "treeviews/private/sidebarview_p.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "utils/sidebarhelper.h"
+#include "utils/fileoperatorhelper.h"
+
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QMouseEvent>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QDrag>
+#include <QMimeData>
+#include <QUrl>
+#include <QTimer>
+#include <thread>
+#include <chrono>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_sidebar;
+
+class UT_SidebarView : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        model = new SideBarModel;
+        SideBarItem *item1 = createGroupItem(QString("group1"));
+        SideBarItem *item2 = createGroupItem(QString("group2"));
+        model->appendRow(item1);
+        model->appendRow(item2);   // two groups added.
+
+        SideBarItem *group1_item1 = createSubItem("item1", QUrl("test/url3"), QString("group1"));
+        SideBarItem *group1_item2 = createSubItem("item2", QUrl("test/url4"), QString("group1"));
+
+        model->appendRow(group1_item1);
+        model->appendRow(group1_item2);   // two items under group1
+
+        view = new SideBarView;
+        view->setModel(model);
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (model) {
+            model->clear();
+            delete model;
+        }
+        if (view)
+            delete view;
+    }
+    SideBarItem *createGroupItem(const QString &group)
+    {
+        SideBarItem *item = new SideBarItemSeparator(group);
+        return item;
+    }
+    SideBarItem *createSubItem(const QString &name, const QUrl &url, const QString &group)
+    {
+        QString iconName { SystemPathUtil::instance()->systemPathIconName(name) };
+        QString text { name };
+        if (!iconName.contains("-symbolic"))
+            iconName.append("-symbolic");
+
+        SideBarItem *item = new SideBarItem(QIcon::fromTheme(iconName),
+                                            text,
+                                            group,
+                                            url);
+        return item;
+    }
+    SideBarModel *model = nullptr;
+    SideBarView *view = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SidebarView, FindItemIndex)
+{
+    QModelIndex index1 = view->findItemIndex(QUrl("test/url3"));
+    EXPECT_TRUE(index1.row() == 0);
+
+    QModelIndex index2 = view->findItemIndex(QUrl("test/url4"));
+    EXPECT_TRUE(index2.row() == 1);
+}
+
+TEST_F(UT_SidebarView, testDragEnterEvent)
+{
+    bool isCall { false };
+    stub.set_lamda(&QDropEvent::setDropAction, []() {
+        return;
+    });
+
+    stub.set_lamda(&QDropEvent::ignore, [&]() {
+        isCall = true;
+        return;
+    });
+
+    QDragEnterEvent event(QPoint(10, 10), Qt::IgnoreAction, nullptr, Qt::LeftButton, Qt::NoModifier);
+
+    // action1
+    stub.set_lamda(&QMimeData::urls, []() -> QList<QUrl> {
+        return {};
+    });
+
+    QMimeData data;
+    data.setData(DFMGLOBAL_NAMESPACE::Mime::kDFMTreeUrlsKey, "file:///home");
+    stub.set_lamda(&QDropEvent::mimeData, [&] {
+        return &data;
+    });
+
+    view->dragEnterEvent(&event);
+    EXPECT_FALSE(isCall);
+
+    // action2
+    isCall = false;
+    stub.set_lamda(&QMimeData::urls, []() -> QList<QUrl> {
+        return { QUrl("/home/uos") };
+    });
+
+    stub.set_lamda(&FileUtils::isContainProhibitPath, []() -> bool {
+        return true;
+    });
+
+    view->dragEnterEvent(&event);
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_SidebarView, testDragLeaveEvent)
+{
+    bool isCall { false };
+    stub.set_lamda(&QAbstractItemView::setCurrentIndex, []() {
+        return;
+    });
+    stub.set_lamda(&QAbstractItemView::setState, []() {
+        return;
+    });
+
+    auto upDate = static_cast<void (QWidget::*)()>(&QWidget::update);
+    stub.set_lamda(upDate, [&]() {
+        __DBG_STUB_INVOKE__
+        isCall = true;
+        return;
+    });
+
+    QDragLeaveEvent event;
+
+    view->dragLeaveEvent(&event);
+    // Product now refreshes the viewport while clearing hover/drag state on
+    // drag leave, so QWidget::update() is expected to be called.
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_SidebarView, MousePressEvent_RightButton)
+{
+    stub.set_lamda(&SideBarView::urlAt, [](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///home/test");
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPoint(10, 10), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+
+    // Right click should be accepted and not trigger parent handler
+    view->mousePressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+}
+
+TEST_F(UT_SidebarView, MousePressEvent_LeftButton)
+{
+    QUrl testUrl("file:///home/test");
+    QString testGroup("Common");
+
+    stub.set_lamda(&SideBarView::urlAt, [testUrl](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    SideBarItem *testItem = createSubItem("test", testUrl, testGroup);
+    stub.set_lamda(&SideBarView::itemAt, [testItem](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return testItem;
+    });
+
+    stub.set_lamda(VADDR(DTreeView, mousePressEvent), [](DTreeView *, QMouseEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&event);
+
+    delete testItem;
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, MouseReleaseEvent_ValidItem)
+{
+    bool reportCalled = false;
+    QUrl testUrl("file:///home/test");
+
+    SideBarItem *testItem = createSubItem("TestItem", testUrl, "Common");
+    model->appendRow(testItem);
+
+    stub.set_lamda(&SideBarView::itemAt, [testItem](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return testItem;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [testItem, this](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return testItem->index();
+    });
+
+    typedef bool (EventDispatcherManager::*PublishFunc)(const QString &, const QString &, QString, QVariantMap &);
+    stub.set_lamda(static_cast<PublishFunc>(&EventDispatcherManager::publish),
+                   [&reportCalled](EventDispatcherManager *, const QString &, const QString &, QString, QVariantMap) {
+                       __DBG_STUB_INVOKE__
+                       reportCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(DTreeView, mouseReleaseEvent), [](DTreeView *, QMouseEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMouseEvent event(QEvent::MouseButtonRelease, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    EXPECT_TRUE(reportCalled);
+}
+
+TEST_F(UT_SidebarView, ItemAt_ValidPoint)
+{
+    SideBarItem *item = createSubItem("item", QUrl("file:///test"), "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item, this](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    SideBarItem *result = view->itemAt(QPoint(10, 10));
+    EXPECT_NE(result, nullptr);
+    if (result) {
+        EXPECT_EQ(result->url(), QUrl("file:///test"));
+    }
+}
+
+TEST_F(UT_SidebarView, ItemAt_InvalidPoint)
+{
+    stub.set_lamda(VADDR(SideBarView, indexAt), [](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    SideBarItem *result = view->itemAt(QPoint(10, 10));
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_SidebarView, UrlAt_ValidItem)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("item", testUrl, "group1");
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    QUrl result = view->urlAt(QPoint(10, 10));
+    EXPECT_EQ(result, testUrl);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, UrlAt_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QUrl result = view->urlAt(QPoint(10, 10));
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_ValidUrl)
+{
+    QUrl testUrl("test/url3");
+
+    stub.set_lamda(&QAbstractItemView::setCurrentIndex, [](QAbstractItemView *, const QModelIndex &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_EQ(view->currentUrl(), testUrl);
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_InvalidUrl)
+{
+    QUrl invalidUrl("file:///nonexistent");
+
+    stub.set_lamda(&QAbstractItemView::clearSelection, [](QAbstractItemView *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->setCurrentUrl(invalidUrl);
+
+    // Should handle invalid URL gracefully
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, SetCurrentUrl_CollapsedGroup)
+{
+    QUrl testUrl("test/url3");
+
+    SideBarItem *item = model->itemFromIndex(model->index(0, 0));
+    SideBarItemSeparator *separator = dynamic_cast<SideBarItemSeparator *>(item);
+    if (separator) {
+        separator->setExpanded(false);
+    }
+
+    // Should not set current index when group is collapsed
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, CurrentUrl)
+{
+    QUrl testUrl("file:///home/test");
+    view->setCurrentUrl(testUrl);
+
+    EXPECT_EQ(view->currentUrl(), testUrl);
+}
+
+TEST_F(UT_SidebarView, SaveStateWhenClose_WithExpandRules)
+{
+    bool saveConfigCalled = false;
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        map["group2"] = false;
+        return map;
+    });
+
+    stub.set_lamda(&SideBarHelper::saveGroupsStateToConfig, [&saveConfigCalled] {
+        __DBG_STUB_INVOKE__
+        saveConfigCalled = true;
+    });
+
+    view->saveStateWhenClose();
+
+    EXPECT_TRUE(saveConfigCalled);
+}
+
+TEST_F(UT_SidebarView, SaveStateWhenClose_EmptyRules)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    // Should return early when no expand rules
+    view->saveStateWhenClose();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, UpdateSeparatorVisibleState_AllChildrenHidden)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    stub.set_lamda(&QTreeView::isRowHidden, [](const QTreeView *, int, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;   // All children are hidden
+    });
+
+    stub.set_lamda(&QTreeView::setRowHidden, [](QTreeView *, int, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->updateSeparatorVisibleState();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, UpdateSeparatorVisibleState_SomeChildrenVisible)
+{
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    stub.set_lamda(&QTreeView::isRowHidden, [](const QTreeView *, int row, const QModelIndex &) -> bool {
+        __DBG_STUB_INVOKE__
+        return row > 0;   // First child visible, others hidden
+    });
+
+    stub.set_lamda(&QTreeView::setRowHidden, [](QTreeView *, int, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->updateSeparatorVisibleState();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_ExpandGroup)
+{
+    SideBarItem *groupItem = model->itemFromIndex(model->index(0, 0));
+    ASSERT_NE(groupItem, nullptr);
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool expand) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(expand);
+    });
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        return QVariantMap();
+    });
+
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    auto updateFunc = static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update);
+    stub.set_lamda(updateFunc, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->onChangeExpandState(groupItem->index(), true);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_CollapseGroup)
+{
+    SideBarItem *groupItem = model->itemFromIndex(model->index(0, 0));
+    ASSERT_NE(groupItem, nullptr);
+
+    stub.set_lamda(&QTreeView::setExpanded, [](QTreeView *, const QModelIndex &, bool expand) {
+        __DBG_STUB_INVOKE__
+        EXPECT_FALSE(expand);
+    });
+
+    stub.set_lamda(&SideBarHelper::groupExpandRules, []() -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["group1"] = true;
+        return map;
+    });
+
+    auto updateFunc = static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::update);
+    stub.set_lamda(updateFunc, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->onChangeExpandState(groupItem->index(), false);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnChangeExpandState_NullItem)
+{
+    QModelIndex invalidIndex;
+
+    // Should handle null item gracefully
+    view->onChangeExpandState(invalidIndex, true);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, PreviousIndex)
+{
+    QModelIndex testIndex = model->index(0, 0);
+    view->setPreviousIndex(testIndex);
+
+    EXPECT_EQ(view->previousIndex(), testIndex);
+}
+
+TEST_F(UT_SidebarView, IsDropTarget_True)
+{
+    QModelIndex testIndex = model->index(0, 0);
+
+    // Simulate drag event to set current hover index
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [testIndex](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return testIndex;
+    });
+
+    QMimeData mimeData;
+    QDragMoveEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    view->dragMoveEvent(&event);
+
+    bool result = view->isDropTarget(testIndex);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, IsSideBarItemDragged_False)
+{
+    bool result = view->isSideBarItemDragged();
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SidebarView, StartDrag_ValidUrl)
+{
+    QUrl dragUrl("file:///home/test");
+
+    // mousePressEvent() throttles ops within 200ms of view construction
+    // (checkOpTime()); wait out the window so the press is processed.
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+    stub.set_lamda(&SideBarView::urlAt, [dragUrl](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return dragUrl;
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    // Give startDrag() a valid, drag-enabled source index. Note: inside
+    // SideBarView::mousePressEvent the call to indexAt() is devirtualized, so
+    // the vtable stub only affects calls from Qt's view machinery; also stub
+    // the non-virtual currentIndex() as startDrag()'s fallback.
+    stub.set_lamda(VADDR(SideBarView, indexAt), [this](SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return model->index(0, 0, model->index(0, 0));
+    });
+
+    stub.set_lamda(&QAbstractItemView::currentIndex, [this](QAbstractItemView *) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return model->index(0, 0, model->index(0, 0));
+    });
+
+    // QDrag::exec() spins a nested event loop; stub it to return immediately
+    using ExecFunc = Qt::DropAction (QDrag::*)(Qt::DropActions, Qt::DropAction);
+    auto exec = static_cast<ExecFunc>(&QDrag::exec);
+    bool execCalled = false;
+    stub.set_lamda(exec, [&execCalled](QDrag *, Qt::DropActions, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+        execCalled = true;
+        return Qt::IgnoreAction;
+    });
+
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&pressEvent);
+
+    view->startDrag(Qt::CopyAction | Qt::MoveAction);
+
+    // The drag pipeline ran through exec(); the product clears the dragged
+    // flag after the drag finishes, so it must be false again here.
+    EXPECT_TRUE(execCalled);
+    EXPECT_FALSE(view->isSideBarItemDragged());
+}
+
+TEST_F(UT_SidebarView, StartDrag_InvalidUrl)
+{
+    stub.set_lamda(&SideBarView::urlAt, [](SideBarView *, const QPoint &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl();
+    });
+
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPoint(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&pressEvent);
+
+    // Should return early without calling parent
+    view->startDrag(Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, GroupExpandState)
+{
+    QVariantMap state = view->groupExpandState();
+    // Initially should be empty
+    EXPECT_TRUE(state.isEmpty());
+}
+
+TEST_F(UT_SidebarView, DragMoveEvent_ValidItem)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("test", testUrl, "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    auto updateFunc = static_cast<void (QWidget::*)()>(&QWidget::update);
+    stub.set_lamda(updateFunc, [](QWidget *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source") });
+    QDragMoveEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    // Should not ignore the event
+    view->dragMoveEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, DragMoveEvent_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source") });
+    QDragMoveEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::ignore, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->dragMoveEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, DropEvent_ValidDrop)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+    model->appendRow(item);
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(VADDR(SideBarView, indexAt), [item](const SideBarView *, const QPoint &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return item->index();
+    });
+
+    stub.set_lamda(VADDR(SideBarView, visualRect), [] {
+        __DBG_STUB_INVOKE__
+        return QRect(0, 0, 100, 30);
+    });
+
+    stub.set_lamda(&SideBarView::onDropData, [](const SideBarView *, QList<QUrl>, QUrl, Qt::DropAction) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QWidget::activateWindow, [](QWidget *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::accept, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+    QDropEvent event(QPoint(10, 10), Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view->dropEvent(&event);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SidebarView, OnDropData_CopyAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    typedef void (*Func)(int, const QObject *, const std::function<void()> &);
+    stub.set_lamda(static_cast<Func>(&QTimer::singleShot), [](int, const QObject *, std::function<void()> func) {
+        __DBG_STUB_INVOKE__
+        func();   // Execute the lambda
+    });
+
+    stub.set_lamda(&FileOperatorHelper::pasteFiles, [](FileOperatorHelper *, quint64, const QList<QUrl> &, const QUrl &, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return 12345;
+    });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return false; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::CopyAction);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, OnDropData_MoveAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    bool pasteCalled = false;
+
+    stub.set_lamda(&FileOperatorHelper::pasteFiles, [&pasteCalled](FileOperatorHelper *, quint64, const QList<QUrl> &, const QUrl &, Qt::DropAction action) {
+        __DBG_STUB_INVOKE__
+        pasteCalled = true;
+        EXPECT_EQ(action, Qt::MoveAction);
+    });
+
+    stub.set_lamda(&SideBarHelper::windowId, [](QWidget *) -> quint64 {
+        __DBG_STUB_INVOKE__
+        return 12345;
+    });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return false; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::MoveAction);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(pasteCalled);
+}
+
+TEST_F(UT_SidebarView, OnDropData_IgnoreAction)
+{
+    QUrl srcUrl("file:///home/source.txt");
+    QUrl dstUrl("file:///home/target");
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QList<QUrl>, QUrl &, Qt::DropAction *&&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [] { return true; });
+
+    bool result = view->onDropData({ srcUrl }, dstUrl, Qt::IgnoreAction);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_IgnoreAction_EmptyUrls)
+{
+    SideBarItem *item = createSubItem("test", QUrl("file:///test"), "group1");
+
+    QMimeData mimeData;
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_IgnoreAction_InvalidTargetUrl)
+{
+    SideBarItem *item = createSubItem("test", QUrl(), "group1");
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///source") });
+
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_CopyAction)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isSameDevice, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    EXPECT_NO_THROW(view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction));
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_MoveAction_SameDevice)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isSameDevice, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UrlRoute::urlParent, [](const QUrl &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    EXPECT_NO_THROW(view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction));
+    delete item;
+}
+
+TEST_F(UT_SidebarView, CanDropMimeData_TrashFile_DifferentUser)
+{
+    QUrl targetUrl("file:///home/.local/share/Trash/files");
+    SideBarItem *item = createSubItem("trash", targetUrl, "group1");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info(new FileInfo(QUrl::fromLocalFile("/home/test")));
+        return info;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes), [](const FileInfo *, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](const FileInfo *, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, fileType), [](const FileInfo *) -> FileInfo::FileType {
+        __DBG_STUB_INVOKE__
+        return FileInfo::FileType::kDirectory;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [targetUrl](const FileInfo *, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return targetUrl;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, supportedOfAttributes), [](const FileInfo *, SupportedType) -> Qt::DropActions {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction | Qt::MoveAction;
+    });
+
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&SysInfoUtils::isSameUser, [](const QMimeData *) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&UrlRoute::urlParent, [](const QUrl &) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///other");
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+
+    Qt::DropAction result = view->canDropMimeData(item, &mimeData, Qt::CopyAction | Qt::MoveAction);
+
+    EXPECT_EQ(result, Qt::IgnoreAction);
+
+    delete item;
+}
+
+TEST_F(UT_SidebarView, IsAccepteDragEvent_Accept)
+{
+    QUrl targetUrl("file:///home/target");
+    SideBarItem *item = createSubItem("target", targetUrl, "group1");
+
+    stub.set_lamda(&SideBarView::itemAt, [item](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return item;
+    });
+
+    stub.set_lamda(&SideBarView::canDropMimeData, [](const SideBarView *, SideBarItem *, const QMimeData *, Qt::DropActions) -> Qt::DropAction {
+        __DBG_STUB_INVOKE__
+        return Qt::CopyAction;
+    });
+
+    stub.set_lamda(&QDropEvent::setDropAction, [](QDropEvent *, Qt::DropAction) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QDropEvent::accept, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl("file:///home/source.txt") });
+    QDropEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    bool result = view->isAccepteDragEvent(&event);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SidebarView, IsAccepteDragEvent_Reject_NoItem)
+{
+    stub.set_lamda(&SideBarView::itemAt, [](SideBarView *, const QPoint &) -> SideBarItem * {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    QMimeData mimeData;
+    QDropEvent event(QPoint(10, 10), Qt::CopyAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+
+    stub.set_lamda(&QDropEvent::mimeData, [&mimeData]() -> const QMimeData * {
+        __DBG_STUB_INVOKE__
+        return &mimeData;
+    });
+
+    bool result = view->isAccepteDragEvent(&event);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SidebarView, FindItemIndex_WithCallback)
+{
+    QUrl testUrl("file:///home/test");
+    SideBarItem *item = createSubItem("test", testUrl, "group1");
+
+    ItemInfo info = item->itemInfo();
+    info.findMeCb = [](const QUrl &, const QUrl &) -> bool {
+        return true;
+    };
+
+    stub.set_lamda(&SideBarItem::itemInfo, [&] { __DBG_STUB_INVOKE__ return info; });
+
+    model->appendRow(item);
+
+    QModelIndex result = view->findItemIndex(QUrl("file:///other"));
+
+    EXPECT_TRUE(result.isValid());
+}
+
+TEST_F(UT_SidebarView, FindItemIndex_NotFound)
+{
+    QModelIndex result = view->findItemIndex(QUrl("file:///nonexistent"));
+
+    EXPECT_FALSE(result.isValid());
+}

--- a/autotests/plugins/dfmplugin-sidebar/test_sidebarwidget.cpp
+++ b/autotests/plugins/dfmplugin-sidebar/test_sidebarwidget.cpp
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "treeviews/sidebarwidget.h"
+#include "treeviews/sidebarview.h"
+#include "treeviews/sidebaritem.h"
+#include "treemodels/sidebarmodel.h"
+#include "dfmplugin_sidebar_global.h"
+
+#include <DBlurEffectWidget>
+#include <DConfig>
+
+#include <QUrl>
+#include <QEvent>
+#include <QListView>
+
+using namespace dfmplugin_sidebar;
+DWIDGET_USE_NAMESPACE
+
+class UT_SideBarWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub GUI operations
+        stub.set_lamda(ADDR(QWidget, show), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QWidget, hide), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(static_cast<void (QWidget::*)()>(&QWidget::update), [](QWidget *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        widget = new SideBarWidget();
+        ASSERT_NE(widget, nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+protected:
+    SideBarWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SideBarWidget, Constructor)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_SideBarWidget, View)
+{
+    QAbstractItemView *view = widget->view();
+
+    // Should return the sidebar view
+    EXPECT_NE(view, nullptr);
+}
+
+TEST_F(UT_SideBarWidget, SetCurrentUrl)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
+
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->setCurrentUrl(testUrl);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, CurrentUrl)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/current");
+
+    stub.set_lamda(&SideBarView::currentUrl, [testUrl]() -> QUrl {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    QUrl retrievedUrl = widget->currentUrl();
+
+    EXPECT_EQ(retrievedUrl, testUrl);
+}
+
+TEST_F(UT_SideBarWidget, AddItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/add");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::appendRow, [](SideBarModel *, SideBarItem *, bool) -> int {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+
+    int result = widget->addItem(item, true);
+
+    EXPECT_GE(result, -1);
+}
+
+TEST_F(UT_SideBarWidget, InsertItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/insert");
+    SideBarItem *item = new SideBarItem(testUrl);
+    item->setGroup(DefaultGroup::kCommon);
+
+    stub.set_lamda(&SideBarModel::insertRow, [](SideBarModel *, int, SideBarItem *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = widget->insertItem(0, item);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarWidget, RemoveItem_InvalidUrl)
+{
+    QUrl invalidUrl;
+
+    bool result = widget->removeItem(invalidUrl);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_SideBarWidget, RemoveItem_Success)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/remove");
+
+    stub.set_lamda(&SideBarModel::removeRow, [](SideBarModel *, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = widget->removeItem(testUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/update");
+
+    ItemInfo newInfo;
+    newInfo.url = testUrl;
+    newInfo.displayName = "Updated";
+
+    stub.set_lamda(&SideBarModel::updateRow, [](SideBarModel *, const QUrl &, const ItemInfo &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->updateItem(testUrl, newInfo);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, FindItem_NotFound)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/notfound");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    int result = widget->findItem(testUrl);
+    EXPECT_EQ(result, -1);
+}
+
+TEST_F(UT_SideBarWidget, FindItemIndex)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/find");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        QModelIndex index;
+        return index;
+    });
+
+    QModelIndex index = widget->findItemIndex(testUrl);
+
+    // Just verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, EditItem)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/edit");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    stub.set_lamda(static_cast<void (SideBarView::*)(const QModelIndex &)>(&SideBarView::edit), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->editItem(testUrl);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, SetItemVisiable)
+{
+    QUrl testUrl = QUrl::fromLocalFile("/home/visible");
+
+    stub.set_lamda(&SideBarView::findItemIndex, [](SideBarView *, const QUrl &) -> QModelIndex {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+
+    stub.set_lamda(&QListView::setRowHidden, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->setItemVisiable(testUrl, true);
+
+    // Verify no crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItemVisiable_EmptyMap)
+{
+    QVariantMap emptyStates;
+
+    widget->updateItemVisiable(emptyStates);
+
+    // Should not crash with empty map
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateItemVisiable_WithStates)
+{
+    QVariantMap states;
+    states["key1"] = false;
+    states["key2"] = true;
+
+    stub.set_lamda(&SideBarWidget::findItemUrlsByVisibleControlKey,
+                   [](const SideBarWidget *, const QString &) -> QList<QUrl> {
+                       __DBG_STUB_INVOKE__
+                       return QList<QUrl>();
+                   });
+
+    widget->updateItemVisiable(states);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, FindItemUrlsByVisibleControlKey)
+{
+    QString key = "test_key";
+
+    stub.set_lamda(static_cast<QList<SideBarItem *> (SideBarModel::*)() const>(&SideBarModel::subItems),
+                   [](const SideBarModel *) -> QList<SideBarItem *> {
+                       __DBG_STUB_INVOKE__
+                       return QList<SideBarItem *>();
+                   });
+
+    QList<QUrl> urls = widget->findItemUrlsByVisibleControlKey(key);
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, UpdateSelection)
+{
+    stub.set_lamda(&SideBarView::setCurrentUrl, [](SideBarView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->updateSelection();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, SaveStateWhenClose)
+{
+    stub.set_lamda(&SideBarView::saveStateWhenClose, [](SideBarView *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    widget->saveStateWhenClose();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, ResetSettingPanel)
+{
+    stub.set_lamda(&SideBarModel::groupItems,
+                   [](const SideBarModel *) -> QList<SideBarItemSeparator *> {
+                       __DBG_STUB_INVOKE__
+                       return QList<SideBarItemSeparator *>();
+                   });
+
+    widget->resetSettingPanel();
+
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_SideBarWidget, ChangeEvent_PaletteChange)
+{
+    QPalette oldPalette;
+    QPalette newPalette;
+
+    QEvent *event = new QEvent(QEvent::PaletteChange);
+
+    stub.set_lamda(VADDR(QWidget, changeEvent), [](QWidget *, QEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    // Protected method, tested through public API
+    widget->changeEvent(event);
+
+    delete event;
+
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
Port sidebar plugin tests from autotests/old, covering sidebar
model, events and utils.

从 autotests/old 移植侧边栏插件测试，覆盖侧边栏模型、事件
与工具。

Log: 新增 dfmplugin-sidebar 单元测试
Influence: 仅新增测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.