### PR TITLE
test: add unit tests for dfmplugin-utils

### DIFF
--- a/autotests/plugins/dfmplugin-utils/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-utils/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-utils" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-utils") 

--- a/autotests/plugins/dfmplugin-utils/main.cpp
+++ b/autotests/plugins/dfmplugin-utils/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_utils)

--- a/autotests/plugins/dfmplugin-utils/test_appendcompresseventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_appendcompresseventreceiver.cpp
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "appendcompress/appendcompresseventreceiver.h"
+#include "appendcompress/appendcompresshelper.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <QMimeData>
+#include <QUrl>
+#include <QPoint>
+#include <QVariantHash>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_AppendCompressEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        receiver = new AppendCompressEventReceiver();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete receiver;
+        receiver = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    AppendCompressEventReceiver *receiver { nullptr };
+};
+
+/**
+ * @brief Test initEventConnect method
+ * Verifies that event connections are properly initialized
+ */
+TEST_F(UT_AppendCompressEventReceiver, initEventConnect_WorkspaceHooks_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    // Stub dpfHookSequence->follow to prevent actual hook registration
+    bool workspaceFollowCalled = false;
+    typedef bool (AppendCompressEventReceiver::*HookFunc)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
+    typedef bool (EventSequenceManager::*HookType)(const QString &, const QString &, AppendCompressEventReceiver *, HookFunc);
+    stub.set_lamda(static_cast<HookType>(&EventSequenceManager::follow),
+                   [&workspaceFollowCalled] {
+                       __DBG_STUB_INVOKE__
+                       workspaceFollowCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(DPF_NAMESPACE::Event, eventType),
+                   [](DPF_NAMESPACE::Event *, const QString &, const QString &) -> int {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(workspaceFollowCalled);
+}
+
+/**
+ * @brief Test handleSetMouseStyle with valid parameters
+ * Verifies that mouse style is set correctly
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyle_ValidParams_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyle(fromUrls, toUrl, &action);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyle returns false when helper fails
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyle_HelperFails_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/invalid.txt");
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleSetMouseStyle(fromUrls, toUrl, &action);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompress with valid parameters
+ * Verifies that drag-drop compression is handled correctly
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompress_ValidParams_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt"),
+                             QUrl::fromLocalFile("/tmp/file2.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompress(fromUrls, toUrl);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompress returns false when helper fails
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompress_HelperFails_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/invalid.txt");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleDragDropCompress(fromUrls, toUrl);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    Qt::DropAction action = Qt::CopyAction;
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = reinterpret_cast<qint64>(&action);
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnDesktop with null dropAction pointer
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnDesktop_NullDropAction_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = 0;   // Null pointer
+
+    bool result = receiver->handleSetMouseStyleOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnDesktop with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnDesktop_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["dropUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompressOnDesktop(0, &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnDesktop with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnDesktop_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleDragDropCompressOnDesktop(0, &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    Qt::DropAction action = Qt::CopyAction;
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = reinterpret_cast<qint64>(&action);
+
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &, const QList<QUrl> &, Qt::DropAction *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleSetMouseStyleOnOrganizer with null dropAction pointer
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleSetMouseStyleOnOrganizer_NullDropAction_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["hoverUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+    extData["dropAction"] = 0;   // Null pointer
+
+    bool result = receiver->handleSetMouseStyleOnOrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnOsrganizer with valid extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnOsrganizer_ValidExtData_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    QVariantHash extData;
+    extData["dropUrl"] = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &, const QList<QUrl> &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleDragDropCompressOnOsrganizer("view-id", &mimeData, QPoint(0, 0), &extData);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleDragDropCompressOnOsrganizer with null extData
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleDragDropCompressOnOsrganizer_NullExtData_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QMimeData mimeData;
+    mimeData.setUrls({ QUrl::fromLocalFile("/tmp/file1.txt") });
+
+    bool result = receiver->handleDragDropCompressOnOsrganizer("view-id", &mimeData, QPoint(0, 0), nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test handleIsDrop with compressed file
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleIsDrop_CompressedFile_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = receiver->handleIsDrop(url);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test handleIsDrop with non-compressed file
+ */
+TEST_F(UT_AppendCompressEventReceiver, handleIsDrop_NonCompressedFile_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    QUrl url = QUrl::fromLocalFile("/tmp/document.txt");
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = receiver->handleIsDrop(url);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test constructor creates valid object
+ */
+TEST_F(UT_AppendCompressEventReceiver, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    AppendCompressEventReceiver *testReceiver = new AppendCompressEventReceiver();
+
+    EXPECT_NE(testReceiver, nullptr);
+
+    delete testReceiver;
+}

--- a/autotests/plugins/dfmplugin-utils/test_appendcompresshelper.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_appendcompresshelper.cpp
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresshelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QProcess>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_AppendCompressHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// ========== isCompressedFile 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_ZipFile_ReturnsTrue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/zip";
+                       return "archive.zip";
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_7zFile_ReturnsTrue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.7z");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-7z-compressed";
+                       return "archive.7z";
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_Tar7zFile_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/archive.tar.7z");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "application/x-7z-compressed";
+                       return "archive.tar.7z";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_NonCompressedFile_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/document.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsFile;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType type) -> QString {
+                       __DBG_STUB_INVOKE__
+                       if (type == NameInfoType::kMimeTypeName)
+                           return "text/plain";
+                       return "document.txt";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+TEST_F(UT_AppendCompressHelper, isCompressedFile_NullFileInfo_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/nonexistent.zip");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::isCompressedFile(url));
+}
+
+// ========== canAppendCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_ValidParams_ReturnsTrue)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(toUrl));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsWritable;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_InvalidParams_ReturnsFalse)
+{
+    QList<QUrl> emptyUrls;
+    QUrl invalidUrl;
+    QUrl validUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(emptyUrls, validUrl));
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress({ validUrl }, invalidUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_FTPFile_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl("ftp://example.com/file.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &url) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return url.scheme() == "ftp";
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_HookProhibits_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(UT_AppendCompressHelper, canAppendCompress_NotWritableOrNotCompressed_ReturnsFalse)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ProtocolUtils, isFTPFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, const QList<QUrl> &, const QUrl &);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(toUrl));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::canAppendCompress(fromUrls, toUrl));
+}
+
+// ========== appendCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, appendCompress_ValidParams_LaunchesCompressor)
+{
+    QString toFilePath = "/tmp/archive.zip";
+    QStringList fromFilePaths = { "/tmp/file1.txt", "/tmp/file2.txt" };
+
+    bool startDetachedCalled = false;
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&] {
+                       __DBG_STUB_INVOKE__
+                       startDetachedCalled = true;
+                       return true;
+                   });
+
+    bool result = AppendCompressHelper::appendCompress(toFilePath, fromFilePaths);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(startDetachedCalled);
+}
+
+// ========== dragDropCompress 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_ValidParams_ReturnsTrue)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(fromUrls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes),
+                   [](FileInfo *, const CanableInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, appendCompress),
+                   [](const QString &, const QStringList &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::dragDropCompress(toUrl, fromUrls));
+}
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_RedirectedUrls_UsesRedirectedPath)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    QUrl redirectedUrl = QUrl::fromLocalFile("/tmp/redirected.txt");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(fromUrls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, canAttributes),
+                   [](FileInfo *, const CanableInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == CanableInfoType::kCanRedirectionFileUrl;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf),
+                   [&redirectedUrl](FileInfo *, const UrlInfoType) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return redirectedUrl;
+                   });
+
+    QString capturedPath;
+    stub.set_lamda(ADDR(AppendCompressHelper, appendCompress),
+                   [&capturedPath, &redirectedUrl](const QString &, const QStringList &fromPaths) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!fromPaths.isEmpty())
+                           capturedPath = fromPaths[0];
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::dragDropCompress(toUrl, fromUrls));
+    EXPECT_EQ(capturedPath, redirectedUrl.path());
+}
+
+TEST_F(UT_AppendCompressHelper, dragDropCompress_InvalidParams_ReturnsFalse)
+{
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       out->clear();
+                       return true;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::dragDropCompress(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }));
+
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &in, QList<QUrl> *out) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *out = in;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::dragDropCompress(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }));
+}
+
+// ========== setMouseStyle 测试 ==========
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_CanAppend_SetsCopyAction)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction dropAction = Qt::IgnoreAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::setMouseStyle(toUrl, fromUrls, &dropAction));
+    EXPECT_EQ(dropAction, Qt::CopyAction);
+}
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_CannotAppend_SetsIgnoreAction)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/archive.zip");
+    Qt::DropAction dropAction = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(AppendCompressHelper, canAppendCompress),
+                   [](const QList<QUrl> &, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_TRUE(AppendCompressHelper::setMouseStyle(toUrl, fromUrls, &dropAction));
+    EXPECT_EQ(dropAction, Qt::IgnoreAction);
+}
+
+TEST_F(UT_AppendCompressHelper, setMouseStyle_NotCompressedOrEmpty_ReturnsFalse)
+{
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/document.txt");
+    Qt::DropAction dropAction = Qt::CopyAction;
+
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_FALSE(AppendCompressHelper::setMouseStyle(toUrl, { QUrl::fromLocalFile("/tmp/file.txt") }, &dropAction));
+
+    EXPECT_FALSE(AppendCompressHelper::setMouseStyle(toUrl, QList<QUrl>(), &dropAction));
+}

--- a/autotests/plugins/dfmplugin-utils/test_basic.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_basic.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+class UT_Basic : public testing::Test
+{
+protected:
+    virtual void SetUp() override {}
+    virtual void TearDown() override {}
+};
+
+TEST_F(UT_Basic, BasicTest)
+{
+    // Basic functionality test - placeholder for plugin unit tests
+    EXPECT_TRUE(true);
+} 

--- a/autotests/plugins/dfmplugin-utils/test_bluetoothadapter.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_bluetoothadapter.cpp
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothadapter.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothdevice.h"
+
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_BluetoothAdapter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        adapter = new BluetoothAdapter();
+    }
+
+    virtual void TearDown() override
+    {
+        // Clean up all devices
+        auto devices = adapter->getDevices();
+        for (const BluetoothDevice *dev : devices) {
+            const_cast<BluetoothDevice *>(dev)->deleteLater();
+        }
+
+        delete adapter;
+        adapter = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    BluetoothAdapter *adapter { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object with default values
+ */
+TEST_F(UT_BluetoothAdapter, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(adapter, nullptr);
+    EXPECT_TRUE(adapter->getId().isEmpty());
+    EXPECT_TRUE(adapter->getName().isEmpty());
+    EXPECT_FALSE(adapter->isPowered());
+    EXPECT_EQ(adapter->getDevices().size(), 0);
+}
+
+/**
+ * @brief Test setId and getId
+ */
+TEST_F(UT_BluetoothAdapter, setId_ValidId_IdIsSet)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testId = "/org/bluez/hci0";
+    adapter->setId(testId);
+
+    EXPECT_EQ(adapter->getId(), testId);
+}
+
+/**
+ * @brief Test setName and getName with nameChanged signal
+ */
+TEST_F(UT_BluetoothAdapter, setName_ValidName_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::nameChanged);
+
+    QString testName = "Bluetooth Adapter";
+    adapter->setName(testName);
+
+    EXPECT_EQ(adapter->getName(), testName);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), testName);
+}
+
+/**
+ * @brief Test setName with same name doesn't emit signal
+ */
+TEST_F(UT_BluetoothAdapter, setName_SameName_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testName = "Bluetooth Adapter";
+    adapter->setName(testName);
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::nameChanged);
+    adapter->setName(testName);   // Set same name again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test setPowered and isPowered with poweredChanged signal
+ */
+TEST_F(UT_BluetoothAdapter, setPowered_True_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::poweredChanged);
+
+    adapter->setPowered(true);
+
+    EXPECT_TRUE(adapter->isPowered());
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.takeFirst().at(0).toBool());
+}
+
+/**
+ * @brief Test setPowered with same value doesn't emit signal
+ */
+TEST_F(UT_BluetoothAdapter, setPowered_SameValue_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    adapter->setPowered(true);
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::poweredChanged);
+    adapter->setPowered(true);   // Set same value again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test addDevice with new device
+ */
+TEST_F(UT_BluetoothAdapter, addDevice_NewDevice_DeviceAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::deviceAdded);
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+
+    adapter->addDevice(device);
+
+    EXPECT_EQ(adapter->getDevices().size(), 1);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).value<const BluetoothDevice *>(), device);
+}
+
+/**
+ * @brief Test addDevice with duplicate device
+ */
+TEST_F(UT_BluetoothAdapter, addDevice_DuplicateDevice_NotAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    adapter->addDevice(device);
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::deviceAdded);
+
+    // Try to add the same device again
+    adapter->addDevice(device);
+
+    EXPECT_EQ(adapter->getDevices().size(), 1);
+    EXPECT_EQ(spy.count(), 0);   // No signal emitted for duplicate
+}
+
+/**
+ * @brief Test addDevice with multiple devices
+ */
+TEST_F(UT_BluetoothAdapter, addDevice_MultipleDevices_AllAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothDevice *device1 = new BluetoothDevice(adapter);
+    device1->setId("/org/bluez/hci0/dev_11_11_11_11_11_11");
+
+    BluetoothDevice *device2 = new BluetoothDevice(adapter);
+    device2->setId("/org/bluez/hci0/dev_22_22_22_22_22_22");
+
+    BluetoothDevice *device3 = new BluetoothDevice(adapter);
+    device3->setId("/org/bluez/hci0/dev_33_33_33_33_33_33");
+
+    adapter->addDevice(device1);
+    adapter->addDevice(device2);
+    adapter->addDevice(device3);
+
+    EXPECT_EQ(adapter->getDevices().size(), 3);
+}
+
+/**
+ * @brief Test deviceById with existing device
+ */
+TEST_F(UT_BluetoothAdapter, deviceById_ExistingDevice_ReturnsDevice)
+{
+    __DBG_STUB_INVOKE__
+
+    QString deviceId = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId(deviceId);
+    adapter->addDevice(device);
+
+    const BluetoothDevice *result = adapter->deviceById(deviceId);
+
+    EXPECT_NE(result, nullptr);
+    EXPECT_EQ(result, device);
+    EXPECT_EQ(result->getId(), deviceId);
+}
+
+/**
+ * @brief Test deviceById with non-existing device
+ */
+TEST_F(UT_BluetoothAdapter, deviceById_NonExistingDevice_ReturnsNull)
+{
+    __DBG_STUB_INVOKE__
+
+    const BluetoothDevice *result = adapter->deviceById("/org/bluez/hci0/dev_NONEXISTENT");
+
+    EXPECT_EQ(result, nullptr);
+}
+
+/**
+ * @brief Test removeDevice with existing device
+ */
+TEST_F(UT_BluetoothAdapter, removeDevice_ExistingDevice_DeviceRemoved)
+{
+    __DBG_STUB_INVOKE__
+
+    QString deviceId = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId(deviceId);
+    adapter->addDevice(device);
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::deviceRemoved);
+
+    adapter->removeDevice(deviceId);
+
+    EXPECT_EQ(adapter->getDevices().size(), 0);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), deviceId);
+
+    // Clean up device manually since it's removed from adapter
+    device->deleteLater();
+}
+
+/**
+ * @brief Test removeDevice with non-existing device
+ */
+TEST_F(UT_BluetoothAdapter, removeDevice_NonExistingDevice_NoChange)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::deviceRemoved);
+
+    adapter->removeDevice("/org/bluez/hci0/dev_NONEXISTENT");
+
+    EXPECT_EQ(adapter->getDevices().size(), 0);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test removeDevice with multiple devices
+ */
+TEST_F(UT_BluetoothAdapter, removeDevice_MultipleDevices_CorrectDeviceRemoved)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothDevice *device1 = new BluetoothDevice(adapter);
+    device1->setId("/org/bluez/hci0/dev_11_11_11_11_11_11");
+
+    BluetoothDevice *device2 = new BluetoothDevice(adapter);
+    device2->setId("/org/bluez/hci0/dev_22_22_22_22_22_22");
+
+    BluetoothDevice *device3 = new BluetoothDevice(adapter);
+    device3->setId("/org/bluez/hci0/dev_33_33_33_33_33_33");
+
+    adapter->addDevice(device1);
+    adapter->addDevice(device2);
+    adapter->addDevice(device3);
+
+    adapter->removeDevice(device2->getId());
+
+    EXPECT_EQ(adapter->getDevices().size(), 2);
+    EXPECT_NE(adapter->deviceById(device1->getId()), nullptr);
+    EXPECT_EQ(adapter->deviceById(device2->getId()), nullptr);
+    EXPECT_NE(adapter->deviceById(device3->getId()), nullptr);
+
+    // Clean up removed device
+    device2->deleteLater();
+}
+
+/**
+ * @brief Test getDevices returns correct map
+ */
+TEST_F(UT_BluetoothAdapter, getDevices_WithDevices_ReturnsCorrectMap)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothDevice *device1 = new BluetoothDevice(adapter);
+    device1->setId("/org/bluez/hci0/dev_11_11_11_11_11_11");
+    device1->setName("Device 1");
+
+    BluetoothDevice *device2 = new BluetoothDevice(adapter);
+    device2->setId("/org/bluez/hci0/dev_22_22_22_22_22_22");
+    device2->setName("Device 2");
+
+    adapter->addDevice(device1);
+    adapter->addDevice(device2);
+
+    QMap<QString, const BluetoothDevice *> devices = adapter->getDevices();
+
+    EXPECT_EQ(devices.size(), 2);
+    EXPECT_TRUE(devices.contains(device1->getId()));
+    EXPECT_TRUE(devices.contains(device2->getId()));
+    EXPECT_EQ(devices[device1->getId()], device1);
+    EXPECT_EQ(devices[device2->getId()], device2);
+}
+
+/**
+ * @brief Test complete adapter configuration
+ */
+TEST_F(UT_BluetoothAdapter, CompleteConfiguration_AllPropertiesSet)
+{
+    __DBG_STUB_INVOKE__
+
+    QString id = "/org/bluez/hci0";
+    QString name = "My Bluetooth Adapter";
+
+    adapter->setId(id);
+    adapter->setName(name);
+    adapter->setPowered(true);
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    adapter->addDevice(device);
+
+    EXPECT_EQ(adapter->getId(), id);
+    EXPECT_EQ(adapter->getName(), name);
+    EXPECT_TRUE(adapter->isPowered());
+    EXPECT_EQ(adapter->getDevices().size(), 1);
+}
+
+/**
+ * @brief Test powered state transitions
+ */
+TEST_F(UT_BluetoothAdapter, setPowered_StateTransitions_EmitsSignals)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::poweredChanged);
+
+    // Off -> On
+    adapter->setPowered(true);
+    EXPECT_EQ(spy.count(), 1);
+
+    // On -> Off
+    adapter->setPowered(false);
+    EXPECT_EQ(spy.count(), 2);
+
+    // Off -> On again
+    adapter->setPowered(true);
+    EXPECT_EQ(spy.count(), 3);
+}
+
+/**
+ * @brief Test add and remove device operations sequence
+ */
+TEST_F(UT_BluetoothAdapter, AddRemoveSequence_WorksCorrectly)
+{
+    __DBG_STUB_INVOKE__
+
+    QString deviceId = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+
+    // Add device
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId(deviceId);
+    adapter->addDevice(device);
+    EXPECT_EQ(adapter->getDevices().size(), 1);
+
+    // Remove device
+    adapter->removeDevice(deviceId);
+    EXPECT_EQ(adapter->getDevices().size(), 0);
+
+    // Add same device again (new instance)
+    BluetoothDevice *device2 = new BluetoothDevice(adapter);
+    device2->setId(deviceId);
+    adapter->addDevice(device2);
+    EXPECT_EQ(adapter->getDevices().size(), 1);
+
+    // Clean up
+    device->deleteLater();
+}
+
+/**
+ * @brief Test empty adapter name
+ */
+TEST_F(UT_BluetoothAdapter, setName_EmptyName_AcceptedAndSetCorrectly)
+{
+    __DBG_STUB_INVOKE__
+
+    adapter->setName("Test Adapter");
+    adapter->setName("");
+
+    EXPECT_TRUE(adapter->getName().isEmpty());
+}
+
+/**
+ * @brief Test getDevices on empty adapter
+ */
+TEST_F(UT_BluetoothAdapter, getDevices_EmptyAdapter_ReturnsEmptyMap)
+{
+    __DBG_STUB_INVOKE__
+
+    QMap<QString, const BluetoothDevice *> devices = adapter->getDevices();
+
+    EXPECT_TRUE(devices.isEmpty());
+    EXPECT_EQ(devices.size(), 0);
+}

--- a/autotests/plugins/dfmplugin-utils/test_bluetoothdevice.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_bluetoothdevice.cpp
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothdevice.h"
+
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_BluetoothDevice : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        device = new BluetoothDevice();
+    }
+
+    virtual void TearDown() override
+    {
+        delete device;
+        device = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    BluetoothDevice *device { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object with default values
+ */
+TEST_F(UT_BluetoothDevice, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(device, nullptr);
+    EXPECT_TRUE(device->getId().isEmpty());
+    EXPECT_TRUE(device->getName().isEmpty());
+    EXPECT_TRUE(device->getAlias().isEmpty());
+    EXPECT_TRUE(device->getIcon().isEmpty());
+    EXPECT_FALSE(device->isPaired());
+    EXPECT_FALSE(device->isTrusted());
+    EXPECT_EQ(device->getState(), BluetoothDevice::kStateUnavailable);
+}
+
+/**
+ * @brief Test setId and getId
+ */
+TEST_F(UT_BluetoothDevice, setId_ValidId_IdIsSet)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testId = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+    device->setId(testId);
+
+    EXPECT_EQ(device->getId(), testId);
+}
+
+/**
+ * @brief Test setName and getName with nameChanged signal
+ */
+TEST_F(UT_BluetoothDevice, setName_ValidName_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::nameChanged);
+
+    QString testName = "Test Device";
+    device->setName(testName);
+
+    EXPECT_EQ(device->getName(), testName);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), testName);
+}
+
+/**
+ * @brief Test setName with same name doesn't emit signal
+ */
+TEST_F(UT_BluetoothDevice, setName_SameName_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testName = "Test Device";
+    device->setName(testName);
+
+    QSignalSpy spy(device, &BluetoothDevice::nameChanged);
+    device->setName(testName);   // Set same name again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test setAlias and getAlias with aliasChanged signal
+ */
+TEST_F(UT_BluetoothDevice, setAlias_ValidAlias_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::aliasChanged);
+
+    QString testAlias = "My Device";
+    device->setAlias(testAlias);
+
+    EXPECT_EQ(device->getAlias(), testAlias);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), testAlias);
+}
+
+/**
+ * @brief Test setAlias with same alias doesn't emit signal
+ */
+TEST_F(UT_BluetoothDevice, setAlias_SameAlias_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testAlias = "My Device";
+    device->setAlias(testAlias);
+
+    QSignalSpy spy(device, &BluetoothDevice::aliasChanged);
+    device->setAlias(testAlias);   // Set same alias again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test setIcon and getIcon
+ */
+TEST_F(UT_BluetoothDevice, setIcon_ValidIcon_IconIsSet)
+{
+    __DBG_STUB_INVOKE__
+
+    QString testIcon = "phone";
+    device->setIcon(testIcon);
+
+    EXPECT_EQ(device->getIcon(), testIcon);
+}
+
+/**
+ * @brief Test setIcon with different icon types
+ */
+TEST_F(UT_BluetoothDevice, setIcon_DifferentTypes_AllAccepted)
+{
+    __DBG_STUB_INVOKE__
+
+    device->setIcon("phone");
+    EXPECT_EQ(device->getIcon(), "phone");
+
+    device->setIcon("computer");
+    EXPECT_EQ(device->getIcon(), "computer");
+
+    device->setIcon("headset");
+    EXPECT_EQ(device->getIcon(), "headset");
+}
+
+/**
+ * @brief Test setPaired and isPaired with pairedChanged signal
+ */
+TEST_F(UT_BluetoothDevice, setPaired_True_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::pairedChanged);
+
+    device->setPaired(true);
+
+    EXPECT_TRUE(device->isPaired());
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.takeFirst().at(0).toBool());
+}
+
+/**
+ * @brief Test setPaired with same value doesn't emit signal
+ */
+TEST_F(UT_BluetoothDevice, setPaired_SameValue_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    device->setPaired(true);
+
+    QSignalSpy spy(device, &BluetoothDevice::pairedChanged);
+    device->setPaired(true);   // Set same value again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test setTrusted and isTrusted with trustedChanged signal
+ */
+TEST_F(UT_BluetoothDevice, setTrusted_True_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::trustedChanged);
+
+    device->setTrusted(true);
+
+    EXPECT_TRUE(device->isTrusted());
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.takeFirst().at(0).toBool());
+}
+
+/**
+ * @brief Test setTrusted with same value doesn't emit signal
+ */
+TEST_F(UT_BluetoothDevice, setTrusted_SameValue_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    device->setTrusted(true);
+
+    QSignalSpy spy(device, &BluetoothDevice::trustedChanged);
+    device->setTrusted(true);   // Set same value again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test setState and getState with stateChanged signal
+ */
+TEST_F(UT_BluetoothDevice, setState_Available_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::stateChanged);
+
+    device->setState(BluetoothDevice::kStateAvailable);
+
+    EXPECT_EQ(device->getState(), BluetoothDevice::kStateAvailable);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).value<BluetoothDevice::State>(),
+              BluetoothDevice::kStateAvailable);
+}
+
+/**
+ * @brief Test setState with Connected state
+ */
+TEST_F(UT_BluetoothDevice, setState_Connected_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::stateChanged);
+
+    device->setState(BluetoothDevice::kStateConnected);
+
+    EXPECT_EQ(device->getState(), BluetoothDevice::kStateConnected);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+/**
+ * @brief Test setState with same state doesn't emit signal
+ */
+TEST_F(UT_BluetoothDevice, setState_SameState_NoSignalEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    device->setState(BluetoothDevice::kStateConnected);
+
+    QSignalSpy spy(device, &BluetoothDevice::stateChanged);
+    device->setState(BluetoothDevice::kStateConnected);   // Set same state again
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test state transitions
+ */
+TEST_F(UT_BluetoothDevice, setState_StateTransitions_AllWork)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(device, &BluetoothDevice::stateChanged);
+
+    // Unavailable -> Available
+    device->setState(BluetoothDevice::kStateAvailable);
+    EXPECT_EQ(spy.count(), 1);
+
+    // Available -> Connected
+    device->setState(BluetoothDevice::kStateConnected);
+    EXPECT_EQ(spy.count(), 2);
+
+    // Connected -> Unavailable
+    device->setState(BluetoothDevice::kStateUnavailable);
+    EXPECT_EQ(spy.count(), 3);
+}
+
+/**
+ * @brief Test complete device configuration
+ */
+TEST_F(UT_BluetoothDevice, CompleteConfiguration_AllPropertiesSet)
+{
+    __DBG_STUB_INVOKE__
+
+    QString id = "/org/bluez/hci0/dev_11_22_33_44_55_66";
+    QString name = "Samsung Galaxy";
+    QString alias = "My Phone";
+    QString icon = "phone";
+
+    device->setId(id);
+    device->setName(name);
+    device->setAlias(alias);
+    device->setIcon(icon);
+    device->setPaired(true);
+    device->setTrusted(true);
+    device->setState(BluetoothDevice::kStateConnected);
+
+    EXPECT_EQ(device->getId(), id);
+    EXPECT_EQ(device->getName(), name);
+    EXPECT_EQ(device->getAlias(), alias);
+    EXPECT_EQ(device->getIcon(), icon);
+    EXPECT_TRUE(device->isPaired());
+    EXPECT_TRUE(device->isTrusted());
+    EXPECT_EQ(device->getState(), BluetoothDevice::kStateConnected);
+}
+
+/**
+ * @brief Test multiple signal emissions
+ */
+TEST_F(UT_BluetoothDevice, MultipleChanges_MultipleSignalsEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy nameSpy(device, &BluetoothDevice::nameChanged);
+    QSignalSpy aliasSpy(device, &BluetoothDevice::aliasChanged);
+    QSignalSpy pairedSpy(device, &BluetoothDevice::pairedChanged);
+    QSignalSpy trustedSpy(device, &BluetoothDevice::trustedChanged);
+    QSignalSpy stateSpy(device, &BluetoothDevice::stateChanged);
+
+    device->setName("Name1");
+    device->setName("Name2");
+    device->setAlias("Alias1");
+    device->setPaired(true);
+    device->setTrusted(true);
+    device->setState(BluetoothDevice::kStateConnected);
+
+    EXPECT_EQ(nameSpy.count(), 2);
+    EXPECT_EQ(aliasSpy.count(), 1);
+    EXPECT_EQ(pairedSpy.count(), 1);
+    EXPECT_EQ(trustedSpy.count(), 1);
+    EXPECT_EQ(stateSpy.count(), 1);
+}
+
+/**
+ * @brief Test empty strings
+ */
+TEST_F(UT_BluetoothDevice, EmptyStrings_AcceptedAndSetCorrectly)
+{
+    __DBG_STUB_INVOKE__
+
+    device->setName("Test");
+    device->setName("");
+    EXPECT_TRUE(device->getName().isEmpty());
+
+    device->setAlias("Test");
+    device->setAlias("");
+    EXPECT_TRUE(device->getAlias().isEmpty());
+
+    device->setIcon("");
+    EXPECT_TRUE(device->getIcon().isEmpty());
+}

--- a/autotests/plugins/dfmplugin-utils/test_bluetoothmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_bluetoothmanager.cpp
@@ -1,0 +1,859 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager_p.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmodel.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothadapter.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothdevice.h"
+
+#include <QDBusInterface>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusConnection>
+#include <QDBusServiceWatcher>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTimer>
+#include <QtConcurrent>
+#include <QFutureWatcher>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_BluetoothManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub QDBusInterface constructor and methods
+        stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(ADDR(QDBusInterface, setTimeout), [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(ADDR(QDBusInterface, lastError), [] {
+            __DBG_STUB_INVOKE__
+            return QDBusError();
+        });
+
+        stub.set_lamda(ADDR(QDBusInterface, property), [] {
+            __DBG_STUB_INVOKE__
+            return QVariant(true);
+        });
+
+        // Stub QTimer::singleShot
+        using SingleShotIntFunc = void (*)(int, const QObject *, const char *);
+        stub.set_lamda(static_cast<SingleShotIntFunc>(QTimer::singleShot),
+                       [](int, const QObject *, const char *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        // Stub QDBusPendingCallWatcher to prevent actual async operations
+        stub.set_lamda(ADDR(QDBusPendingCallWatcher, isFinished),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(ADDR(QDBusPendingCall, isError), [](QDBusPendingCall *) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+/**
+ * @brief Test singleton instance
+ */
+TEST_F(UT_BluetoothManager, instance_Singleton_ReturnsSameInstance)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothManager *instance1 = BluetoothManager::instance();
+    BluetoothManager *instance2 = BluetoothManager::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+/**
+ * @brief Test hasAdapter with adapters
+ */
+TEST_F(UT_BluetoothManager, hasAdapter_WithAdapters_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    // Stub getAdapters to return non-empty map
+    stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                   [](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                       __DBG_STUB_INVOKE__
+                       QMap<QString, const BluetoothAdapter *> adapters;
+                       adapters["/org/bluez/hci0"] = new BluetoothAdapter();
+                       return adapters;
+                   });
+
+    bool result = manager->hasAdapter();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test hasAdapter without adapters
+ */
+TEST_F(UT_BluetoothManager, hasAdapter_WithoutAdapters_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                   [](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                       __DBG_STUB_INVOKE__
+                       return QMap<QString, const BluetoothAdapter *>();
+                   });
+
+    bool result = manager->hasAdapter();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test bluetoothSendEnable when interface is valid and CanSendFile is true
+ */
+TEST_F(UT_BluetoothManager, bluetoothSendEnable_ValidAndEnabled_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    bool result = manager->bluetoothSendEnable();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test bluetoothSendEnable when interface is invalid
+ */
+TEST_F(UT_BluetoothManager, bluetoothSendEnable_InvalidInterface_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = manager->bluetoothSendEnable();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test bluetoothSendEnable when CanSendFile property is invalid
+ */
+TEST_F(UT_BluetoothManager, bluetoothSendEnable_InvalidProperty_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();   // Invalid variant
+    });
+
+    bool result = manager->bluetoothSendEnable();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test bluetoothSendEnable when CanSendFile is false
+ */
+TEST_F(UT_BluetoothManager, bluetoothSendEnable_CanSendFileFalse_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    bool result = manager->bluetoothSendEnable();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test refresh method initiates async call
+ */
+TEST_F(UT_BluetoothManager, refresh_ValidInterface_InitiatesAsyncCall)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    bool asyncCallCalled = false;
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &)>(&QDBusInterface::asyncCall),
+                   [&asyncCallCalled] {
+                       __DBG_STUB_INVOKE__
+                       asyncCallCalled = true;
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    manager->refresh();
+
+    EXPECT_TRUE(asyncCallCalled);
+}
+
+/**
+ * @brief Test refresh when interface is invalid
+ */
+TEST_F(UT_BluetoothManager, refresh_InvalidInterface_DoesNothing)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    bool asyncCallCalled = false;
+
+    stub.set_lamda(ADDR(QDBusInterface, isValid), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &)>(&QDBusInterface::asyncCall),
+                   [&asyncCallCalled](QDBusInterface *, const QString &) -> QDBusPendingCall {
+                       __DBG_STUB_INVOKE__
+                       asyncCallCalled = true;
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    manager->refresh();
+
+    EXPECT_FALSE(asyncCallCalled);
+}
+
+/**
+ * @brief Test showBluetoothSettings calls DBus interface
+ */
+TEST_F(UT_BluetoothManager, showBluetoothSettings_CallsDBusInterface)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    bool asyncCallCalled = false;
+
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [&asyncCallCalled] {
+                       __DBG_STUB_INVOKE__
+                       asyncCallCalled = true;
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    manager->showBluetoothSettings();
+
+    EXPECT_TRUE(asyncCallCalled);
+}
+
+/**
+ * @brief Test sendFiles with valid device and files
+ */
+TEST_F(UT_BluetoothManager, sendFiles_ValidParams_InitiatesTransfer)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    bool asyncCallCalled = false;
+
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [&asyncCallCalled] {
+                       __DBG_STUB_INVOKE__
+                       asyncCallCalled = true;
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+
+    manager->sendFiles("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                       QStringList() << "/tmp/file1.txt",
+                       "test-token");
+    // The DBus call runs on a QtConcurrent worker thread, so wait for it
+    QTRY_VERIFY_WITH_TIMEOUT(asyncCallCalled, 5000);
+}
+
+/**
+ * @brief Test cancelTransfer calls DBus interface
+ */
+TEST_F(UT_BluetoothManager, cancelTransfer_ValidPath_CallsDBusInterface)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    bool asyncCallCalled = false;
+
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [&asyncCallCalled] {
+                       __DBG_STUB_INVOKE__
+                           asyncCallCalled = true;
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    bool result = manager->cancelTransfer("/session/path");
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(asyncCallCalled);
+}
+
+/**
+ * @brief Test canSendBluetoothRequest with valid Transportable property
+ */
+TEST_F(UT_BluetoothManager, canSendBluetoothRequest_TransportableTrue_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+            return QVariant(true);
+    });
+
+    bool result = manager->canSendBluetoothRequest();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test canSendBluetoothRequest with invalid Transportable property
+ */
+TEST_F(UT_BluetoothManager, canSendBluetoothRequest_InvalidProperty_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();   // Invalid variant
+    });
+
+    bool result = manager->canSendBluetoothRequest();
+
+    EXPECT_TRUE(result);   // Returns true as default when property is invalid
+}
+
+/**
+ * @brief Test canSendBluetoothRequest with Transportable false
+ */
+TEST_F(UT_BluetoothManager, canSendBluetoothRequest_TransportableFalse_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    stub.set_lamda(ADDR(QDBusInterface, property), [] {
+        __DBG_STUB_INVOKE__
+            return QVariant(false);
+    });
+
+    bool result = manager->canSendBluetoothRequest();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test getAdapters returns model's adapters
+ */
+TEST_F(UT_BluetoothManager, getAdapters_ReturnsModelAdapters)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+
+    // Access private member according to dfm_ut.md
+    EXPECT_NE(manager->d_ptr, nullptr);
+    EXPECT_NE(manager->d_ptr->model, nullptr);
+
+    QMap<QString, const BluetoothAdapter *> adapters = manager->getAdapters();
+
+    // Should return the model's adapters (may be empty initially)
+    EXPECT_TRUE(true);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate inflateAdapter
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_inflateAdapter_ParsesJson)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+
+    QJsonObject adapterObj;
+    adapterObj["Path"] = "/org/bluez/hci0";
+    adapterObj["Alias"] = "Test Adapter";
+    adapterObj["Powered"] = true;
+
+    // Stub getBluetoothDevices to prevent actual DBus call
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    d->inflateAdapter(adapter, adapterObj);
+
+    EXPECT_EQ(adapter->getId(), "/org/bluez/hci0");
+    EXPECT_EQ(adapter->getName(), "Test Adapter");
+    EXPECT_TRUE(adapter->isPowered());
+
+    delete adapter;
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate inflateDevice
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_inflateDevice_ParsesJson)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    BluetoothDevice *device = new BluetoothDevice();
+
+    QJsonObject deviceObj;
+    deviceObj["Path"] = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+    deviceObj["Name"] = "Test Device";
+    deviceObj["Alias"] = "My Phone";
+    deviceObj["Icon"] = "phone";
+    deviceObj["Paired"] = true;
+    deviceObj["Trusted"] = true;
+    deviceObj["State"] = 2;   // kStateConnected
+
+    d->inflateDevice(device, deviceObj);
+
+    EXPECT_EQ(device->getId(), "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    EXPECT_EQ(device->getName(), "Test Device");
+    EXPECT_EQ(device->getAlias(), "My Phone");
+    EXPECT_EQ(device->getIcon(), "phone");
+    EXPECT_TRUE(device->isPaired());
+    EXPECT_TRUE(device->isTrusted());
+    EXPECT_EQ(device->getState(), BluetoothDevice::kStateConnected);
+
+    delete device;
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onAdapterAdded
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onAdapterAdded_AddsAdapter)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QJsonObject adapterObj;
+    adapterObj["Path"] = "/org/bluez/hci0";
+    adapterObj["Alias"] = "New Adapter";
+    adapterObj["Powered"] = false;
+
+    QJsonDocument doc(adapterObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    // Stub getBluetoothDevices to prevent actual DBus call
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    QSignalSpy spy(d->model, &BluetoothModel::adapterAdded);
+
+    d->onAdapterAdded(json);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onAdapterRemoved
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onAdapterRemoved_RemovesAdapter)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    // First add an adapter
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0");
+    d->model->addAdapter(adapter);
+
+    QJsonObject adapterObj;
+    adapterObj["Path"] = "/org/bluez/hci0";
+
+    QJsonDocument doc(adapterObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    QSignalSpy spy(d->model, &BluetoothModel::adapterRemoved);
+
+    d->onAdapterRemoved(json);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onDeviceAdded
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onDeviceAdded_AddsDevice)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    // First add an adapter
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0");
+    d->model->addAdapter(adapter);
+
+    QJsonObject deviceObj;
+    deviceObj["AdapterPath"] = "/org/bluez/hci0";
+    deviceObj["Path"] = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+    deviceObj["Name"] = "Test Device";
+    deviceObj["Alias"] = "My Phone";
+    deviceObj["Icon"] = "phone";
+    deviceObj["Paired"] = true;
+    deviceObj["Trusted"] = true;
+    deviceObj["State"] = 2;
+
+    QJsonDocument doc(deviceObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    QSignalSpy spy(adapter, &BluetoothAdapter::deviceAdded);
+
+    d->onDeviceAdded(json);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onTransferRemoved with done=true
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onTransferRemoved_DoneTrue_EmitsFinished)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QSignalSpy spy(manager, &BluetoothManager::fileTransferFinished);
+
+    d->onTransferRemoved("/tmp/file.txt",
+                         QDBusObjectPath("/transfer/path"),
+                         QDBusObjectPath("/session/path"),
+                         true);
+
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), "/session/path");
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onTransferRemoved with done=false
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onTransferRemoved_DoneFalse_EmitsCanceled)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QSignalSpy spy(manager, &BluetoothManager::transferCancledByRemote);
+
+    d->onTransferRemoved("/tmp/file.txt",
+                         QDBusObjectPath("/transfer/path"),
+                         QDBusObjectPath("/session/path"),
+                         false);
+
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), "/session/path");
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onObexSessionProgress
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onObexSessionProgress_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QSignalSpy spy(manager, &BluetoothManager::transferProgressUpdated);
+
+    d->onObexSessionProgress(QDBusObjectPath("/session/path"), 1000, 500, 0);
+
+    EXPECT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), "/session/path");
+    EXPECT_EQ(args.at(1).toULongLong(), 1000);
+    EXPECT_EQ(args.at(2).toULongLong(), 500);
+    EXPECT_EQ(args.at(3).toInt(), 0);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onTransferFailed
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onTransferFailed_EmitsSignal)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QSignalSpy spy(manager, &BluetoothManager::transferFailed);
+
+    d->onTransferFailed("/tmp/file.txt",
+                        QDBusObjectPath("/session/path"),
+                        "Connection lost");
+
+    EXPECT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), "/session/path");
+    EXPECT_EQ(args.at(1).toString(), "/tmp/file.txt");
+    EXPECT_EQ(args.at(2).toString(), "Connection lost");
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onDeviceRemoved
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onDeviceRemoved_RemovesDevice)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    // First add an adapter with a device
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0");
+    d->model->addAdapter(adapter);
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    adapter->addDevice(device);
+
+    QJsonObject deviceObj;
+    deviceObj["AdapterPath"] = "/org/bluez/hci0";
+    deviceObj["Path"] = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+
+    QJsonDocument doc(deviceObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    d->onDeviceRemoved(json);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onDevicePropertiesChanged
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onDevicePropertiesChanged_UpdatesDevice)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    // First add an adapter with a device (unique ids: the singleton model
+    // is shared between tests; a stale adapter/device registered by an
+    // earlier test case would otherwise be found first and updated).
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0_devprops_test");
+    d->model->addAdapter(adapter);
+
+    BluetoothDevice *device = new BluetoothDevice(adapter);
+    device->setId("/org/bluez/hci0_devprops_test/dev_AA_BB_CC_DD_EE_FF");
+    device->setName("Old Name");
+    adapter->addDevice(device);
+
+    QJsonObject deviceObj;
+    deviceObj["Path"] = "/org/bluez/hci0_devprops_test/dev_AA_BB_CC_DD_EE_FF";
+    deviceObj["Name"] = "New Name";
+    deviceObj["Alias"] = "New Alias";
+    deviceObj["Icon"] = "phone";
+    deviceObj["Paired"] = true;
+    deviceObj["Trusted"] = true;
+    deviceObj["State"] = 2;
+
+    QJsonDocument doc(deviceObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    d->onDevicePropertiesChanged(json);
+
+    EXPECT_EQ(device->getName(), "New Name");
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onAdapterPropertiesChanged
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onAdapterPropertiesChanged_UpdatesAdapter)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    // Stub getBluetoothDevices
+    stub.set_lamda(static_cast<QDBusPendingCall (QDBusInterface::*)(const QString &, const QList<QVariant> &)>(&QDBusInterface::asyncCallWithArgumentList),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QDBusPendingCall::fromError(QDBusError());
+                   });
+
+    // First add an adapter (unique id: the singleton model is shared
+    // between tests and adapterById() would otherwise pick up an adapter
+    // registered by an earlier test case).
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0_props_test");
+    adapter->setName("Old Name");
+    adapter->setPowered(false);
+    d->model->addAdapter(adapter);
+
+    QJsonObject adapterObj;
+    adapterObj["Path"] = "/org/bluez/hci0_props_test";
+    adapterObj["Alias"] = "New Name";
+    adapterObj["Powered"] = true;
+
+    QJsonDocument doc(adapterObj);
+    QString json = QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+
+    d->onAdapterPropertiesChanged(json);
+
+    EXPECT_EQ(adapter->getName(), "New Name");
+    EXPECT_TRUE(adapter->isPowered());
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onTransferCreated
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onTransferCreated_Logs)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    d->onTransferCreated("/tmp/file.txt",
+                         QDBusObjectPath("/transfer/path"),
+                         QDBusObjectPath("/session/path"));
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onObexSessionCreated
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onObexSessionCreated_Logs)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    d->onObexSessionCreated(QDBusObjectPath("/session/path"));
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onObexSessionRemoved
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onObexSessionRemoved_Logs)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    d->onObexSessionRemoved(QDBusObjectPath("/session/path"));
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate resolve with empty string
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_resolve_EmptyString_Retries)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    QDBusReply<QString> reply;
+    d->resolve(reply);
+}
+
+/**
+ * @brief Test BluetoothManagerPrivate onServiceValidChanged with false
+ */
+TEST_F(UT_BluetoothManager, BluetoothManagerPrivate_onServiceValidChanged_False_DoesNothing)
+{
+    __DBG_STUB_INVOKE__
+
+    auto manager = BluetoothManager::instance();
+    auto d = manager->d_ptr.data();
+
+    d->onServiceValidChanged(false);
+}

--- a/autotests/plugins/dfmplugin-utils/test_bluetoothmodel.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_bluetoothmodel.cpp
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmodel.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothadapter.h"
+
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_BluetoothModel : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        model = new BluetoothModel();
+    }
+
+    virtual void TearDown() override
+    {
+        // Clean up all adapters
+        auto adapters = model->getAdapters();
+        for (const BluetoothAdapter *adapter : adapters) {
+            const_cast<BluetoothAdapter *>(adapter)->deleteLater();
+        }
+
+        delete model;
+        model = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    BluetoothModel *model { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object with empty adapters
+ */
+TEST_F(UT_BluetoothModel, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(model, nullptr);
+    EXPECT_EQ(model->getAdapters().size(), 0);
+}
+
+/**
+ * @brief Test addAdapter with new adapter
+ */
+TEST_F(UT_BluetoothModel, addAdapter_NewAdapter_AdapterAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(model, &BluetoothModel::adapterAdded);
+
+    BluetoothAdapter *adapter = new BluetoothAdapter(model);
+    adapter->setId("/org/bluez/hci0");
+
+    model->addAdapter(adapter);
+
+    EXPECT_EQ(model->getAdapters().size(), 1);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).value<const BluetoothAdapter *>(), adapter);
+}
+
+/**
+ * @brief Test addAdapter with duplicate adapter
+ */
+TEST_F(UT_BluetoothModel, addAdapter_DuplicateAdapter_DeletedAndNotAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+    model->addAdapter(adapter1);
+
+    QSignalSpy spy(model, &BluetoothModel::adapterAdded);
+
+    // Try to add another adapter with same ID
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci0");
+
+    model->addAdapter(adapter2);
+
+    // Should not add duplicate, and adapter2 should be deleted automatically
+    EXPECT_EQ(model->getAdapters().size(), 1);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test addAdapter with multiple adapters
+ */
+TEST_F(UT_BluetoothModel, addAdapter_MultipleAdapters_AllAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci1");
+
+    BluetoothAdapter *adapter3 = new BluetoothAdapter(model);
+    adapter3->setId("/org/bluez/hci2");
+
+    model->addAdapter(adapter1);
+    model->addAdapter(adapter2);
+    model->addAdapter(adapter3);
+
+    EXPECT_EQ(model->getAdapters().size(), 3);
+}
+
+/**
+ * @brief Test adapterById with existing adapter
+ */
+TEST_F(UT_BluetoothModel, adapterById_ExistingAdapter_ReturnsAdapter)
+{
+    __DBG_STUB_INVOKE__
+
+    QString adapterId = "/org/bluez/hci0";
+
+    BluetoothAdapter *adapter = new BluetoothAdapter(model);
+    adapter->setId(adapterId);
+    model->addAdapter(adapter);
+
+    const BluetoothAdapter *result = model->adapterById(adapterId);
+
+    EXPECT_NE(result, nullptr);
+    EXPECT_EQ(result, adapter);
+    EXPECT_EQ(result->getId(), adapterId);
+}
+
+/**
+ * @brief Test adapterById with non-existing adapter
+ */
+TEST_F(UT_BluetoothModel, adapterById_NonExistingAdapter_ReturnsNull)
+{
+    __DBG_STUB_INVOKE__
+
+    const BluetoothAdapter *result = model->adapterById("/org/bluez/hci_NONEXISTENT");
+
+    EXPECT_EQ(result, nullptr);
+}
+
+/**
+ * @brief Test removeAdapater with existing adapter
+ */
+TEST_F(UT_BluetoothModel, removeAdapater_ExistingAdapter_AdapterRemoved)
+{
+    __DBG_STUB_INVOKE__
+
+    QString adapterId = "/org/bluez/hci0";
+
+    BluetoothAdapter *adapter = new BluetoothAdapter(model);
+    adapter->setId(adapterId);
+    model->addAdapter(adapter);
+
+    QSignalSpy spy(model, &BluetoothModel::adapterRemoved);
+
+    const BluetoothAdapter *removed = model->removeAdapater(adapterId);
+
+    EXPECT_EQ(model->getAdapters().size(), 0);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).value<const BluetoothAdapter *>(), removed);
+    EXPECT_EQ(removed, adapter);
+
+    // Clean up removed adapter manually
+    const_cast<BluetoothAdapter *>(removed)->deleteLater();
+}
+
+/**
+ * @brief Test removeAdapater with non-existing adapter
+ */
+TEST_F(UT_BluetoothModel, removeAdapater_NonExistingAdapter_ReturnsNull)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy spy(model, &BluetoothModel::adapterRemoved);
+
+    const BluetoothAdapter *removed = model->removeAdapater("/org/bluez/hci_NONEXISTENT");
+
+    EXPECT_EQ(removed, nullptr);
+    EXPECT_EQ(model->getAdapters().size(), 0);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+/**
+ * @brief Test removeAdapater with multiple adapters
+ */
+TEST_F(UT_BluetoothModel, removeAdapater_MultipleAdapters_CorrectAdapterRemoved)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci1");
+
+    BluetoothAdapter *adapter3 = new BluetoothAdapter(model);
+    adapter3->setId("/org/bluez/hci2");
+
+    model->addAdapter(adapter1);
+    model->addAdapter(adapter2);
+    model->addAdapter(adapter3);
+
+    const BluetoothAdapter *removed = model->removeAdapater(adapter2->getId());
+
+    EXPECT_EQ(model->getAdapters().size(), 2);
+    EXPECT_NE(model->adapterById(adapter1->getId()), nullptr);
+    EXPECT_EQ(model->adapterById(adapter2->getId()), nullptr);
+    EXPECT_NE(model->adapterById(adapter3->getId()), nullptr);
+    EXPECT_EQ(removed, adapter2);
+
+    // Clean up removed adapter
+    const_cast<BluetoothAdapter *>(removed)->deleteLater();
+}
+
+/**
+ * @brief Test getAdapters returns correct map
+ */
+TEST_F(UT_BluetoothModel, getAdapters_WithAdapters_ReturnsCorrectMap)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+    adapter1->setName("Adapter 1");
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci1");
+    adapter2->setName("Adapter 2");
+
+    model->addAdapter(adapter1);
+    model->addAdapter(adapter2);
+
+    QMap<QString, const BluetoothAdapter *> adapters = model->getAdapters();
+
+    EXPECT_EQ(adapters.size(), 2);
+    EXPECT_TRUE(adapters.contains(adapter1->getId()));
+    EXPECT_TRUE(adapters.contains(adapter2->getId()));
+    EXPECT_EQ(adapters[adapter1->getId()], adapter1);
+    EXPECT_EQ(adapters[adapter2->getId()], adapter2);
+}
+
+/**
+ * @brief Test getAdapters on empty model
+ */
+TEST_F(UT_BluetoothModel, getAdapters_EmptyModel_ReturnsEmptyMap)
+{
+    __DBG_STUB_INVOKE__
+
+    QMap<QString, const BluetoothAdapter *> adapters = model->getAdapters();
+
+    EXPECT_TRUE(adapters.isEmpty());
+    EXPECT_EQ(adapters.size(), 0);
+}
+
+/**
+ * @brief Test add and remove adapter operations sequence
+ */
+TEST_F(UT_BluetoothModel, AddRemoveSequence_WorksCorrectly)
+{
+    __DBG_STUB_INVOKE__
+
+    QString adapterId = "/org/bluez/hci0";
+
+    // Add adapter
+    BluetoothAdapter *adapter = new BluetoothAdapter(model);
+    adapter->setId(adapterId);
+    model->addAdapter(adapter);
+    EXPECT_EQ(model->getAdapters().size(), 1);
+
+    // Remove adapter
+    const BluetoothAdapter *removed = model->removeAdapater(adapterId);
+    EXPECT_EQ(model->getAdapters().size(), 0);
+
+    // Add same adapter again (new instance)
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId(adapterId);
+    model->addAdapter(adapter2);
+    EXPECT_EQ(model->getAdapters().size(), 1);
+
+    // Clean up
+    const_cast<BluetoothAdapter *>(removed)->deleteLater();
+}
+
+/**
+ * @brief Test multiple signal emissions
+ */
+TEST_F(UT_BluetoothModel, MultipleOperations_MultipleSignalsEmitted)
+{
+    __DBG_STUB_INVOKE__
+
+    QSignalSpy addedSpy(model, &BluetoothModel::adapterAdded);
+    QSignalSpy removedSpy(model, &BluetoothModel::adapterRemoved);
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci1");
+
+    model->addAdapter(adapter1);
+    model->addAdapter(adapter2);
+
+    const BluetoothAdapter *removed = model->removeAdapater(adapter1->getId());
+
+    EXPECT_EQ(addedSpy.count(), 2);
+    EXPECT_EQ(removedSpy.count(), 1);
+
+    // Clean up
+    const_cast<BluetoothAdapter *>(removed)->deleteLater();
+}
+
+/**
+ * @brief Test adapter with same ID override behavior
+ */
+TEST_F(UT_BluetoothModel, addAdapter_SameIdTwice_SecondOneDeleted)
+{
+    __DBG_STUB_INVOKE__
+
+    QString adapterId = "/org/bluez/hci0";
+
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId(adapterId);
+    adapter1->setName("First Adapter");
+    model->addAdapter(adapter1);
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId(adapterId);
+    adapter2->setName("Second Adapter");
+    model->addAdapter(adapter2);   // Should be deleted automatically
+
+    // Only the first adapter should remain
+    EXPECT_EQ(model->getAdapters().size(), 1);
+    const BluetoothAdapter *result = model->adapterById(adapterId);
+    EXPECT_EQ(result->getName(), "First Adapter");
+}
+
+/**
+ * @brief Test empty adapter ID handling
+ */
+TEST_F(UT_BluetoothModel, addAdapter_EmptyId_CanBeAdded)
+{
+    __DBG_STUB_INVOKE__
+
+    BluetoothAdapter *adapter = new BluetoothAdapter(model);
+    adapter->setId("");
+
+    model->addAdapter(adapter);
+
+    // Adapter with empty ID can be added
+    EXPECT_EQ(model->getAdapters().size(), 1);
+}
+
+/**
+ * @brief Test adapterById with empty ID
+ */
+TEST_F(UT_BluetoothModel, adapterById_EmptyId_ReturnsNull)
+{
+    __DBG_STUB_INVOKE__
+
+    const BluetoothAdapter *result = model->adapterById("");
+
+    EXPECT_EQ(result, nullptr);
+}
+
+/**
+ * @brief Test complete model operations
+ */
+TEST_F(UT_BluetoothModel, CompleteOperations_AllWorkCorrectly)
+{
+    __DBG_STUB_INVOKE__
+
+    // Add adapters
+    BluetoothAdapter *adapter1 = new BluetoothAdapter(model);
+    adapter1->setId("/org/bluez/hci0");
+    adapter1->setName("Adapter 1");
+
+    BluetoothAdapter *adapter2 = new BluetoothAdapter(model);
+    adapter2->setId("/org/bluez/hci1");
+    adapter2->setName("Adapter 2");
+
+    model->addAdapter(adapter1);
+    model->addAdapter(adapter2);
+    EXPECT_EQ(model->getAdapters().size(), 2);
+
+    // Query adapter
+    const BluetoothAdapter *queried = model->adapterById("/org/bluez/hci0");
+    EXPECT_NE(queried, nullptr);
+    EXPECT_EQ(queried->getName(), "Adapter 1");
+
+    // Remove one adapter
+    const BluetoothAdapter *removed = model->removeAdapater("/org/bluez/hci1");
+    EXPECT_EQ(model->getAdapters().size(), 1);
+    EXPECT_NE(removed, nullptr);
+
+    // Verify remaining adapter
+    EXPECT_NE(model->adapterById("/org/bluez/hci0"), nullptr);
+    EXPECT_EQ(model->adapterById("/org/bluez/hci1"), nullptr);
+
+    // Clean up
+    const_cast<BluetoothAdapter *>(removed)->deleteLater();
+}

--- a/autotests/plugins/dfmplugin-utils/test_bluetoothtransdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_bluetoothtransdialog.cpp
@@ -1,0 +1,586 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothadapter.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothdevice.h"
+
+#include <dfm-base/utils/dialogmanager.h>
+
+#include <DDialog>
+#include <DLabel>
+#include <DListView>
+#include <DProgressBar>
+#include <DSpinner>
+#include <DCommandLinkButton>
+
+#include <QStackedWidget>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QSignalSpy>
+#include <QPushButton>
+
+#include <gtest/gtest.h>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_BluetoothTransDialog : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                       [](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                           __DBG_STUB_INVOKE__
+                           return QMap<QString, const BluetoothAdapter *>();
+                       });
+
+        stub.set_lamda(ADDR(BluetoothManager, refresh), [](BluetoothManager *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        // Stub QTimer
+        typedef void (*FuncType)(int, Qt::TimerType, const QObject *, QtPrivate::QSlotObjectBase *);
+        stub.set_lamda(static_cast<FuncType>(QTimer::singleShotImpl),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(&BluetoothDevice::getIcon, [] {
+            __DBG_STUB_INVOKE__
+            return "test";
+        });
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+/**
+ * @brief Test isBluetoothIdle returns manager state
+ */
+TEST_F(UT_BluetoothTransDialog, isBluetoothIdle_ManagerCanSend_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    stub.set_lamda(ADDR(BluetoothManager, canSendBluetoothRequest),
+                   [](BluetoothManager *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = BluetoothTransDialog::isBluetoothIdle();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test isBluetoothIdle when manager is busy
+ */
+TEST_F(UT_BluetoothTransDialog, isBluetoothIdle_ManagerBusy_ReturnsFalse)
+{
+    __DBG_STUB_INVOKE__
+
+    stub.set_lamda(ADDR(BluetoothManager, canSendBluetoothRequest),
+                   [](BluetoothManager *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = BluetoothTransDialog::isBluetoothIdle();
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief Test sendFilesToDevice with valid device
+ */
+TEST_F(UT_BluetoothTransDialog, sendFilesToDevice_ValidDevice_SendsFiles)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    // Create mock adapter and device
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0");
+
+    BluetoothDevice *device = new BluetoothDevice();
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    device->setAlias("My Phone");
+
+    adapter->addDevice(device);
+
+    stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                   [adapter](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                       __DBG_STUB_INVOKE__
+                       QMap<QString, const BluetoothAdapter *> adapters;
+                       adapters["/org/bluez/hci0"] = adapter;
+                       return adapters;
+                   });
+
+    bool sendFilesCalled = false;
+    stub.set_lamda(ADDR(BluetoothManager, sendFiles),
+                   [&sendFilesCalled](BluetoothManager *, const QString &,
+                                      const QStringList &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       sendFilesCalled = true;
+                   });
+
+    dialog->sendFilesToDevice("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+
+    EXPECT_EQ(dialog->selectedDeviceId, "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    EXPECT_EQ(dialog->selectedDeviceName, "My Phone");
+
+    delete dialog;
+    delete adapter;
+}
+
+/**
+ * @brief Test sendFilesToDevice with non-existing device
+ */
+TEST_F(UT_BluetoothTransDialog, sendFilesToDevice_NonExistingDevice_DoesNothing)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                   [](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                       __DBG_STUB_INVOKE__
+                       return QMap<QString, const BluetoothAdapter *>();
+                   });
+
+    bool sendFilesCalled = false;
+    stub.set_lamda(ADDR(BluetoothManager, sendFiles),
+                   [&sendFilesCalled](BluetoothManager *, const QString &,
+                                      const QStringList &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       sendFilesCalled = true;
+                   });
+
+    dialog->sendFilesToDevice("/org/bluez/hci0/dev_NONEXISTENT");
+
+    EXPECT_FALSE(sendFilesCalled);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test humanizeObexErrMsg with timeout error
+ */
+TEST_F(UT_BluetoothTransDialog, humanizeObexErrMsg_TimeoutError_ReturnsReadableMessage)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    QString result = dialog->humanizeObexErrMsg("Connection Timed out");
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_TRUE(result.contains("timed out") || result.contains("Timed out"));
+
+    delete dialog;
+}
+
+/**
+ * @brief Test humanizeObexErrMsg with service busy error
+ */
+TEST_F(UT_BluetoothTransDialog, humanizeObexErrMsg_ServiceBusy_ReturnsReadableMessage)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    QString result = dialog->humanizeObexErrMsg("Error 0x53");
+
+    EXPECT_FALSE(result.isEmpty());
+
+    delete dialog;
+}
+
+/**
+ * @brief Test humanizeObexErrMsg with connection error
+ */
+TEST_F(UT_BluetoothTransDialog, humanizeObexErrMsg_ConnectionError_ReturnsReadableMessage)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    QString result1 = dialog->humanizeObexErrMsg("device not connected");
+    QString result2 = dialog->humanizeObexErrMsg("Connection refused");
+    QString result3 = dialog->humanizeObexErrMsg("Connection reset by peer");
+
+    EXPECT_FALSE(result1.isEmpty());
+    EXPECT_FALSE(result2.isEmpty());
+    EXPECT_FALSE(result3.isEmpty());
+
+    delete dialog;
+}
+
+/**
+ * @brief Test setNextButtonEnable on selector page
+ */
+TEST_F(UT_BluetoothTransDialog, setNextButtonEnable_OnSelectorPage_EnablesButton)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    // Stub getButtons to return mock buttons
+    stub.set_lamda(ADDR(DDialog, getButtons), [dialog](DDialog *) -> QList<QAbstractButton *> {
+        __DBG_STUB_INVOKE__
+        QList<QAbstractButton *> buttons;
+        buttons << new QPushButton(dialog);
+        buttons << new QPushButton(dialog);
+        return buttons;
+    });
+
+    stub.set_lamda(ADDR(QStackedWidget, currentIndex), [](QStackedWidget *) -> int {
+        __DBG_STUB_INVOKE__
+        return 0;   // kSelectDevicePage
+    });
+
+    bool setEnabledCalled = false;
+    stub.set_lamda(ADDR(QAbstractButton, setEnabled),
+                   [&setEnabledCalled] {
+                       __DBG_STUB_INVOKE__
+                       setEnabledCalled = true;
+                   });
+
+    dialog->setNextButtonEnable(true);
+
+    EXPECT_TRUE(setEnabledCalled);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test closeEvent
+ */
+TEST_F(UT_BluetoothTransDialog, closeEvent_WithActiveTransfer_CancelsTransfer)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    // Set an active session and switch to a transfer page so the close
+    // handler actually cancels the session.
+    dialog->currSessionPath = "/session/path";
+    dialog->stackedWidget->setCurrentIndex(BluetoothTransDialog::Page::kTransferPage);
+
+    bool cancelTransferCalled = false;
+    stub.set_lamda(ADDR(BluetoothManager, cancelTransfer),
+                   [&cancelTransferCalled](BluetoothManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       cancelTransferCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(DDialog, closeEvent), [](DDialog *, QCloseEvent *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    dialog->closeEvent(nullptr);
+
+    EXPECT_TRUE(cancelTransferCalled);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test updateDeviceList with adapters and devices
+ */
+TEST_F(UT_BluetoothTransDialog, updateDeviceList_WithDevices_UpdatesModel)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    // Create mock adapter with devices
+    BluetoothAdapter *adapter = new BluetoothAdapter();
+    adapter->setId("/org/bluez/hci0");
+
+    BluetoothDevice *device1 = new BluetoothDevice();
+    device1->setId("/org/bluez/hci0/dev_11_11_11_11_11_11");
+    device1->setAlias("Device 1");
+    device1->setIcon("phone");
+    device1->setPaired(true);
+    device1->setTrusted(true);
+    device1->setState(BluetoothDevice::kStateConnected);
+
+    adapter->addDevice(device1);
+
+    stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                   [adapter](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                       __DBG_STUB_INVOKE__
+                       QMap<QString, const BluetoothAdapter *> adapters;
+                       adapters["/org/bluez/hci0"] = adapter;
+                       return adapters;
+                   });
+
+    // Stub QStandardItemModel operations
+    stub.set_lamda(qOverload<QStandardItem *>(&QStandardItemModel::appendRow),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    dialog->updateDeviceList();
+
+    // Device should be added to model
+    EXPECT_TRUE(true);
+
+    delete dialog;
+    delete adapter;
+}
+
+/**
+ * @brief Test showBluetoothSetting calls manager
+ */
+TEST_F(UT_BluetoothTransDialog, showBluetoothSetting_CallsManager)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    bool showSettingsCalled = false;
+    stub.set_lamda(ADDR(BluetoothManager, showBluetoothSettings),
+                   [&showSettingsCalled](BluetoothManager *) {
+                       __DBG_STUB_INVOKE__
+                       showSettingsCalled = true;
+                   });
+
+    dialog->showBluetoothSetting();
+
+    EXPECT_TRUE(showSettingsCalled);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test onBtnClicked with cancel button
+ */
+TEST_F(UT_BluetoothTransDialog, onBtnClicked_CancelButton_ClosesDialog)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    bool closeCalled = false;
+    stub.set_lamda(ADDR(DDialog, close), [&closeCalled] {
+        __DBG_STUB_INVOKE__
+        closeCalled = true;
+        return true;
+    });
+
+    dialog->onBtnClicked(0);   // Cancel button index
+
+    EXPECT_TRUE(closeCalled);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test onPageChagned updates title and buttons
+ */
+TEST_F(UT_BluetoothTransDialog, onPageChagned_DifferentPages_UpdatesUI)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    // Stub clearButtons and addButton
+    stub.set_lamda(ADDR(DDialog, clearButtons), [](DDialog *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(ADDR(DDialog, addButton),
+                   [](DDialog *, const QString &, bool, DDialog::ButtonType) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DLabel, setText), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    // Test page change
+    dialog->onPageChagned(0);   // kSelectDevicePage
+    dialog->onPageChagned(1);   // kNoneDevicePage
+    dialog->onPageChagned(3);   // kTransferPage
+    dialog->onPageChagned(5);   // kSuccessPage
+
+    // Should update UI without crash
+    EXPECT_TRUE(true);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test addDevice adds device to model
+ */
+TEST_F(UT_BluetoothTransDialog, addDevice_ValidDevice_AddsToModel)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    BluetoothDevice *device = new BluetoothDevice();
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+    device->setAlias("Test Device");
+    device->setIcon("phone");
+    device->setPaired(true);
+    device->setTrusted(true);
+    device->setState(BluetoothDevice::kStateConnected);
+
+    // The fixture stubs getIcon() to "test"; override it so the device
+    // passes addDevice()'s can-receive-file filter.
+    stub.set_lamda(&BluetoothDevice::getIcon, [] {
+        __DBG_STUB_INVOKE__
+        return "phone";
+    });
+
+    // QStandardItemModel::appendRow(QStandardItem*) is inline in the header
+    // and cannot be intercepted; patch the non-inline list overload the
+    // inline body forwards to.
+    bool appendRowCalled = false;
+    stub.set_lamda(qOverload<const QList<QStandardItem *> &>(&QStandardItemModel::appendRow),
+                   [&appendRowCalled] {
+                       __DBG_STUB_INVOKE__
+                       appendRowCalled = true;
+                   });
+
+    dialog->addDevice(device);
+
+    EXPECT_TRUE(appendRowCalled);
+
+    delete dialog;
+    delete device;
+}
+
+/**
+ * @brief Test removeDevice by device pointer
+ */
+TEST_F(UT_BluetoothTransDialog, removeDevice_ByPointer_RemovesFromModel)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    BluetoothDevice *device = new BluetoothDevice();
+    device->setId("/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF");
+
+    // Product reads device ids via QStandardItemModel::data(), not item();
+    // stub data() so removeDevice() finds a matching device.
+    bool removeRowCalled = false;
+    stub.set_lamda(VADDR(QStandardItemModel, rowCount),
+                   [](QStandardItemModel *, const QModelIndex &) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 1;
+                   });
+
+    stub.set_lamda(VADDR(QStandardItemModel, data),
+                   [device](QStandardItemModel *, const QModelIndex &, int) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return device->getId();
+                   });
+
+    stub.set_lamda(ADDR(QStandardItemModel, removeRow),
+                   [&removeRowCalled] {
+                       __DBG_STUB_INVOKE__
+                       removeRowCalled = true;
+                       return true;
+                   });
+
+    dialog->removeDevice(device);
+
+    // Should attempt to remove device
+    EXPECT_TRUE(removeRowCalled);
+
+    delete dialog;
+    delete device;
+}
+
+/**
+ * @brief Test removeDevice by ID
+ */
+TEST_F(UT_BluetoothTransDialog, removeDevice_ById_RemovesFromModel)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog = new BluetoothTransDialog(urls);
+
+    QString deviceId = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF";
+
+    bool removeRowCalled = false;
+    stub.set_lamda(ADDR(QStandardItemModel, removeRow),
+                   [&removeRowCalled] {
+                       __DBG_STUB_INVOKE__
+                       removeRowCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(QStandardItemModel, rowCount),
+                   [](QStandardItemModel *, const QModelIndex &) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 1;
+                   });
+
+    stub.set_lamda(ADDR(QStandardItemModel, item),
+                   [deviceId](QStandardItemModel *, int, int) -> QStandardItem * {
+                       __DBG_STUB_INVOKE__
+                       DStandardItem *item = new DStandardItem();
+                       item->setData(deviceId, Qt::UserRole + 101);
+                       return item;
+                   });
+
+    dialog->removeDevice(deviceId);
+
+    // Should attempt to remove device
+    EXPECT_TRUE(true);
+
+    delete dialog;
+}
+
+/**
+ * @brief Test dialog token generation
+ */
+TEST_F(UT_BluetoothTransDialog, Constructor_GeneratesUniqueToken)
+{
+    __DBG_STUB_INVOKE__
+
+    QStringList urls = { "/tmp/file1.txt" };
+    BluetoothTransDialog *dialog1 = new BluetoothTransDialog(urls);
+    BluetoothTransDialog *dialog2 = new BluetoothTransDialog(urls);
+
+    EXPECT_FALSE(dialog1->dialogToken.isEmpty());
+    EXPECT_FALSE(dialog2->dialogToken.isEmpty());
+    EXPECT_NE(dialog1->dialogToken, dialog2->dialogToken);
+
+    delete dialog1;
+    delete dialog2;
+}

--- a/autotests/plugins/dfmplugin-utils/test_dfmextactionimpl.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextactionimpl.cpp
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextactionimpl_p.h"
+
+#include <QAction>
+#include <QMenu>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtActionImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImpl, Constructor_WithNullAction_CreatesNewAction)
+{
+    DFMExtActionImpl *impl = new DFMExtActionImpl(nullptr);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+TEST_F(UT_DFMExtActionImpl, Constructor_WithExistingAction_UsesAction)
+{
+    QAction *action = new QAction();
+    DFMExtActionImpl *impl = new DFMExtActionImpl(action);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+// ========== DFMExtActionImplPrivate Tests ==========
+
+class UT_DFMExtActionImplPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        action = new QAction();
+        impl = new DFMExtActionImpl(nullptr);
+        d = dynamic_cast<DFMExtActionImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete action;
+        action = nullptr;
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    QAction *action { nullptr };
+    DFMExtActionImpl *impl { nullptr };
+    DFMExtActionImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImplPrivate, isInterior_ExternalAction_ReturnsFalse)
+{
+    EXPECT_FALSE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setText_SetsActionText)
+{
+    d->setText("Test Text");
+
+    std::string result = d->text();
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setToolTip_SetsActionToolTip)
+{
+    d->setToolTip("Test Tooltip");
+
+    std::string result = d->toolTip();
+    EXPECT_EQ(result, "Test Tooltip");
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setSeparator_SetsActionSeparator)
+{
+    d->setSeparator(true);
+
+    EXPECT_TRUE(d->isSeparator());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setCheckable_SetsActionCheckable)
+{
+    d->setCheckable(true);
+
+    EXPECT_TRUE(d->isCheckable());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setEnabled_SetsActionEnabled)
+{
+    d->setEnabled(false);
+
+    EXPECT_FALSE(d->isEnabled());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_ThemeName_SetsIcon)
+{
+    d->setIcon("dialog-information");
+
+    std::string result = d->icon();
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, qaction_ReturnsQAction)
+{
+    QAction *result = d->qaction();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, actionImpl_ReturnsImpl)
+{
+    DFMExtActionImpl *result = d->actionImpl();
+
+    EXPECT_EQ(result, impl);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setChecked_SetsActionChecked)
+{
+    d->setCheckable(true);
+    d->setChecked(true);
+
+    bool result = d->isChecked();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_FilePath_SetsIcon)
+{
+    d->setIcon("/usr/share/icons/default.png");
+
+    std::string result = d->icon();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setIcon_EmptyPath_SetsEmptyIcon)
+{
+    d->setIcon("");
+
+    std::string result = d->icon();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, text_WithEmptyAction_ReturnsEmpty)
+{
+    std::string result = d->text();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, setMenu_NullMenu_DoesNotCrash)
+{
+    d->setMenu(nullptr);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate, menu_NoMenu_ReturnsNull)
+{
+    DFMEXT::DFMExtMenu *result = d->menu();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+// ========== Interior Action Tests ==========
+
+class UT_DFMExtActionImplPrivate_Interior : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        action = new QAction();
+        impl = new DFMExtActionImpl(action);
+        d = dynamic_cast<DFMExtActionImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    QAction *action { nullptr };
+    DFMExtActionImpl *impl { nullptr };
+    DFMExtActionImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, isInterior_InteriorAction_ReturnsTrue)
+{
+    EXPECT_TRUE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setText_InteriorAction_DoesNotSetText)
+{
+    QString originalText = action->text();
+
+    d->setText("New Text");
+
+    EXPECT_EQ(action->text(), originalText);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setIcon_InteriorAction_DoesNotSetIcon)
+{
+    d->setIcon("dialog-information");
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setToolTip_InteriorAction_DoesNotSetToolTip)
+{
+    QString originalTip = action->toolTip();
+
+    d->setToolTip("New Tip");
+
+    EXPECT_EQ(action->toolTip(), originalTip);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setSeparator_InteriorAction_DoesNotSetSeparator)
+{
+    bool originalSeparator = action->isSeparator();
+
+    d->setSeparator(true);
+
+    EXPECT_EQ(action->isSeparator(), originalSeparator);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setCheckable_InteriorAction_DoesNotSetCheckable)
+{
+    bool originalCheckable = action->isCheckable();
+
+    d->setCheckable(true);
+
+    EXPECT_EQ(action->isCheckable(), originalCheckable);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setChecked_InteriorAction_DoesNotSetChecked)
+{
+    action->setCheckable(true);
+    bool originalChecked = action->isChecked();
+
+    d->setChecked(true);
+
+    EXPECT_EQ(action->isChecked(), originalChecked);
+}
+
+TEST_F(UT_DFMExtActionImplPrivate_Interior, setEnabled_InteriorAction_DoesNotSetEnabled)
+{
+    bool originalEnabled = action->isEnabled();
+
+    d->setEnabled(false);
+
+    EXPECT_EQ(action->isEnabled(), originalEnabled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenucache.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenucache.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenucache.h"
+
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtMenuCache : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuCache, instance_ReturnsSingleton)
+{
+    DFMExtMenuCache &instance1 = DFMExtMenuCache::instance();
+    DFMExtMenuCache &instance2 = DFMExtMenuCache::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_DFMExtMenuCache, extMenuSortRules_InitiallyEmpty)
+{
+    DFMExtMenuCache &cache = DFMExtMenuCache::instance();
+
+    cache.extMenuSortRules.clear();
+
+    EXPECT_TRUE(cache.extMenuSortRules.isEmpty());
+}
+
+TEST_F(UT_DFMExtMenuCache, extMenuSortRules_CanAddRules)
+{
+    DFMExtMenuCache &cache = DFMExtMenuCache::instance();
+    cache.extMenuSortRules.clear();
+
+    QAction action1;
+    QAction action2;
+    cache.extMenuSortRules.append(qMakePair(&action1, &action2));
+
+    EXPECT_EQ(cache.extMenuSortRules.size(), 1);
+    cache.extMenuSortRules.clear();
+}

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenuimpl.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenuimpl.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextmenuimpl_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+
+#include <QMenu>
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_DFMExtMenuImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImpl, Constructor_WithNullMenu_CreatesNewMenu)
+{
+    DFMExtMenuImpl *impl = new DFMExtMenuImpl(nullptr);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+TEST_F(UT_DFMExtMenuImpl, Constructor_WithExistingMenu_UsesMenu)
+{
+    QMenu *menu = new QMenu();
+    DFMExtMenuImpl *impl = new DFMExtMenuImpl(menu);
+
+    EXPECT_NE(impl, nullptr);
+
+    delete impl;
+}
+
+// ========== DFMExtMenuImplPrivate Tests ==========
+
+class UT_DFMExtMenuImplPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        impl = new DFMExtMenuImpl(nullptr);
+        d = dynamic_cast<DFMExtMenuImplPrivate *>(impl->d);
+    }
+
+    void TearDown() override
+    {
+        delete impl;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImpl *impl { nullptr };
+    DFMExtMenuImplPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplPrivate, isInterior_ExternalMenu_ReturnsFalse)
+{
+    EXPECT_FALSE(d->isInterior());
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, setTitle_SetsMenuTitle)
+{
+    d->setTitle("Test Title");
+
+    std::string result = d->title();
+    EXPECT_EQ(result, "Test Title");
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, setIcon_ThemeName_SetsIcon)
+{
+    d->setIcon("dialog-information");
+
+    std::string result = d->icon();
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, qmenu_ReturnsQMenu)
+{
+    QMenu *result = d->qmenu();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, menuImpl_ReturnsImpl)
+{
+    DFMExtMenuImpl *result = d->menuImpl();
+
+    EXPECT_EQ(result, impl);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, addAction_ExternalAction_ReturnsTrue)
+{
+    DFMExtActionImpl *action = new DFMExtActionImpl(nullptr);
+
+    bool result = d->addAction(action);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, addAction_NullAction_ReturnsFalse)
+{
+    bool result = d->addAction(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, menuAction_ReturnsMenuAction)
+{
+    DFMEXT::DFMExtAction *result = d->menuAction();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_DFMExtMenuImplPrivate, actions_ReturnsActionList)
+{
+    std::list<DFMEXT::DFMExtAction *> result = d->actions();
+
+    // Initially may be empty or contain menu action
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_dfmextmenuimplproxy.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_dfmextmenuimplproxy.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimplproxy.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextmenuimplproxy_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextmenuimpl.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+USING_DFMEXT_NAMESPACE
+
+class UT_DFMExtMenuImplProxy : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        proxy = new DFMExtMenuImplProxy();
+    }
+
+    void TearDown() override
+    {
+        delete proxy;
+        proxy = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImplProxy *proxy { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplProxy, Constructor_CreatesProxy)
+{
+    EXPECT_NE(proxy, nullptr);
+}
+
+// ========== DFMExtMenuImplProxyPrivate Tests ==========
+
+class UT_DFMExtMenuImplProxyPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        d = new DFMExtMenuImplProxyPrivate();
+    }
+
+    void TearDown() override
+    {
+        delete d;
+        d = nullptr;
+        stub.clear();
+    }
+
+    DFMExtMenuImplProxyPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, createMenu_ReturnsNewMenu)
+{
+    DFMExtMenu *menu = d->createMenu();
+
+    EXPECT_NE(menu, nullptr);
+
+    d->deleteMenu(menu);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteMenu_NullMenu_ReturnsTrue)
+{
+    bool result = d->deleteMenu(nullptr);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteMenu_ExternalMenu_ReturnsTrue)
+{
+    DFMExtMenu *menu = d->createMenu();
+
+    bool result = d->deleteMenu(menu);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, createAction_ReturnsNewAction)
+{
+    DFMExtAction *action = d->createAction();
+
+    EXPECT_NE(action, nullptr);
+
+    d->deleteAction(action);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteAction_NullAction_ReturnsTrue)
+{
+    bool result = d->deleteAction(nullptr);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_DFMExtMenuImplProxyPrivate, deleteAction_ExternalAction_ReturnsTrue)
+{
+    DFMExtAction *action = d->createAction();
+
+    bool result = d->deleteAction(action);
+
+    EXPECT_TRUE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionemblemmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionemblemmanager.cpp
@@ -1,0 +1,523 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QIcon>
+#include <QSignalSpy>
+#include <QThread>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+// ========== ExtensionEmblemManagerPrivate Tests ==========
+
+class UT_ExtensionEmblemManagerPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        manager = new ExtensionEmblemManager();
+        d = new ExtensionEmblemManagerPrivate(manager);
+    }
+
+    void TearDown() override
+    {
+        delete d;
+        d = nullptr;
+        delete manager;
+        manager = nullptr;
+        stub.clear();
+    }
+
+    ExtensionEmblemManager *manager { nullptr };
+    ExtensionEmblemManagerPrivate *d { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, Constructor_InitializesFields)
+{
+    EXPECT_NE(d, nullptr);
+    EXPECT_EQ(d->q_ptr, manager);
+    EXPECT_FALSE(d->readyFlag);
+    EXPECT_TRUE(d->readyLocalPaths.isEmpty());
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_AddsPath)
+{
+    QPair<QString, int> path("/test/file.txt", 0);
+
+    d->addReadyLocalPath(path);
+
+    EXPECT_TRUE(d->readyLocalPaths.contains(path));
+    EXPECT_TRUE(d->readyFlag);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_DuplicatePath_NotAdded)
+{
+    QPair<QString, int> path("/test/file.txt", 0);
+
+    d->addReadyLocalPath(path);
+    d->addReadyLocalPath(path);
+
+    EXPECT_EQ(d->readyLocalPaths.count(), 1);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, addReadyLocalPath_DifferentPaths_AllAdded)
+{
+    d->addReadyLocalPath({ "/test/file1.txt", 0 });
+    d->addReadyLocalPath({ "/test/file2.txt", 1 });
+    d->addReadyLocalPath({ "/test/file3.txt", 2 });
+
+    EXPECT_EQ(d->readyLocalPaths.count(), 3);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, clearReadyLocalPath_ClearsAll)
+{
+    d->addReadyLocalPath({ "/test/file1.txt", 0 });
+    d->addReadyLocalPath({ "/test/file2.txt", 1 });
+
+    d->clearReadyLocalPath();
+
+    EXPECT_TRUE(d->readyLocalPaths.isEmpty());
+    EXPECT_FALSE(d->readyFlag);
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_ThemeName_ReturnsThemeIcon)
+{
+    // Offscreen platform: QIcon::fromTheme finds no theme engine, so stub it
+    // to return a valid icon as a real theme would.
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(&QIcon::fromTheme), [](const QString &) -> QIcon {
+        __DBG_STUB_INVOKE__
+        QPixmap pm(16, 16);
+        pm.fill(Qt::red);
+        return QIcon(pm);
+    });
+    stub.set_lamda(static_cast<QIcon (*)(const QString &, const QIcon &)>(&QIcon::fromTheme), [](const QString &, const QIcon &) -> QIcon {
+        __DBG_STUB_INVOKE__
+        QPixmap pm(16, 16);
+        pm.fill(Qt::red);
+        return QIcon(pm);
+    });
+
+    QIcon result = d->makeIcon("dialog-information");
+
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_FilePath_ReturnsFileIcon)
+{
+    QIcon result = d->makeIcon("/nonexistent/path/icon.png");
+}
+
+TEST_F(UT_ExtensionEmblemManagerPrivate, makeIcon_EmptyPath_ReturnsEmptyIcon)
+{
+    QIcon result = d->makeIcon("");
+
+    EXPECT_TRUE(result.isNull());
+}
+
+// ========== ExtensionEmblemManager Tests ==========
+
+class UT_ExtensionEmblemManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionEmblemManager, instance_ReturnsSingleton)
+{
+    ExtensionEmblemManager &instance1 = ExtensionEmblemManager::instance();
+    ExtensionEmblemManager &instance2 = ExtensionEmblemManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionEmblemManager, initialize_RegistersMetaType)
+{
+    ExtensionEmblemManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_InvalidUrl_ReturnsFalse)
+{
+    QUrl invalidUrl;
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(invalidUrl, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_PluginsNotInitialized_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kReady;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_NoEmblemPlugin_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_TooManyEmblems_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+    for (int i = 0; i < 5; ++i)
+        emblems.append(QIcon());
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onEmblemIconChanged_UpdatesCache)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [](EventChannelManager *, const QString &, const QString &, QUrl) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant();
+                   });
+
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    QString path = "/tmp/test.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("emblem-default"), 0) };
+
+    ExtensionEmblemManager::instance().onEmblemIconChanged(path, group);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onUrlChanged_ClearsCacheAndEmitsSignal)
+{
+    QSignalSpy spy(&ExtensionEmblemManager::instance(), &ExtensionEmblemManager::requestClearCache);
+
+    bool result = ExtensionEmblemManager::instance().onUrlChanged(0, QUrl::fromLocalFile("/tmp"));
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onAllPluginsInitialized_StartsWorkerThread)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, emblemPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtEmblemIconPlugin *>();
+                   });
+
+    ExtensionEmblemManager::instance().onAllPluginsInitialized();
+}
+
+// ========== EmblemIconWorker Tests ==========
+
+class UT_EmblemIconWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new EmblemIconWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    EmblemIconWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemIconWorker, Constructor_CreatesWorker)
+{
+    EXPECT_NE(worker, nullptr);
+}
+
+TEST_F(UT_EmblemIconWorker, onClearCache_ClearsCaches)
+{
+    worker->onClearCache();
+}
+
+TEST_F(UT_EmblemIconWorker, onFetchEmblemIcons_EmptyPaths_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, emblemPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtEmblemIconPlugin *>();
+                   });
+
+    stub.set_lamda(&QThread::currentThread, []() {
+        __DBG_STUB_INVOKE__
+        return nullptr;   // Different from app thread
+    });
+
+    QList<QPair<QString, int>> emptyPaths;
+    worker->onFetchEmblemIcons(emptyPaths);
+}
+
+TEST_F(UT_EmblemIconWorker, makeCache_ReturnsValidCache)
+{
+    QString path = "/test/file.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("icon"), 0) };
+
+    auto cache = worker->makeCache(path, group);
+
+    EXPECT_TRUE(cache.contains(path));
+    EXPECT_EQ(cache.value(path), group);
+}
+
+TEST_F(UT_EmblemIconWorker, makeLayoutGroup_EmptyLayouts_ReturnsEmptyGroup)
+{
+    std::vector<DFMEXT::DFMExtEmblemIconLayout> layouts;
+    QList<QPair<QString, int>> group;
+
+    worker->makeLayoutGroup(layouts, &group);
+
+    EXPECT_TRUE(group.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_EmptyIcons_ReturnsEmptyGroup)
+{
+    std::vector<std::string> icons;
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_TRUE(group.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_WithIcons_CreatesGroup)
+{
+    std::vector<std::string> icons = { "icon1", "icon2" };
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_EQ(group.size(), 2);
+    EXPECT_EQ(group[0].first, "icon1");
+    EXPECT_EQ(group[0].second, 0);
+    EXPECT_EQ(group[1].first, "icon2");
+    EXPECT_EQ(group[1].second, 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_BothEmpty_ReturnsEmpty)
+{
+    QList<QPair<QString, int>> oldGroup;
+    QList<QPair<QString, int>> newGroup;
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_OnlyOldGroup_ReturnsOld)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup;
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_OnlyNewGroup_ReturnsNew)
+{
+    QList<QPair<QString, int>> oldGroup;
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 0) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_SamePosition_NewOverwritesOld)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 0) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].first, "new-icon");
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_EmptyCache_ReturnsGroup)
+{
+    QList<QPair<QString, int>> cache;
+    QList<QPair<QString, int>> group = { qMakePair(QString("icon"), 0) };
+
+    auto result = worker->updateLayoutGroup(cache, group);
+
+    EXPECT_EQ(result, group);
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_SameAsCache_ReturnsGroup)
+{
+    QList<QPair<QString, int>> data = { qMakePair(QString("icon"), 0) };
+
+    auto result = worker->updateLayoutGroup(data, data);
+
+    EXPECT_EQ(result, data);
+}
+
+TEST_F(UT_EmblemIconWorker, hasCachedByOtherLocationEmblem_NoCache_ReturnsFalse)
+{
+    bool result = worker->hasCachedByOtherLocationEmblem("/test/file.txt", 0);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemIconWorker, makeNormalGroup_PositionOverflow_LimitsGroup)
+{
+    std::vector<std::string> icons = { "icon1", "icon2", "icon3", "icon4", "icon5" };
+    QList<QPair<QString, int>> group;
+
+    worker->makeNormalGroup(icons, 0, &group);
+
+    EXPECT_LE(group.size(), 4);   // kMaxEmblemCount = 4
+}
+
+TEST_F(UT_EmblemIconWorker, mergeGroup_DifferentPositions_MergesBoth)
+{
+    QList<QPair<QString, int>> oldGroup = { qMakePair(QString("old-icon"), 0) };
+    QList<QPair<QString, int>> newGroup = { qMakePair(QString("new-icon"), 1) };
+    QList<QPair<QString, int>> result;
+
+    worker->mergeGroup(oldGroup, newGroup, &result);
+
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(UT_EmblemIconWorker, updateLayoutGroup_DifferentCache_ReturnsUpdatedGroup)
+{
+    QList<QPair<QString, int>> cache = { qMakePair(QString("cached"), 0) };
+    QList<QPair<QString, int>> group = { qMakePair(QString("new"), 1) };
+
+    auto result = worker->updateLayoutGroup(cache, group);
+
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(UT_EmblemIconWorker, makeLayoutGroup_WithLayouts_CreatesGroup)
+{
+    std::vector<DFMEXT::DFMExtEmblemIconLayout> layouts;
+    DFMEXT::DFMExtEmblemIconLayout layout(DFMEXT::DFMExtEmblemIconLayout::LocationType::BottomRight, "test-icon");
+    layouts.push_back(layout);
+
+    QList<QPair<QString, int>> group;
+    worker->makeLayoutGroup(layouts, &group);
+
+    EXPECT_EQ(group.size(), 1);
+    EXPECT_EQ(group[0].first, "test-icon");
+}
+
+// ========== ExtensionEmblemManager Additional Tests ==========
+
+TEST_F(UT_ExtensionEmblemManager, onFetchCustomEmblems_ValidUrlWithCache_ReturnsResult)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, exists),
+                   [](ExtensionPluginManager *, ExtensionPluginManager::ExtensionType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QList<QIcon> emblems;
+
+    bool result = ExtensionEmblemManager::instance().onFetchCustomEmblems(url, &emblems);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionEmblemManager, onEmblemIconChanged_DesktopPlugin_PushesToCanvas)
+{
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return 1;   // Valid event type
+                   });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [](EventChannelManager *, const QString &, const QString &, QUrl) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return QVariant();
+                   });
+
+    QString path = "/tmp/test.txt";
+    QList<QPair<QString, int>> group = { qMakePair(QString("emblem"), 0) };
+
+    ExtensionEmblemManager::instance().onEmblemIconChanged(path, group);
+}

--- a/autotests/plugins/dfmplugin-utils/test_extensionfilemanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionfilemanager.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/fileimpl/extensionfilemanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/utils/applaunchutils.h>
+#include <dfm-extension/file/dfmextfileplugin.h>
+
+#include <QTimer>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionFileManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionFileManager, instance_ReturnsSingleton)
+{
+    ExtensionFileManager &instance1 = ExtensionFileManager::instance();
+    ExtensionFileManager &instance2 = ExtensionFileManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionFileManager, initialize_PluginsInitialized_CallsOnAllPluginsInitialized)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionFileManager, onAllPluginsInitialized_EmptyPlugins_DoesNotAddStrategy)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+}
+
+TEST_F(UT_ExtensionFileManager, launch_EmptyContainer_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("test.desktop", QStringList() << "/tmp/test.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_MultipleFiles_ReturnsFalse)
+{
+    QStringList files;
+    files << "/tmp/file1.txt" << "/tmp/file2.txt" << "/tmp/file3.txt";
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_EmptyFileList_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("test.desktop", QStringList());
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithDesktopFile_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("/usr/share/applications/deepin-editor.desktop",
+                                                          QStringList() << "/tmp/test.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithSpecialChars_ReturnsFalse)
+{
+    QStringList files;
+    files << "/tmp/文件.txt" << "/tmp/file with spaces.txt";
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, onAllPluginsInitialized_CalledMultipleTimes_OnlyInitializesOnce)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, filePlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtFilePlugin *>();
+                   });
+
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+    ExtensionFileManager::instance().onAllPluginsInitialized();
+}
+
+TEST_F(UT_ExtensionFileManager, launch_VariousDesktopFiles_ReturnsFalse)
+{
+    QStringList files = { "/home/user/document.pdf" };
+
+    bool result1 = ExtensionFileManager::instance().launch("org.gnome.Evince.desktop", files);
+    bool result2 = ExtensionFileManager::instance().launch("libreoffice-writer.desktop", files);
+
+    EXPECT_FALSE(result1);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithAbsolutePaths_ReturnsFalse)
+{
+    QStringList files = {
+        "/home/user/Documents/test.txt",
+        "/var/log/syslog",
+        "/etc/hosts"
+    };
+
+    bool result = ExtensionFileManager::instance().launch("gedit.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithSingleFile_ReturnsFalse)
+{
+    bool result = ExtensionFileManager::instance().launch("vim.desktop",
+                                                          QStringList() << "/tmp/single.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionFileManager, launch_WithLargeFileList_ReturnsFalse)
+{
+    QStringList files;
+    for (int i = 0; i < 100; ++i) {
+        files << QString("/tmp/file%1.txt").arg(i);
+    }
+
+    bool result = ExtensionFileManager::instance().launch("test.desktop", files);
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionlibmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionlibmenuscene.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+// ========== ExtensionLibMenuSceneCreator Tests ==========
+
+class UT_ExtensionLibMenuSceneCreator : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        creator = new ExtensionLibMenuSceneCreator();
+    }
+
+    void TearDown() override
+    {
+        delete creator;
+        creator = nullptr;
+        stub.clear();
+    }
+
+    ExtensionLibMenuSceneCreator *creator { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionLibMenuSceneCreator, name_ReturnsExtensionLibMenu)
+{
+    EXPECT_EQ(ExtensionLibMenuSceneCreator::name(), "ExtensionLibMenu");
+}
+
+TEST_F(UT_ExtensionLibMenuSceneCreator, create_ReturnsNewScene)
+{
+    AbstractMenuScene *scene = creator->create();
+
+    EXPECT_NE(scene, nullptr);
+
+    delete scene;
+}
+
+// ========== ExtensionLibMenuScene Tests ==========
+
+class UT_ExtensionLibMenuScene : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        scene = new ExtensionLibMenuScene();
+    }
+
+    void TearDown() override
+    {
+        delete scene;
+        scene = nullptr;
+        stub.clear();
+    }
+
+    ExtensionLibMenuScene *scene { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionLibMenuScene, Constructor_CreatesScene)
+{
+    EXPECT_NE(scene, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, name_ReturnsExtensionLibMenu)
+{
+    EXPECT_EQ(scene->name(), "ExtensionLibMenu");
+}
+
+TEST_F(UT_ExtensionLibMenuScene, initialize_EmptyParams_ReturnsFalse)
+{
+    QVariantHash params;
+    params[MenuParamKey::kCurrentDir] = QUrl::fromLocalFile("/home");
+
+    bool result = scene->initialize(params);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, initialize_ValidParams_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kInitialized;
+                   });
+
+    QVariantHash params;
+    params.insert(MenuParamKey::kCurrentDir, QUrl::fromLocalFile("/tmp"));
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert(MenuParamKey::kIsEmptyArea, false);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, create_NullMenu_ReturnsFalse)
+{
+    bool result = scene->create(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, create_PluginsNotInitialized_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, currentState),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return ExtensionPluginManager::kReady;
+                   });
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, triggered_CallsBaseClass)
+{
+    QAction action;
+
+    bool result = scene->triggered(&action);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, scene_NullAction_ReturnsNull)
+{
+    AbstractMenuScene *result = scene->scene(nullptr);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, scene_UnknownAction_ReturnsNull)
+{
+    QAction unknownAction;
+
+    AbstractMenuScene *result = scene->scene(&unknownAction);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionLibMenuScene, updateState_NullMenu_Returns)
+{
+    scene->updateState(nullptr);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionpluginloader.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionpluginloader.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginloader.h"
+
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_ExtensionPluginLoader : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginLoader, Constructor_SetsFileName)
+{
+    ExtensionPluginLoader loader("/path/to/plugin.so");
+
+    EXPECT_EQ(loader.fileName(), "/path/to/plugin.so");
+}
+
+TEST_F(UT_ExtensionPluginLoader, fileName_ReturnsLoaderFileName)
+{
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    QString result = loader.fileName();
+
+    EXPECT_EQ(result, "/test/plugin.so");
+}
+
+TEST_F(UT_ExtensionPluginLoader, lastError_InitiallyEmpty)
+{
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    QString result = loader.lastError();
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_EmptyFileName_ReturnsFalse)
+{
+    ExtensionPluginLoader loader("");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(loader.lastError().isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_LoadFailed_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QLibrary, errorString),
+                   [](QLibrary *) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "Load error";
+                   });
+
+    ExtensionPluginLoader loader("/nonexistent/plugin.so");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, loadPlugin_LoadSuccess_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.loadPlugin();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, initialize_NotLoaded_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.initialize();
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(loader.lastError().isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginLoader, initialize_ResolveFailed_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(static_cast<QFunctionPointer (QLibrary::*)(const char *)>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.initialize();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveMenuPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtMenuPlugin *result = loader.resolveMenuPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveEmblemPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtEmblemIconPlugin *result = loader.resolveEmblemPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveWindowPlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtWindowPlugin *result = loader.resolveWindowPlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, resolveFilePlugin_NotLoaded_ReturnsNull)
+{
+    stub.set_lamda(ADDR(QLibrary, isLoaded),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    DFMEXT::DFMExtFilePlugin *result = loader.resolveFilePlugin();
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginLoader, shutdown_ResolveFailed_ReturnsFalse)
+{
+    stub.set_lamda(static_cast<QFunctionPointer (QLibrary::*)(const char *)>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginLoader loader("/test/plugin.so");
+
+    bool result = loader.shutdown();
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionpluginmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionpluginmanager.cpp
@@ -1,0 +1,364 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager_p.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginloader.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <QSignalSpy>
+#include <QThread>
+#include <QCoreApplication>
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionPluginManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginManager, instance_ReturnsSingleton)
+{
+    ExtensionPluginManager &instance1 = ExtensionPluginManager::instance();
+    ExtensionPluginManager &instance2 = ExtensionPluginManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionPluginManager, currentState_ReturnsValidState)
+{
+    ExtensionPluginManager::InitState state = ExtensionPluginManager::instance().currentState();
+
+    EXPECT_TRUE(state == ExtensionPluginManager::kReady ||
+                state == ExtensionPluginManager::kScanned ||
+                state == ExtensionPluginManager::kLoaded ||
+                state == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManager, initialized_ReturnsCorrectState)
+{
+    bool result = ExtensionPluginManager::instance().initialized();
+    ExtensionPluginManager::InitState state = ExtensionPluginManager::instance().currentState();
+
+    EXPECT_EQ(result, state == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_Menu_ReturnsCorrectValue)
+{
+    bool result = ExtensionPluginManager::instance().exists(ExtensionPluginManager::kMenu);
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_EmblemIcon_ReturnsCorrectValue)
+{
+    bool result = ExtensionPluginManager::instance().exists(ExtensionPluginManager::kEmblemIcon);
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, exists_InvalidType_ReturnsFalse)
+{
+    bool result = ExtensionPluginManager::instance().exists(static_cast<ExtensionPluginManager::ExtensionType>(99));
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ExtensionPluginManager, menuPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtMenuPlugin *> result = ExtensionPluginManager::instance().menuPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, emblemPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtEmblemIconPlugin *> result = ExtensionPluginManager::instance().emblemPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, windowPlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtWindowPlugin *> result = ExtensionPluginManager::instance().windowPlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, filePlugins_ReturnsPluginList)
+{
+    QList<DFMEXT::DFMExtFilePlugin *> result = ExtensionPluginManager::instance().filePlugins();
+    Q_UNUSED(result)
+}
+
+TEST_F(UT_ExtensionPluginManager, pluginMenuProxy_ReturnsNonNull)
+{
+    DFMEXT::DFMExtMenuProxy *result = ExtensionPluginManager::instance().pluginMenuProxy();
+
+    EXPECT_NE(result, nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManager, onLoadingPlugins_CalledOnce)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManagerPrivate, startInitializePlugins),
+                   [](ExtensionPluginManagerPrivate *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    ExtensionPluginManager::instance().onLoadingPlugins();
+}
+
+// ========== ExtensionPluginManagerPrivate Tests ==========
+
+class UT_ExtensionPluginManagerPrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginManagerPrivate, startMonitorPlugins_NotDesktop_DoesNothing)
+{
+    stub.set_lamda(&QCoreApplication::applicationName,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString("dde-file-manager");
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->startMonitorPlugins();
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, restartDesktop_NonSoFile_ReturnsEarly)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->restartDesktop(QUrl::fromLocalFile("/tmp/test.txt"));
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, release_CalledMultipleTimes_SafelyHandled)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->release();
+    d->release();
+}
+
+// ========== ExtensionPluginInitWorker Tests ==========
+
+class UT_ExtensionPluginInitWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new ExtensionPluginInitWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    ExtensionPluginInitWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_EmptyPaths_EmitsSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+    QSignalSpy loadSpy(worker, &ExtensionPluginInitWorker::loadPluginsFinished);
+    QSignalSpy initSpy(worker, &ExtensionPluginInitWorker::initPluginsFinished);
+
+    worker->doWork(QStringList());
+
+    EXPECT_EQ(scanSpy.count(), 1);
+    EXPECT_EQ(loadSpy.count(), 1);
+    EXPECT_EQ(initSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_NonExistentPath_EmitsSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+
+    worker->doWork({ "/nonexistent/path" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_MultiplePaths_EmitsAllSignals)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+    QSignalSpy loadSpy(worker, &ExtensionPluginInitWorker::loadPluginsFinished);
+    QSignalSpy initSpy(worker, &ExtensionPluginInitWorker::initPluginsFinished);
+
+    worker->doWork({ "/nonexistent/path1", "/nonexistent/path2" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+    EXPECT_EQ(loadSpy.count(), 1);
+    EXPECT_EQ(initSpy.count(), 1);
+}
+
+TEST_F(UT_ExtensionPluginInitWorker, doWork_TmpPath_ScansDirectory)
+{
+    QSignalSpy scanSpy(worker, &ExtensionPluginInitWorker::scanPluginsFinished);
+
+    worker->doWork({ "/tmp" });
+
+    EXPECT_EQ(scanSpy.count(), 1);
+}
+
+// ========== ExtensionPluginManagerPrivate Additional Tests ==========
+
+TEST_F(UT_ExtensionPluginManagerPrivate, startMonitorPlugins_IsDesktop_CreatesWatcher)
+{
+    stub.set_lamda(&QCoreApplication::applicationName,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString("dde-desktop");
+                   });
+
+    stub.set_lamda(&WatcherFactory::create<AbstractFileWatcher>,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->startMonitorPlugins();
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, restartDesktop_SoFile_CallsUpgrade)
+{
+    stub.set_lamda(&QLibrary::load,
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    d->restartDesktop(QUrl::fromLocalFile("/tmp/test.so"));
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, curState_InitialValue_IsReady)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_TRUE(d->curState == ExtensionPluginManager::kReady ||
+                d->curState == ExtensionPluginManager::kScanned ||
+                d->curState == ExtensionPluginManager::kLoaded ||
+                d->curState == ExtensionPluginManager::kInitialized);
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, defaultPluginPath_IsNotEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_FALSE(d->defaultPluginPath.isEmpty());
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, proxy_IsNotNull)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    EXPECT_NE(d->proxy.data(), nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, menuMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->menuMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, emblemMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->emblemMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, windowMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->windowMap.isEmpty())
+}
+
+TEST_F(UT_ExtensionPluginManagerPrivate, fileMap_InitiallyEmpty)
+{
+    ExtensionPluginManager &manager = ExtensionPluginManager::instance();
+    ExtensionPluginManagerPrivate *d = reinterpret_cast<ExtensionPluginManagerPrivate *>(
+            *reinterpret_cast<void **>(reinterpret_cast<char *>(&manager) + sizeof(QObject)));
+
+    Q_UNUSED(d->fileMap.isEmpty())
+}
+
+// ========== ExtensionPluginManager Additional Tests ==========
+
+TEST_F(UT_ExtensionPluginManager, constructor_InitializesPrivate)
+{
+    EXPECT_NE(&ExtensionPluginManager::instance(), nullptr);
+}
+
+TEST_F(UT_ExtensionPluginManager, onLoadingPlugins_SecondCall_DoesNotReinitialize)
+{
+    bool initCalled = false;
+    stub.set_lamda(ADDR(ExtensionPluginManagerPrivate, startInitializePlugins),
+                   [&initCalled](ExtensionPluginManagerPrivate *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    ExtensionPluginManager::instance().onLoadingPlugins();
+    initCalled = false;
+    ExtensionPluginManager::instance().onLoadingPlugins();
+
+    EXPECT_FALSE(initCalled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_extensionwindowsmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_extensionwindowsmanager.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/windowimpl/extensionwindowsmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-extension/window/dfmextwindowplugin.h>
+
+#include <QUrl>
+#include <QTimer>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ExtensionWindowsManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ExtensionWindowsManager, instance_ReturnsSingleton)
+{
+    ExtensionWindowsManager &instance1 = ExtensionWindowsManager::instance();
+    ExtensionWindowsManager &instance2 = ExtensionWindowsManager::instance();
+
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(UT_ExtensionWindowsManager, initialize_ConnectsSignals)
+{
+    ExtensionWindowsManager::instance().initialize();
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowOpened_PluginsInitialized_CallsHandleWindow)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onWindowOpened(100);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowClosed_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onWindowClosed_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onLastWindowClosed_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onLastWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onLastWindowClosed_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onLastWindowClosed(1);
+}
+
+TEST_F(UT_ExtensionWindowsManager, onCurrentUrlChanged_PluginsNotInitialized_ReturnsEarly)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    ExtensionWindowsManager::instance().onCurrentUrlChanged(1, QUrl::fromLocalFile("/tmp"));
+}
+
+TEST_F(UT_ExtensionWindowsManager, onCurrentUrlChanged_PluginsInitialized_CallsPlugins)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onCurrentUrlChanged(1, QUrl::fromLocalFile("/home"));
+}
+
+TEST_F(UT_ExtensionWindowsManager, onAllPluginsInitialized_FirstWinIdZero_DoesNothing)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, initialized),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionPluginManager, windowPlugins),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QList<DFMEXT::DFMExtWindowPlugin *>();
+                   });
+
+    ExtensionWindowsManager::instance().onAllPluginsInitialized();
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_fileshredworker.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_fileshredworker.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/fileshredworker.h"
+
+#include <QSignalSpy>
+#include <QProcess>
+#include <QDir>
+#include <QFile>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_FileShredWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new FileShredWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    FileShredWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_FileShredWorker, Constructor_InitializesMembers)
+{
+    EXPECT_NE(worker, nullptr);
+}
+
+TEST_F(UT_FileShredWorker, stop_SetsShouldStopFlag)
+{
+    worker->stop();
+}
+
+TEST_F(UT_FileShredWorker, shredFile_EmptyList_EmitsFinished)
+{
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+    QSignalSpy progressSpy(worker, &FileShredWorker::progressUpdated);
+
+    worker->shredFile(QList<QUrl>());
+
+    EXPECT_GE(progressSpy.count(), 1);
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_TRUE(args.at(0).toBool());
+    }
+}
+
+TEST_F(UT_FileShredWorker, shredFile_StopRequested_EmitsCancelled)
+{
+    worker->stop();
+
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/test.txt") });
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_FALSE(args.at(0).toBool());
+    }
+}
+
+TEST_F(UT_FileShredWorker, shredFile_SymLink_RemovesFile)
+{
+    bool removeCalled = false;
+
+    stub.set_lamda(static_cast<bool (*)(const QString &)>(&QFile::remove),
+                   [&removeCalled](const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       removeCalled = true;
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(QFileInfo, isSymLink),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/symlink") });
+
+    EXPECT_TRUE(removeCalled);
+}
+
+TEST_F(UT_FileShredWorker, shredFile_ProcessStartFailed_EmitsFailure)
+{
+    stub.set_lamda(ADDR(QFileInfo, isSymLink),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QFileInfo, isDir),
+                   [](QFileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(QProcess, waitForStarted),
+                   [](QProcess *, int) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QSignalSpy finishedSpy(worker, &FileShredWorker::finished);
+
+    worker->shredFile({ QUrl::fromLocalFile("/tmp/test.txt") });
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    if (finishedSpy.count() > 0) {
+        QList<QVariant> args = finishedSpy.takeFirst();
+        EXPECT_FALSE(args.at(0).toBool());
+    }
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <QProcess>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_GlobalEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new GlobalEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    GlobalEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+// ========== initEventConnect 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, initEventConnect_SubscribesEvent)
+{
+    bool subscribed = false;
+
+    typedef bool (EventDispatcherManager::*Subscribe)(EventType, GlobalEventReceiver *, decltype(&GlobalEventReceiver::handleOpenAsAdmin));
+    auto subscribe = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe,
+                   [&subscribed] {
+                       __DBG_STUB_INVOKE__
+                       subscribed = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(subscribed);
+}
+
+// ========== handleOpenAsAdmin 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_InvalidUrl_ReturnsEarly)
+{
+    bool processStarted = false;
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(QUrl());
+    EXPECT_FALSE(processStarted);
+
+    receiver->handleOpenAsAdmin(QUrl(""));
+    EXPECT_FALSE(processStarted);
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_ValidLocalFile_StartsProcess)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    QString capturedPath;
+    bool processStarted = false;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted, &capturedPath](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return program == "dde-file-manager-pkexec";
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+    EXPECT_EQ(capturedPath, url.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_DirSymlink_UsesRedirectedPath)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/symlink_dir");
+    QUrl redirectedUrl = QUrl::fromLocalFile("/tmp/real_dir");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir || type == OptInfoType::kIsSymLink;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf),
+                   [&redirectedUrl](FileInfo *, const UrlInfoType) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return redirectedUrl;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, redirectedUrl.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NonLocalUrl_UsesUrlString)
+{
+    QUrl url("smb://server/share");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, url.toString());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NullFileInfo_ContinuesExecution)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    bool processStarted = false;
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QCheckBox>
+#include <QMouseEvent>
+#include <QKeyEvent>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QString();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                       [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                           __DBG_STUB_INVOKE__
+                           return nullptr;
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialog, Constructor_WithUrlList_CreatesDialog)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, Constructor_WithSingleUrl_CreatesDialog)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    OpenWithDialog *dialog = new OpenWithDialog(url);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, openFileByApp_NoCheckedItem_Returns)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    dialog->openFileByApp();
+
+    delete dialog;
+}
+
+// ========== OpenWithDialogListItem 测试 ==========
+
+class UT_OpenWithDialogListItem : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialogListItem, Constructor_CreatesItem)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, setChecked_UpdatesCheckState)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    item->setChecked(true);
+    item->setChecked(false);
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, text_ReturnsLabelText)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "My Application");
+
+    EXPECT_EQ(item->text(), "My Application");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, Constructor_EmptyIconName_UsesDefaultIcon)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("", "Test App");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, initUiForSizeMode_SetsSize)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test");
+
+    item->initUiForSizeMode();
+
+    EXPECT_EQ(item->width(), 220);
+
+    delete item;
+}
+
+// ========== OpenWithDialog Additional Tests ==========
+
+TEST_F(UT_OpenWithDialog, Constructor_EmptyUrlList_CreatesDialog)
+{
+    QList<QUrl> urls;
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, checkItem_SetsCheckedItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test App", dialog);
+
+    dialog->checkItem(item);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, checkItem_UnchecksOldItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item1 = new OpenWithDialogListItem("icon", "App1", dialog);
+    OpenWithDialogListItem *item2 = new OpenWithDialogListItem("icon", "App2", dialog);
+
+    dialog->checkItem(item1);
+    dialog->checkItem(item2);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, createItem_ReturnsValidItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = dialog->createItem("icon", "Test App", "/usr/share/applications/test.desktop");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+    EXPECT_EQ(item->property("app").toString(), "/usr/share/applications/test.desktop");
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, eventFilter_MouseButtonPress_ChecksItem)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "Test App", dialog);
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    bool result = dialog->eventFilter(item, &event);
+
+    EXPECT_TRUE(result);
+
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, eventFilter_OtherEvent_ReturnsFalse)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier);
+    bool result = dialog->eventFilter(dialog, &event);
+
+    EXPECT_FALSE(result);
+
+    delete dialog;
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/dpf.h>
+
+#include <QApplication>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new OpenWithEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    OpenWithEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithEventReceiver, initEventConnect_ConnectsSlot)
+{
+    bool connected = false;
+
+    typedef bool (EventChannelManager::*Connect)(const QString &, const QString &, OpenWithEventReceiver *, decltype(&OpenWithEventReceiver::showOpenWithDialog));
+    stub.set_lamda(static_cast<Connect>(&EventChannelManager::connect),
+                   [&connected] {
+                       __DBG_STUB_INVOKE__
+                       connected = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(connected);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithValidWinId_FindsWindow)
+{
+    quint64 winId = 12345;
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    FileManagerWindow mockWindow(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(ADDR(FileManagerWindowsManager, findWindowById),
+                   [&mockWindow] {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(winId, urls);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithZeroWinId_NoParent)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(0, urls);
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithHelper : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithHelper, Constructor_CreatesObject)
+{
+    OpenWithHelper *helper = new OpenWithHelper();
+    EXPECT_NE(helper, nullptr);
+    delete helper;
+}
+
+TEST_F(UT_OpenWithHelper, Constructor_WithParent_CreatesObject)
+{
+    QObject parent;
+    OpenWithHelper *helper = new OpenWithHelper(&parent);
+    EXPECT_NE(helper, nullptr);
+    EXPECT_EQ(helper->parent(), &parent);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_InvalidUrl_ReturnsNull)
+{
+    QUrl invalidUrl;
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(invalidUrl);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_NullFileInfo_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_IsDirectory_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/testdir");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_HookDisabled_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = true;
+                       return true;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_ValidFile_ReturnsWidget)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = false;
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(OpenWithWidget, selectFileUrl),
+                   [](OpenWithWidget *, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_NE(result, nullptr);
+    if (result)
+        delete result;
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+
+#include <DRadioButton>
+#include <QListWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_OpenWithWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithWidget, Constructor_CreatesWidget)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    EXPECT_NE(widget, nullptr);
+    EXPECT_NE(widget->openWithListWidget, nullptr);
+    EXPECT_NE(widget->openWithBtnGroup, nullptr);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, selectFileUrl_SetsCurrentUrl)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    widget->selectFileUrl(url);
+
+    EXPECT_EQ(widget->currentFileUrl, url);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_FalseState_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(false);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_InvalidUrl_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_NullFileInfo_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    widget->currentFileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_ValidUrl_LoadsApps)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    widget->currentFileUrl = url;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, fileMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QMimeType();
+                   });
+
+    stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString();
+                   });
+
+    stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QStringList();
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_WithButton_SetsDefault)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    Dtk::Widget::DRadioButton btn;
+    btn.setProperty("mimeTypeName", "text/plain");
+    btn.setProperty("appPath", "/usr/share/applications/test.desktop");
+
+    widget->openWithBtnChecked(&btn);
+
+    EXPECT_TRUE(setDefaultCalled);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_NullButton_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    widget->openWithBtnChecked(nullptr);
+
+    EXPECT_FALSE(setDefaultCalled);
+
+    delete widget;
+}

--- a/autotests/plugins/dfmplugin-utils/test_progressdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_progressdialog.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/progressdialog.h"
+
+#include <DWaterProgress>
+#include <DLabel>
+
+#include <QKeyEvent>
+#include <QStackedWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DWIDGET_USE_NAMESPACE
+
+// ========== ProgressWidget Tests ==========
+
+class UT_ProgressWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        widget = new ProgressWidget();
+    }
+
+    void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+    ProgressWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProgressWidget, Constructor_InitializesWidget)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_ProgressWidget, setValue_UpdatesProgress)
+{
+    bool startCalled = false;
+
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [&startCalled](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                       startCalled = true;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    widget->setValue(50, "test.txt");
+
+    EXPECT_TRUE(startCalled);
+}
+
+TEST_F(UT_ProgressWidget, setValue_At100_ShowsMessage)
+{
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    widget->setValue(100, "Complete");
+}
+
+TEST_F(UT_ProgressWidget, stopProgress_StopsWaterProgress)
+{
+    bool stopCalled = false;
+
+    stub.set_lamda(ADDR(DWaterProgress, stop),
+                   [&stopCalled](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                       stopCalled = true;
+                   });
+
+    widget->stopProgress();
+
+    EXPECT_TRUE(stopCalled);
+}
+
+// ========== ShredFailedWidget Tests ==========
+
+class UT_ShredFailedWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        widget = new ShredFailedWidget();
+    }
+
+    void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+    ShredFailedWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredFailedWidget, Constructor_InitializesWidget)
+{
+    EXPECT_NE(widget, nullptr);
+}
+
+TEST_F(UT_ShredFailedWidget, setMessage_ShortMessage_ShowsFull)
+{
+    widget->setMessage("Short error");
+}
+
+TEST_F(UT_ShredFailedWidget, setMessage_LongMessage_Truncates)
+{
+    QString longMessage = QString("A").repeated(100);
+    widget->setMessage(longMessage);
+}
+
+// ========== ProgressDialog Tests ==========
+
+class UT_ProgressDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dialog = new ProgressDialog();
+    }
+
+    void TearDown() override
+    {
+        delete dialog;
+        dialog = nullptr;
+        stub.clear();
+    }
+
+    ProgressDialog *dialog { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProgressDialog, Constructor_InitializesDialog)
+{
+    EXPECT_NE(dialog, nullptr);
+}
+
+TEST_F(UT_ProgressDialog, updateProgressValue_ValidValue_UpdatesProgress)
+{
+    stub.set_lamda(ADDR(DWaterProgress, start),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, value),
+                   [](DWaterProgress *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    stub.set_lamda(ADDR(DWaterProgress, setValue),
+                   [](DWaterProgress *, int) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    dialog->updateProgressValue(50, "test.txt");
+}
+
+TEST_F(UT_ProgressDialog, updateProgressValue_InvalidValue_Ignores)
+{
+    dialog->updateProgressValue(-1, "test.txt");
+    dialog->updateProgressValue(150, "test.txt");
+}
+
+TEST_F(UT_ProgressDialog, handleShredResult_Failure_ShowsFailedWidget)
+{
+    stub.set_lamda(ADDR(DWaterProgress, stop),
+                   [](DWaterProgress *) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    dialog->handleShredResult(false, "Error message");
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_reportdatas.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportdatas.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/appstartupreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/blockmountreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/desktopstartupreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/enterdirreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/filemenureportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/searchreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/sidebarreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/smbreportdata.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/vaultreportdata.h"
+
+#include <QDateTime>
+#include <QJsonObject>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+// ========== AppStartupReportData 测试 ==========
+
+class UT_AppStartupReportData : public testing::Test
+{
+protected:
+    AppStartupReportData data;
+};
+
+TEST_F(UT_AppStartupReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "AppStartup");
+}
+
+TEST_F(UT_AppStartupReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("testKey", "testValue");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500006);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("testKey").toString(), "testValue");
+}
+
+// ========== BlockMountReportData 测试 ==========
+
+class UT_BlockMountReportData : public testing::Test
+{
+protected:
+    BlockMountReportData data;
+};
+
+TEST_F(UT_BlockMountReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "BlockMount");
+}
+
+TEST_F(UT_BlockMountReportData, prepareData_ContainsTidAndOpTime)
+{
+    QVariantMap args;
+    args.insert("device", "/dev/sda1");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500004);
+    EXPECT_TRUE(result.contains("opTime"));
+    EXPECT_EQ(result.value("device").toString(), "/dev/sda1");
+}
+
+// ========== DesktopStartUpReportData 测试 ==========
+
+class UT_DesktopStartUpReportData : public testing::Test
+{
+protected:
+    DesktopStartUpReportData data;
+};
+
+TEST_F(UT_DesktopStartUpReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "DesktopStartup");
+}
+
+TEST_F(UT_DesktopStartUpReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500008);
+    EXPECT_TRUE(result.contains("sysTime"));
+}
+
+// ========== EnterDirReportData 测试 ==========
+
+class UT_EnterDirReportData : public testing::Test
+{
+protected:
+    EnterDirReportData data;
+};
+
+TEST_F(UT_EnterDirReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "EnterDirectory");
+}
+
+TEST_F(UT_EnterDirReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("path", "/home/user");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500007);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("path").toString(), "/home/user");
+}
+
+// ========== FileMenuReportData 测试 ==========
+
+class UT_FileMenuReportData : public testing::Test
+{
+protected:
+    FileMenuReportData data;
+};
+
+TEST_F(UT_FileMenuReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "FileMenu");
+}
+
+TEST_F(UT_FileMenuReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("action", "copy");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500005);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("action").toString(), "copy");
+}
+
+// ========== SearchReportData 测试 ==========
+
+class UT_SearchReportData : public testing::Test
+{
+protected:
+    SearchReportData data;
+};
+
+TEST_F(UT_SearchReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Search");
+}
+
+TEST_F(UT_SearchReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("keyword", "test");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500002);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("keyword").toString(), "test");
+}
+
+// ========== SidebarReportData 测试 ==========
+
+class UT_SidebarReportData : public testing::Test
+{
+protected:
+    SidebarReportData data;
+};
+
+TEST_F(UT_SidebarReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Sidebar");
+}
+
+TEST_F(UT_SidebarReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("item", "bookmark");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500003);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("item").toString(), "bookmark");
+}
+
+// ========== SmbReportData 测试 ==========
+
+class UT_SmbReportData : public testing::Test
+{
+protected:
+    SmbReportData data;
+};
+
+TEST_F(UT_SmbReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Smb");
+}
+
+TEST_F(UT_SmbReportData, prepareData_SuccessResult_ClearsErrorFields)
+{
+    QVariantMap args;
+    args.insert("result", true);
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500001);
+    EXPECT_TRUE(result.contains("resultTime"));
+    EXPECT_EQ(result.value("errorId").toInt(), 0);
+    EXPECT_EQ(result.value("errorSysMsg").toString(), "");
+    EXPECT_EQ(result.value("errorUiMsg").toString(), "");
+}
+
+TEST_F(UT_SmbReportData, prepareData_FailedResult_KeepsErrorFields)
+{
+    QVariantMap args;
+    args.insert("result", false);
+    args.insert("errorId", 100);
+    args.insert("errorSysMsg", "connection failed");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500001);
+    EXPECT_TRUE(result.contains("resultTime"));
+    EXPECT_EQ(result.value("errorId").toInt(), 100);
+    EXPECT_EQ(result.value("errorSysMsg").toString(), "connection failed");
+}
+
+// ========== VaultReportData 测试 ==========
+
+class UT_VaultReportData : public testing::Test
+{
+protected:
+    VaultReportData data;
+};
+
+TEST_F(UT_VaultReportData, type_ReturnsCorrectType)
+{
+    EXPECT_EQ(data.type(), "Vault");
+}
+
+TEST_F(UT_VaultReportData, prepareData_ContainsTidAndSysTime)
+{
+    QVariantMap args;
+    args.insert("operation", "unlock");
+
+    QJsonObject result = data.prepareData(args);
+
+    EXPECT_EQ(result.value("tid").toInt(), 1000500000);
+    EXPECT_TRUE(result.contains("sysTime"));
+    EXPECT_EQ(result.value("operation").toString(), "unlock");
+}

--- a/autotests/plugins/dfmplugin-utils/test_reportlogeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogeventreceiver.cpp
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
+
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_ReportLogEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new ReportLogEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    ReportLogEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogEventReceiver, Constructor_CreatesObject)
+{
+    EXPECT_NE(receiver, nullptr);
+}
+
+TEST_F(UT_ReportLogEventReceiver, Constructor_WithParent_CreatesObject)
+{
+    QObject parent;
+    ReportLogEventReceiver *recv = new ReportLogEventReceiver(&parent);
+
+    EXPECT_NE(recv, nullptr);
+    EXPECT_EQ(recv->parent(), &parent);
+}
+
+TEST_F(UT_ReportLogEventReceiver, commit_CallsManager)
+{
+    bool managerCalled = false;
+    QString capturedType;
+
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [&managerCalled, &capturedType](ReportLogManager *, const QString &type, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                       capturedType = type;
+                   });
+
+    receiver->commit("TestType", QVariantMap());
+
+    EXPECT_TRUE(managerCalled);
+    EXPECT_EQ(capturedType, "TestType");
+}
+
+TEST_F(UT_ReportLogEventReceiver, commit_WithArgs_PassesArgs)
+{
+    QVariantMap capturedArgs;
+
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [&capturedArgs](ReportLogManager *, const QString &, const QVariantMap &args) {
+                       __DBG_STUB_INVOKE__
+                       capturedArgs = args;
+                   });
+
+    QVariantMap testArgs;
+    testArgs["key1"] = "value1";
+    testArgs["key2"] = 123;
+
+    receiver->commit("TestType", testArgs);
+
+    EXPECT_EQ(capturedArgs["key1"].toString(), "value1");
+    EXPECT_EQ(capturedArgs["key2"].toInt(), 123);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMenuData_CallsManager)
+{
+    bool managerCalled = false;
+    QString capturedName;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportMenuData),
+                   [&managerCalled, &capturedName](ReportLogManager *, const QString &name, const QList<QUrl> &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                       capturedName = name;
+                   });
+
+    receiver->handleMenuData("TestMenu", QList<QUrl>());
+
+    EXPECT_TRUE(managerCalled);
+    EXPECT_EQ(capturedName, "TestMenu");
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMenuData_WithUrls_PassesUrls)
+{
+    QList<QUrl> capturedUrls;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportMenuData),
+                   [&capturedUrls](ReportLogManager *, const QString &, const QList<QUrl> &urls) {
+                       __DBG_STUB_INVOKE__
+                       capturedUrls = urls;
+                   });
+
+    QList<QUrl> testUrls;
+    testUrls << QUrl::fromLocalFile("/tmp/file1.txt");
+    testUrls << QUrl::fromLocalFile("/tmp/file2.txt");
+
+    receiver->handleMenuData("TestMenu", testUrls);
+
+    EXPECT_EQ(capturedUrls.size(), 2);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleBlockMountData_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportBlockMountData),
+                   [&managerCalled](ReportLogManager *, const QString &, bool) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleBlockMountData("/dev/sda1", true);
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleBlockMountData_PassesCorrectParams)
+{
+    QString capturedId;
+    bool capturedResult = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportBlockMountData),
+                   [&capturedId, &capturedResult](ReportLogManager *, const QString &id, bool result) {
+                       __DBG_STUB_INVOKE__
+                       capturedId = id;
+                       capturedResult = result;
+                   });
+
+    receiver->handleBlockMountData("/dev/sdb1", false);
+
+    EXPECT_EQ(capturedId, "/dev/sdb1");
+    EXPECT_FALSE(capturedResult);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMountNetworkResult_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportNetworkMountData),
+                   [&managerCalled](ReportLogManager *, bool, dfmmount::DeviceError, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleMountNetworkResult("smb://server", true, dfmmount::DeviceError::kNoError, "");
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleMountNetworkResult_PassesCorrectParams)
+{
+    bool capturedRet = false;
+    dfmmount::DeviceError capturedErr;
+    QString capturedMsg;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportNetworkMountData),
+                   [&capturedRet, &capturedErr, &capturedMsg](ReportLogManager *, bool ret, dfmmount::DeviceError err, const QString &msg) {
+                       __DBG_STUB_INVOKE__
+                       capturedRet = ret;
+                       capturedErr = err;
+                       capturedMsg = msg;
+                   });
+
+    receiver->handleMountNetworkResult("smb://server", false, dfmmount::DeviceError::kUserErrorFailed, "Connection failed");
+
+    EXPECT_FALSE(capturedRet);
+    EXPECT_EQ(capturedErr, dfmmount::DeviceError::kUserErrorFailed);
+    EXPECT_EQ(capturedMsg, "Connection failed");
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleDesktopStartupData_CallsManager)
+{
+    bool managerCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportDesktopStartUp),
+                   [&managerCalled](ReportLogManager *, const QString &, const QVariant &) {
+                       __DBG_STUB_INVOKE__
+                       managerCalled = true;
+                   });
+
+    receiver->handleDesktopStartupData("testKey", QVariant("testData"));
+
+    EXPECT_TRUE(managerCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, handleDesktopStartupData_PassesCorrectParams)
+{
+    QString capturedKey;
+    QVariant capturedData;
+
+    stub.set_lamda(ADDR(ReportLogManager, reportDesktopStartUp),
+                   [&capturedKey, &capturedData](ReportLogManager *, const QString &key, const QVariant &data) {
+                       __DBG_STUB_INVOKE__
+                       capturedKey = key;
+                       capturedData = data;
+                   });
+
+    receiver->handleDesktopStartupData("loadTime", QVariant(1500));
+
+    EXPECT_EQ(capturedKey, "loadTime");
+    EXPECT_EQ(capturedData.toInt(), 1500);
+}
+
+TEST_F(UT_ReportLogEventReceiver, bindEvents_ConnectsSignals)
+{
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->bindEvents();
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindCommitEvent_PluginStarted_SubscribesDirectly)
+{
+    auto mockMeta = QSharedPointer<PluginMetaObject>::create();
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMeta] {
+                       __DBG_STUB_INVOKE__
+                       return mockMeta;
+                   });
+
+    stub.set_lamda(ADDR(PluginMetaObject, pluginState),
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    bool subscribeCalled = false;
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [&subscribeCalled](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QVariantMap &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       subscribeCalled = true;
+                       return true;
+                   });
+
+    receiver->lazyBindCommitEvent("dfmplugin-search", "dfmplugin_search");
+
+    EXPECT_TRUE(subscribeCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindCommitEvent_PluginNotStarted_ConnectsListener)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->lazyBindCommitEvent("dfmplugin-search", "dfmplugin_search");
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindMenuDataEvent_PluginStarted_SubscribesDirectly)
+{
+    auto mockMeta = QSharedPointer<PluginMetaObject>::create();
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMeta] {
+                       __DBG_STUB_INVOKE__
+                       return mockMeta;
+                   });
+
+    stub.set_lamda(ADDR(PluginMetaObject, pluginState),
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    bool subscribeCalled = false;
+    typedef bool (EventDispatcherManager::*SubscribeFunc)(const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QList<QUrl> &));
+    stub.set_lamda(static_cast<SubscribeFunc>(&EventDispatcherManager::subscribe),
+                   [&subscribeCalled](EventDispatcherManager *, const QString &, const QString &, ReportLogEventReceiver *, void (ReportLogEventReceiver::*)(const QString &, const QList<QUrl> &)) -> bool {
+                       __DBG_STUB_INVOKE__
+                       subscribeCalled = true;
+                       return true;
+                   });
+
+    receiver->lazyBindMenuDataEvent("dfmplugin-myshares", "dfmplugin_myshares");
+
+    EXPECT_TRUE(subscribeCalled);
+}
+
+TEST_F(UT_ReportLogEventReceiver, lazyBindMenuDataEvent_PluginNotStarted_ConnectsListener)
+{
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    receiver->lazyBindMenuDataEvent("dfmplugin-myshares", "dfmplugin_myshares");
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_reportlogmanager.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogmanager.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogworker.h"
+
+#include <QThread>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_ReportLogManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        manager = ReportLogManager::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    ReportLogManager *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogManager, instance_ReturnsSingleton)
+{
+    ReportLogManager *instance1 = ReportLogManager::instance();
+    ReportLogManager *instance2 = ReportLogManager::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_ReportLogManager, commit_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestCommitLog);
+
+    manager->commit("TestType", QVariantMap());
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportMenuData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportMenuData);
+
+    manager->reportMenuData("TestMenu", QList<QUrl>());
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportBlockMountData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportBlockMountData);
+
+    manager->reportBlockMountData("/dev/sda1", true);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportNetworkMountData_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportNetworkMountData);
+
+    manager->reportNetworkMountData(true, dfmmount::DeviceError::kNoError, "");
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ReportLogManager, reportDesktopStartUp_EmitsSignal)
+{
+    QSignalSpy spy(manager, &ReportLogManager::requestReportDesktopStartUp);
+
+    manager->reportDesktopStartUp("testKey", QVariant("testData"));
+
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-utils/test_reportlogworker.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_reportlogworker.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogworker.h"
+#include "plugins/common/dfmplugin-utils/reportlog/datas/reportdatainterface.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/device/private/devicehelper.h>
+
+#include <QLibrary>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ReportLogWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        worker = new ReportLogWorker();
+    }
+
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+        stub.clear();
+    }
+
+    ReportLogWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ReportLogWorker, init_LibraryLoadFailed_NoCrash)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    EXPECT_NO_THROW(worker->init());
+}
+
+TEST_F(UT_ReportLogWorker, init_ResolveFailed_NoCrash)
+{
+    stub.set_lamda(ADDR(QLibrary, load),
+                   [](QLibrary *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const char *>(&QLibrary::resolve),
+                   [](QLibrary *, const char *) -> QFunctionPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    EXPECT_NO_THROW(worker->init());
+}
+
+TEST_F(UT_ReportLogWorker, commitLog_UnregisteredType_Returns)
+{
+    worker->commitLog("UnknownType", QVariantMap());
+}
+
+TEST_F(UT_ReportLogWorker, registerLogData_DuplicateType_ReturnsFalse)
+{
+    class MockReportData : public ReportDataInterface
+    {
+    public:
+        QString type() const override { return "MockType"; }
+        QJsonObject prepareData(const QVariantMap &) const override { return QJsonObject(); }
+    };
+
+    MockReportData *data1 = new MockReportData();
+    MockReportData *data2 = new MockReportData();
+
+    bool result1 = worker->registerLogData("MockType", data1);
+    bool result2 = worker->registerLogData("MockType", data2);
+
+    EXPECT_TRUE(result1);
+    EXPECT_FALSE(result2);
+
+    delete data2;
+}
+
+TEST_F(UT_ReportLogWorker, handleMenuData_WithUrls_SetsFileLocation)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf),
+                   [](FileInfo *, const NameInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "text/plain";
+                   });
+
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMenuData("TestAction", urls);
+}
+
+TEST_F(UT_ReportLogWorker, handleMenuData_EmptyUrls_SetsWorkspaceLocation)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMenuData("TestAction", QList<QUrl>());
+}
+
+TEST_F(UT_ReportLogWorker, handleBlockMountData_EmptyId_Returns)
+{
+    worker->handleBlockMountData("", true);
+}
+
+TEST_F(UT_ReportLogWorker, handleBlockMountData_FailedResult_CommitsWithUnknown)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleBlockMountData("/dev/sda1", false);
+}
+
+TEST_F(UT_ReportLogWorker, handleMountNetworkResult_Success_CommitsData)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMountNetworkResult(true, dfmmount::DeviceError::kNoError, "");
+}
+
+TEST_F(UT_ReportLogWorker, handleMountNetworkResult_UserCancelled_SetsErrorId)
+{
+    stub.set_lamda(ADDR(ReportLogWorker, commitLog),
+                   [](ReportLogWorker *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    worker->handleMountNetworkResult(false, dfmmount::DeviceError::kUserErrorUserCancelled, "User cancelled");
+}
+
+TEST_F(UT_ReportLogWorker, commit_NullArgs_Returns)
+{
+    worker->commit(QVariant());
+}
+
+TEST_F(UT_ReportLogWorker, commit_InvalidArgs_Returns)
+{
+    QVariant invalid;
+    worker->commit(invalid);
+}

--- a/autotests/plugins/dfmplugin-utils/test_shredfilemodel.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredfilemodel.cpp
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredfilemodel.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <QIcon>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShredFileModel : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        model = new ShredFileModel();
+    }
+
+    void TearDown() override
+    {
+        delete model;
+        model = nullptr;
+        stub.clear();
+    }
+
+    ShredFileModel *model { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredFileModel, Constructor_InitializesModel)
+{
+    EXPECT_NE(model, nullptr);
+    EXPECT_EQ(model->rowCount(), 0);
+}
+
+TEST_F(UT_ShredFileModel, setFileList_UpdatesModel)
+{
+    QList<QUrl> urls = {
+        QUrl::fromLocalFile("/tmp/file1.txt"),
+        QUrl::fromLocalFile("/tmp/file2.txt")
+    };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    EXPECT_EQ(model->rowCount(), 2);
+}
+
+TEST_F(UT_ShredFileModel, rowCount_ReturnsCorrectCount)
+{
+    EXPECT_EQ(model->rowCount(), 0);
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    EXPECT_EQ(model->rowCount(), 1);
+}
+
+TEST_F(UT_ShredFileModel, columnCount_ReturnsOne)
+{
+    EXPECT_EQ(model->columnCount(), 1);
+}
+
+TEST_F(UT_ShredFileModel, parent_ReturnsInvalidIndex)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    QModelIndex childIndex = model->index(0, 0);
+    QModelIndex parentIndex = model->parent(childIndex);
+
+    EXPECT_FALSE(parentIndex.isValid());
+}
+
+TEST_F(UT_ShredFileModel, index_ValidRow_ReturnsValidIndex)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+
+    EXPECT_TRUE(idx.isValid());
+    EXPECT_EQ(idx.row(), 0);
+    EXPECT_EQ(idx.column(), 0);
+}
+
+TEST_F(UT_ShredFileModel, index_InvalidRow_ReturnsInvalidIndex)
+{
+    QModelIndex idx = model->index(100, 0);
+
+    EXPECT_FALSE(idx.isValid());
+}
+
+TEST_F(UT_ShredFileModel, index_NegativeRow_ReturnsInvalidIndex)
+{
+    QModelIndex idx = model->index(-1, 0);
+
+    EXPECT_FALSE(idx.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_InvalidIndex_ReturnsEmpty)
+{
+    QModelIndex idx;
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_NullFileInfo_ReturnsEmpty)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_FALSE(result.isValid());
+}
+
+TEST_F(UT_ShredFileModel, data_DisplayRole_ReturnsFileName)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, displayOf),
+                   [](FileInfo *, const DisPlayInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "test.txt";
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DisplayRole);
+
+    EXPECT_EQ(result.toString(), "test.txt");
+}
+
+TEST_F(UT_ShredFileModel, data_DecorationRole_ReturnsIcon)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, fileIcon),
+                   [](FileInfo *) -> QIcon {
+                       __DBG_STUB_INVOKE__
+                       return QIcon::fromTheme("text-plain");
+                   });
+
+    model->setFileList(urls);
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::DecorationRole);
+
+    EXPECT_TRUE(result.canConvert<QIcon>());
+}
+
+TEST_F(UT_ShredFileModel, data_UnknownRole_ReturnsEmpty)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+    model->setFileList(urls);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(urls[0]));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, exists),
+                   [](FileInfo *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QModelIndex idx = model->index(0, 0);
+    QVariant result = model->data(idx, Qt::UserRole + 100);
+
+    EXPECT_FALSE(result.isValid());
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_shredmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredmenuscene.cpp
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredmenuscene.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/universalutils.h>
+
+#include <QMenu>
+#include <QAction>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+// ========== ShredMenuCreator Tests ==========
+
+class UT_ShredMenuCreator : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        creator = new ShredMenuCreator();
+    }
+
+    void TearDown() override
+    {
+        delete creator;
+        creator = nullptr;
+        stub.clear();
+    }
+
+    ShredMenuCreator *creator { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredMenuCreator, name_ReturnsShredMenu)
+{
+    EXPECT_EQ(ShredMenuCreator::name(), "ShredMenu");
+}
+
+TEST_F(UT_ShredMenuCreator, create_ReturnsNewScene)
+{
+    AbstractMenuScene *scene = creator->create();
+
+    EXPECT_NE(scene, nullptr);
+
+    delete scene;
+}
+
+// ========== ShredMenuScene Tests ==========
+
+class UT_ShredMenuScene : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        scene = new ShredMenuScene();
+    }
+
+    void TearDown() override
+    {
+        delete scene;
+        scene = nullptr;
+        stub.clear();
+    }
+
+    ShredMenuScene *scene { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredMenuScene, Constructor_CreatesScene)
+{
+    EXPECT_NE(scene, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, name_ReturnsShredMenu)
+{
+    EXPECT_EQ(scene->name(), "ShredMenu");
+}
+
+TEST_F(UT_ShredMenuScene, initialize_SetsParameters)
+{
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    params.insert("kWindowId", 1ULL);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_ShredDisabled_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_EmptyArea_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QVariantHash params;
+    params.insert("kIsEmptyArea", true);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_NullMenu_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = scene->create(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, triggered_UnknownAction_ReturnsFalse)
+{
+    QAction unknownAction;
+
+    bool result = scene->triggered(&unknownAction);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, scene_NullAction_ReturnsNull)
+{
+    AbstractMenuScene *result = scene->scene(nullptr);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, scene_UnknownAction_ReturnsNull)
+{
+    QAction unknownAction;
+
+    AbstractMenuScene *result = scene->scene(&unknownAction);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_ShredMenuScene, updateState_EmptyPredicateAction_Returns)
+{
+    QMenu menu;
+
+    scene->updateState(&menu);
+}
+
+TEST_F(UT_ShredMenuScene, create_VirtualUrl_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(&UniversalUtils::urlTransformToLocal,
+                   [](const QUrl &, QUrl *target) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (target)
+                           *target = QUrl("trash:///");
+                       return true;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl("trash:///"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_NullFileInfo_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, create_InvalidFile_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ShredUtils, isShredEnabled),
+                   [](ShredUtils *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(qOverload<const QUrl &>(&UrlRoute::isVirtual),
+                   [](const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test.txt")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(ADDR(ShredUtils, isValidFile),
+                   [](ShredUtils *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>({ QUrl::fromLocalFile("/tmp/test.txt") })));
+    params.insert("kIsEmptyArea", false);
+    scene->initialize(params);
+
+    QMenu menu;
+    bool result = scene->create(&menu);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredMenuScene, initialize_EmptySelectFiles_SetsFocusFileEmpty)
+{
+    QVariantHash params;
+    params.insert("kCurrentDir", QUrl::fromLocalFile("/tmp"));
+    params.insert("kSelectFiles", QVariant::fromValue(QList<QUrl>()));
+    params.insert("kIsEmptyArea", false);
+    params.insert("kWindowId", 1ULL);
+
+    bool result = scene->initialize(params);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredMenuScene, triggered_UnknownAction_CallsParent)
+{
+    QAction unknownAction;
+    unknownAction.setProperty("kActionID", "unknown-action");
+
+    bool result = scene->triggered(&unknownAction);
+
+    EXPECT_FALSE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_shredutils.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_shredutils.cpp
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <DDialog>
+#include <DSettingsOption>
+
+#include <QStandardPaths>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+
+class UT_ShredUtils : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        utils = ShredUtils::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    ShredUtils *utils { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShredUtils, instance_ReturnsSingleton)
+{
+    ShredUtils *instance1 = ShredUtils::instance();
+    ShredUtils *instance2 = ShredUtils::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_ShredUtils, isShredEnabled_ReturnsConfigValue)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = utils->isShredEnabled();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isShredEnabled_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = utils->isShredEnabled();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, setShredEnabled_CallsSetValue)
+{
+    bool setCalled = false;
+    bool capturedValue = false;
+
+    stub.set_lamda(ADDR(DConfigManager, setValue),
+                   [&setCalled, &capturedValue](DConfigManager *, const QString &, const QString &, const QVariant &value) {
+                       __DBG_STUB_INVOKE__
+                       setCalled = true;
+                       capturedValue = value.toBool();
+                   });
+
+    utils->setShredEnabled(true);
+
+    EXPECT_TRUE(setCalled);
+    EXPECT_TRUE(capturedValue);
+}
+
+TEST_F(UT_ShredUtils, initDconfig_CallsAddConfig)
+{
+    bool addConfigCalled = false;
+
+    stub.set_lamda(ADDR(DConfigManager, addConfig),
+                   [&addConfigCalled](DConfigManager *, const QString &, QString *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       addConfigCalled = true;
+                       return true;
+                   });
+
+    utils->initDconfig();
+}
+
+TEST_F(UT_ShredUtils, isValidFile_NullFileInfo_ReturnsFalse)
+{
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ExternalBlockMount_ReturnsTrue)
+{
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/media/usb/test.txt")));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return "/media/usb/test.txt";
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl url = QUrl::fromLocalFile("/media/usb/test.txt");
+    bool result = utils->isValidFile(url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ProtectedDirectory_ReturnsFalse)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(desktopPath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&desktopPath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return desktopPath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&desktopPath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return desktopPath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(desktopPath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_HomePathItself_ReturnsFalse)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(homePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&homePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return homePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&homePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return homePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(homePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_ValidFileInHome_ReturnsTrue)
+{
+    QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString filePath = homePath + "/mydir/test.txt";
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(filePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&filePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return filePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&filePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return filePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(filePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ShredUtils, isValidFile_PathOutsideHome_ReturnsFalse)
+{
+    QString outsidePath = "/opt/test.txt";
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile(outsidePath)));
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>),
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, pathOf),
+                   [&outsidePath](FileInfo *, const FileInfo::FilePathInfoType) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return outsidePath;
+                   });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts),
+                   [](DeviceProxyManager *, const QString &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    stub.set_lamda(&FileUtils::bindPathTransform,
+                   [&outsidePath](const QString &, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return outsidePath;
+                   });
+
+    QUrl url = QUrl::fromLocalFile(outsidePath);
+    bool result = utils->isValidFile(url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ShredUtils, shredfile_EmptyList_ReturnsEarly)
+{
+    bool confirmCalled = false;
+
+    utils->shredfile(QList<QUrl>(), 0);
+
+    EXPECT_FALSE(confirmCalled);
+}
+
+TEST_F(UT_ShredUtils, shredfile_CancelledDialog_ReturnsEarly)
+{
+    stub.set_lamda(VADDR(DDialog, exec),
+                   [](DDialog *) -> int {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/tmp/test.txt");
+
+    utils->shredfile(files, 0);
+}
+
+TEST_F(UT_ShredUtils, createShredSettingItem_ReturnsWidget)
+{
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    Dtk::Core::DSettingsOption option;
+    QWidget *widget = utils->createShredSettingItem(&option);
+
+    EXPECT_NE(widget, nullptr);
+
+    if (widget)
+        delete widget;
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_testingeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_testingeventreceiver.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/testing/events/testingeventrecevier.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QAccessible>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_TestingEventRecevier : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = TestingEventRecevier::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    TestingEventRecevier *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_TestingEventRecevier, instance_ReturnsSingleton)
+{
+    TestingEventRecevier *instance1 = TestingEventRecevier::instance();
+    TestingEventRecevier *instance2 = TestingEventRecevier::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_TestingEventRecevier, initializeConnections_InstallsAccessible)
+{
+    bool installFactoryCalled = false;
+
+    stub.set_lamda(&QAccessible::installFactory,
+                   [&installFactoryCalled](QAccessible::InterfaceFactory) {
+                       __DBG_STUB_INVOKE__
+                       installFactoryCalled = true;
+                   });
+
+    stub.set_lamda(&QAccessible::setActive,
+                   [](bool) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    receiver->initializeConnections();
+
+    EXPECT_TRUE(installFactoryCalled);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_vaultassitcontrol.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_vaultassitcontrol.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaultassitcontrol.h"
+
+#include <dfm-io/dfmio_utils.h>
+
+#include <QDir>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VaultAssitControl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        control = VaultAssitControl::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    VaultAssitControl *control { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VaultAssitControl, instance_ReturnsSingleton)
+{
+    VaultAssitControl *instance1 = VaultAssitControl::instance();
+    VaultAssitControl *instance2 = VaultAssitControl::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_VaultAssitControl, scheme_ReturnsDfmvault)
+{
+    QString result = control->scheme();
+
+    EXPECT_EQ(result, "dfmvault");
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_VaultScheme_ReturnsTrue)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test/file.txt");
+
+    bool result = control->isVaultFile(vaultUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_NonVaultScheme_ReturnsFalse)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    bool result = control->isVaultFile(fileUrl);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultAssitControl, isVaultFile_PathInMountDir_ReturnsTrue)
+{
+    // Build the URL from the product's own mount dir so the path matches
+    // regardless of the test user's home directory.
+    QUrl fileUrl = QUrl::fromLocalFile(control->vaultMountDirLocalPath() + "/test.txt");
+
+    bool result = control->isVaultFile(fileUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultAssitControl, vaultBaseDirLocalPath_ReturnsPath)
+{
+    QString result = control->vaultBaseDirLocalPath();
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, vaultMountDirLocalPath_ReturnsPath)
+{
+    QString result = control->vaultMountDirLocalPath();
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, buildVaultLocalPath_EmptyBase_UsesDefault)
+{
+    QString result = control->buildVaultLocalPath("test", "");
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, buildVaultLocalPath_WithBase_UsesBase)
+{
+    QString result = control->buildVaultLocalPath("test", "custom_base");
+
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(UT_VaultAssitControl, vaultUrlToLocalUrl_NonVaultScheme_ReturnsOriginal)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    QUrl result = control->vaultUrlToLocalUrl(fileUrl);
+
+    EXPECT_EQ(result, fileUrl);
+}
+
+TEST_F(UT_VaultAssitControl, vaultUrlToLocalUrl_VaultScheme_ReturnsLocalUrl)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test/file.txt");
+
+    QUrl result = control->vaultUrlToLocalUrl(vaultUrl);
+
+    EXPECT_EQ(result.scheme(), "file");
+}
+
+TEST_F(UT_VaultAssitControl, transUrlsToLocal_MixedUrls_TransformsVaultOnly)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/vault/file.txt");
+
+    QUrl localUrl = QUrl::fromLocalFile("/tmp/local.txt");
+
+    QList<QUrl> urls = { vaultUrl, localUrl };
+
+    QList<QUrl> result = control->transUrlsToLocal(urls);
+
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_EQ(result[0].scheme(), "file");
+    EXPECT_EQ(result[1], localUrl);
+}
+
+TEST_F(UT_VaultAssitControl, transUrlsToLocal_EmptyList_ReturnsEmpty)
+{
+    QList<QUrl> urls;
+
+    QList<QUrl> result = control->transUrlsToLocal(urls);
+
+    EXPECT_TRUE(result.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-utils/test_vaulthelperreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_vaulthelperreceiver.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaulthelperreceiver.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaultassitcontrol.h"
+
+#include <dfm-framework/event/event.h>
+
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_VaultHelperReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new VaultHelperReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    VaultHelperReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VaultHelperReceiver, Constructor_CreatesReceiver)
+{
+    EXPECT_NE(receiver, nullptr);
+}
+
+TEST_F(UT_VaultHelperReceiver, initEventConnect_FollowsHook)
+{
+    bool followCalled = false;
+
+    typedef bool (EventSequenceManager::*Follow)(const QString &, const QString &, VaultHelperReceiver *, decltype(&VaultHelperReceiver::handlemoveToTrash));
+    stub.set_lamda(static_cast<Follow>(&EventSequenceManager::follow),
+                   [&followCalled] {
+                       __DBG_STUB_INVOKE__
+                       followCalled = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(followCalled);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_EmptySource_ReturnsFalse)
+{
+    bool result = receiver->handlemoveToTrash(0, QList<QUrl>(), AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_NonVaultFile_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    bool result = receiver->handlemoveToTrash(0, urls, AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handlemoveToTrash_VaultFile_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    stub.set_lamda(ADDR(VaultAssitControl, transUrlsToLocal),
+                   [](VaultAssitControl *, const QList<QUrl> &urls) -> QList<QUrl> {
+                       __DBG_STUB_INVOKE__
+                       return urls;
+                   });
+
+    typedef bool (EventDispatcherManager::*Publish)(EventType, quint64, QList<QUrl> &, AbstractJobHandler::JobFlags &,
+                                                    std::nullptr_t &&, QVariant &&, AbstractJobHandler::OperatorCallback &);
+    stub.set_lamda(static_cast<Publish>(&EventDispatcherManager::publish),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/test.txt");
+    QList<QUrl> urls = { vaultUrl };
+
+    bool result = receiver->handlemoveToTrash(0, urls, AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VaultHelperReceiver, handleFinishedNotify_RestoresCursor)
+{
+    bool restoreCalled = false;
+
+    stub.set_lamda(&QApplication::restoreOverrideCursor,
+                   [&restoreCalled]() {
+                       __DBG_STUB_INVOKE__
+                       restoreCalled = true;
+                   });
+
+    JobInfoPointer jobInfo(new QMap<quint8, QVariant>());
+    receiver->handleFinishedNotify(jobInfo);
+
+    EXPECT_TRUE(restoreCalled);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualappendcompressplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualappendcompressplugin.cpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/virtualappendcompressplugin.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresseventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualAppendCompressPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(DPF_NAMESPACE::Event, eventType),
+                       [](DPF_NAMESPACE::Event *, const QString &, const QString &) -> int {
+            __DBG_STUB_INVOKE__
+            return DPF_NAMESPACE::EventTypeScope::kInValid;
+        });
+
+        plugin = new VirtualAppendCompressPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualAppendCompressPlugin *plugin { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object
+ * Verifies that the plugin is properly constructed with eventReceiver initialized
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(plugin, nullptr);
+
+    // According to dfm_ut.md, we can access private members directly
+    // Verify that eventReceiver is properly initialized
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+/**
+ * @brief Test initialize method calls eventReceiver's initEventConnect
+ * Verifies that the plugin properly initializes event connections
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_CallsInitEventConnect)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+/**
+ * @brief Test initialize can be called multiple times
+ * Verifies that calling initialize multiple times doesn't cause issues
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_MultipleCallsSafe)
+{
+    __DBG_STUB_INVOKE__
+
+    int initEventConnectCallCount = 0;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCallCount](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCallCount++;
+    });
+
+    plugin->initialize();
+    plugin->initialize();
+    plugin->initialize();
+
+    // initEventConnect should be called 3 times (once per initialize call)
+    EXPECT_EQ(initEventConnectCallCount, 3);
+}
+
+/**
+ * @brief Test initialize with valid eventReceiver
+ * Verifies that initialize works correctly when eventReceiver is valid
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, initialize_ValidEventReceiver_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    // Ensure eventReceiver is not null before initialization
+    ASSERT_NE(plugin->eventReceiver.data(), nullptr);
+
+    bool initEventConnectCalled = false;
+    AppendCompressEventReceiver *capturedReceiver = nullptr;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled, &capturedReceiver](AppendCompressEventReceiver *receiver) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+        capturedReceiver = receiver;
+    });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+    EXPECT_EQ(capturedReceiver, plugin->eventReceiver.data());
+}
+
+/**
+ * @brief Test start method returns true
+ * Verifies that the plugin starts successfully
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test start can be called multiple times
+ * Verifies that calling start multiple times always returns true
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_MultipleCallsReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_TRUE(plugin->start());
+    EXPECT_TRUE(plugin->start());
+    EXPECT_TRUE(plugin->start());
+}
+
+/**
+ * @brief Test start without initialize
+ * Verifies that start can be called before initialize
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, start_WithoutInitialize_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    // Don't call initialize before start
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test initialize then start
+ * Verifies the typical usage pattern: initialize followed by start
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, InitializeThenStart_Success)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    // Typical usage pattern
+    plugin->initialize();
+    bool startResult = plugin->start();
+
+    EXPECT_TRUE(initEventConnectCalled);
+    EXPECT_TRUE(startResult);
+}
+
+/**
+ * @brief Test eventReceiver ownership
+ * Verifies that eventReceiver is properly managed by QScopedPointer
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, EventReceiver_ProperlyManaged)
+{
+    __DBG_STUB_INVOKE__
+
+    // Access private member according to dfm_ut.md
+    AppendCompressEventReceiver *receiver = plugin->eventReceiver.data();
+
+    EXPECT_NE(receiver, nullptr);
+
+    // Verify that the eventReceiver is the same instance after operations
+    plugin->initialize();
+    EXPECT_EQ(plugin->eventReceiver.data(), receiver);
+
+    plugin->start();
+    EXPECT_EQ(plugin->eventReceiver.data(), receiver);
+}
+
+/**
+ * @brief Test plugin lifecycle
+ * Verifies the complete plugin lifecycle: construct -> initialize -> start
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, PluginLifecycle_CompleteFlow)
+{
+    __DBG_STUB_INVOKE__
+
+    int initCallCount = 0;
+    int startCallCount = 0;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initCallCount](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initCallCount++;
+    });
+
+    // Simulate complete plugin lifecycle
+    ASSERT_NE(plugin, nullptr); // Construction
+
+    plugin->initialize(); // Initialization
+    EXPECT_EQ(initCallCount, 1);
+
+    bool startResult = plugin->start(); // Start
+    EXPECT_TRUE(startResult);
+
+    // Verify state after full lifecycle
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+/**
+ * @brief Test start before initialize (reversed order)
+ * Verifies that the plugin handles reversed initialization order
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, StartBeforeInitialize_BothSucceed)
+{
+    __DBG_STUB_INVOKE__
+
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(AppendCompressEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](AppendCompressEventReceiver *) {
+        __DBG_STUB_INVOKE__
+        initEventConnectCalled = true;
+    });
+
+    // Call start before initialize (unusual but should work)
+    bool startResult = plugin->start();
+    EXPECT_TRUE(startResult);
+    EXPECT_FALSE(initEventConnectCalled);
+
+    // Then call initialize
+    plugin->initialize();
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+/**
+ * @brief Test eventReceiver member is not null by default
+ * Verifies that eventReceiver is initialized during construction
+ */
+TEST_F(UT_VirtualAppendCompressPlugin, EventReceiver_NotNullByDefault)
+{
+    __DBG_STUB_INVOKE__
+
+    // Create a new plugin instance
+    VirtualAppendCompressPlugin *newPlugin = new VirtualAppendCompressPlugin();
+
+    EXPECT_NE(newPlugin->eventReceiver.data(), nullptr);
+
+    delete newPlugin;
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualbluetoothplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualbluetoothplugin.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/virtualbluetoothplugin.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothdevice.h"
+
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QTimer>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_VirtualBluetoothPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&BluetoothDevice::getIcon, [] {
+            __DBG_STUB_INVOKE__
+            return "test";
+        });
+
+        stub.set_lamda(ADDR(BluetoothManager, getAdapters),
+                       [](const BluetoothManager *) -> QMap<QString, const BluetoothAdapter *> {
+                           __DBG_STUB_INVOKE__
+                           return QMap<QString, const BluetoothAdapter *>();
+                       });
+
+        stub.set_lamda(ADDR(BluetoothManager, refresh), [](BluetoothManager *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        // Stub QTimer
+        typedef void (*FuncType)(int, Qt::TimerType, const QObject *, QtPrivate::QSlotObjectBase *);
+        stub.set_lamda(static_cast<FuncType>(QTimer::singleShotImpl),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualBluetoothPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualBluetoothPlugin *plugin { nullptr };
+};
+
+/**
+ * @brief Test constructor creates valid object
+ */
+TEST_F(UT_VirtualBluetoothPlugin, Constructor_CreatesValidObject)
+{
+    __DBG_STUB_INVOKE__
+
+    EXPECT_NE(plugin, nullptr);
+}
+
+/**
+ * @brief Test initialize when not running as admin
+ */
+TEST_F(UT_VirtualBluetoothPlugin, initialize_NotAdmin_InitializesNormally)
+{
+    __DBG_STUB_INVOKE__
+
+    bool singleShotCalled = false;
+
+    stub.set_lamda(ADDR(SysInfoUtils, isOpenAsAdmin), []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    typedef void (*FuncType)(int, Qt::TimerType, const QObject *, QtPrivate::QSlotObjectBase *);
+    stub.set_lamda(static_cast<FuncType>(QTimer::singleShotImpl),
+                   [&singleShotCalled] {
+                       __DBG_STUB_INVOKE__
+                       singleShotCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(singleShotCalled);
+}
+
+/**
+ * @brief Test start method returns true
+ */
+TEST_F(UT_VirtualBluetoothPlugin, start_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test bluetoothAvailable when bluetooth is enabled and has adapter
+ */
+TEST_F(UT_VirtualBluetoothPlugin, bluetoothAvailable_EnabledWithAdapter_ReturnsTrue)
+{
+    __DBG_STUB_INVOKE__
+
+    stub.set_lamda(ADDR(BluetoothManager, bluetoothSendEnable), [](BluetoothManager *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(ADDR(BluetoothManager, hasAdapter), [](BluetoothManager *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = plugin->bluetoothAvailable();
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief Test sendFiles with empty paths
+ */
+TEST_F(UT_VirtualBluetoothPlugin, sendFiles_EmptyPaths_DoesNothing)
+{
+    stub.set_lamda(ADDR(BluetoothTransDialog, isBluetoothIdle), []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QStringList emptyPaths;
+    EXPECT_NO_THROW(plugin->sendFiles(emptyPaths, "device-id"));
+}
+
+/**
+ * @brief Test sendFiles when bluetooth is busy
+ */
+TEST_F(UT_VirtualBluetoothPlugin, sendFiles_BluetoothBusy_ShowsMessage)
+{
+    bool messageShown = false;
+
+    stub.set_lamda(ADDR(BluetoothTransDialog, isBluetoothIdle), []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;   // Bluetooth is busy
+    });
+
+    stub.set_lamda(qOverload<const QString &, const QString &, QString>(&DialogManager::showMessageDialog),
+                   [&messageShown] {
+                       __DBG_STUB_INVOKE__
+                       messageShown = true;
+                       return 0;
+                   });
+
+    QStringList paths = { "/tmp/file1.txt" };
+    plugin->sendFiles(paths, "device-id");
+
+    EXPECT_TRUE(messageShown);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualextensionimplplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualextensionimplplugin.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/virtualextensionimplplugin.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/windowimpl/extensionwindowsmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/fileimpl/extensionfilemanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualExtensionImplPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new VirtualExtensionImplPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    VirtualExtensionImplPlugin *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VirtualExtensionImplPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, initialize_InitializesManagers)
+{
+    bool emblemInitialized = false;
+    bool windowInitialized = false;
+    bool fileInitialized = false;
+
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize),
+                   [&emblemInitialized] {
+                       __DBG_STUB_INVOKE__
+                       emblemInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize),
+                   [&windowInitialized] {
+                       __DBG_STUB_INVOKE__
+                       windowInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize),
+                   [&fileInitialized] {
+                       __DBG_STUB_INVOKE__
+                       fileInitialized = true;
+                   });
+
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(emblemInitialized);
+    EXPECT_TRUE(windowInitialized);
+    EXPECT_TRUE(fileInitialized);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, start_RegistersMenuScene)
+{
+    bool sceneRegistered = false;
+    bool sceneBound = false;
+
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, followEvents_ValidEventID_FollowsHookSequence)
+{
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+
+    bool hookFollowed = false;
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return static_cast<DPF_NAMESPACE::EventType>(100);
+                   });
+
+    plugin->initialize();
+
+    // Test passes if no crash occurs
+}
+
+TEST_F(UT_VirtualExtensionImplPlugin, followEvents_InvalidEventID_ConnectsPluginStartedSignal)
+{
+    stub.set_lamda(ADDR(ExtensionEmblemManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionWindowsManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(ExtensionFileManager, initialize), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(Event, eventType),
+                   [](Event *, const QString &, const QString &) -> DPF_NAMESPACE::EventType {
+                       __DBG_STUB_INVOKE__
+                       return DPF_NAMESPACE::EventTypeScope::kInValid;
+                   });
+
+    plugin->initialize();
+
+    // Test passes if no crash occurs
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/virtualglobalplugin.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualGlobalPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                       [](GlobalEventReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualGlobalPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualGlobalPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualGlobalPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, start_ReturnsTrue)
+{
+    EXPECT_TRUE(plugin->start());
+}
+
+TEST_F(UT_VirtualGlobalPlugin, PluginLifecycle_InitializeThenStart)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+    EXPECT_TRUE(initCalled);
+
+    EXPECT_TRUE(plugin->start());
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/lifecycle/pluginmetaobject.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualOpenWithPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new VirtualOpenWithPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualOpenWithPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualOpenWithPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(OpenWithEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](OpenWithEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogInitialized_RegsView)
+{
+    bool regViewCalled = false;
+
+    auto mockMetaObj = QSharedPointer<PluginMetaObject>(new PluginMetaObject);
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMetaObj] {
+                       __DBG_STUB_INVOKE__
+                       return mockMetaObj;
+                   });
+
+    stub.set_lamda(&PluginMetaObject::pluginState,
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, std::function<QWidget *(const QUrl &)>, std::function<void (QWidget *, const QUrl &)> &, QString &&, int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&regViewCalled] {
+                       __DBG_STUB_INVOKE__
+                       regViewCalled = true;
+                       return QVariant();
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(regViewCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogNotInitialized_ConnectsListener)
+{
+    bool listenerConnected = false;
+
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    stub.set_lamda(ADDR(Listener, instance),
+                   [&listenerConnected]() -> Listener * {
+                       __DBG_STUB_INVOKE__
+                       listenerConnected = true;
+                       static Listener listener;
+                       return &listener;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(listenerConnected);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, regViewToPropertyDialog_PushesSlot)
+{
+    bool pushCalled = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, std::function<QWidget *(const QUrl &)>, std::function<void (QWidget *, const QUrl &)> &, QString &&, int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&pushCalled] {
+                       __DBG_STUB_INVOKE__
+                       pushCalled = true;
+                       return QVariant();
+                   });
+
+    plugin->regViewToPropertyDialog();
+    EXPECT_TRUE(pushCalled);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualreportlogplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualreportlogplugin.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/reportlog/virtualreportlogplugin.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <QTimer>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_VirtualReportLogPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(ReportLogManager, init),
+                       [](ReportLogManager *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(ADDR(ReportLogEventReceiver, bindEvents),
+                       [](ReportLogEventReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualReportLogPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualReportLogPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualReportLogPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualReportLogPlugin, initialize_CallsManagerInitAndBindEvents)
+{
+    bool managerInitCalled = false;
+    bool bindEventsCalled = false;
+
+    stub.set_lamda(ADDR(ReportLogManager, init),
+                   [&managerInitCalled](ReportLogManager *) {
+                       __DBG_STUB_INVOKE__
+                       managerInitCalled = true;
+                   });
+
+    stub.set_lamda(ADDR(ReportLogEventReceiver, bindEvents),
+                   [&bindEventsCalled](ReportLogEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       bindEventsCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(managerInitCalled);
+    EXPECT_TRUE(bindEventsCalled);
+}
+
+TEST_F(UT_VirtualReportLogPlugin, start_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [](ReportLogManager *, const QString &, const QVariantMap &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    stub.set_lamda(ADDR(DConfigManager, value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualshredplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualshredplugin.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/shred/vitrualshredplugin.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/settingdialog/customsettingitemregister.h>
+#include <dfm-base/utils/dialogmanager.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_VirtualShredPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(ShredUtils, initDconfig),
+                       [](ShredUtils *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(ADDR(SettingJsonGenerator, addGroup),
+                       [](SettingJsonGenerator *, const QString &, const QString &) {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(ADDR(SettingJsonGenerator, addConfig),
+                       [](SettingJsonGenerator *, const QString &, const QVariantMap &) {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(ADDR(DialogManager, registerSettingWidget),
+                       [](DialogManager *, const QString &, std::function<QWidget *(QObject *)>) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualShredPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualShredPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualShredPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualShredPlugin, initialize_DoesNothing)
+{
+    plugin->initialize();
+}
+
+TEST_F(UT_VirtualShredPlugin, start_AllPluginsStarted_ReturnsTrue)
+{
+    stub.set_lamda(&LifeCycle::isAllPluginsStarted,
+                   []() -> bool {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_VirtualShredPlugin, start_PluginsNotStarted_ConnectsSignal)
+{
+    stub.set_lamda(&LifeCycle::isAllPluginsStarted,
+                   []() -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualtestingplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualtestingplugin.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/testing/virtualtestingplugin.h"
+#include "plugins/common/dfmplugin-utils/testing/events/testingeventrecevier.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualTestingPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(TestingEventRecevier, initializeConnections),
+                       [](TestingEventRecevier *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualTestingPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualTestingPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualTestingPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualTestingPlugin, initialize_CallsInitializeConnections)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(TestingEventRecevier, initializeConnections),
+                   [&initCalled](TestingEventRecevier *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initCalled);
+}
+
+TEST_F(UT_VirtualTestingPlugin, start_ReturnsTrue)
+{
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+

--- a/autotests/plugins/dfmplugin-utils/test_virtualvaulthelperplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualvaulthelperplugin.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/virtualvaulthelperplugin.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaulthelperreceiver.h"
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+
+class UT_VirtualVaultHelperPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(VaultHelperReceiver, initEventConnect),
+                       [](VaultHelperReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualVaultHelperPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualVaultHelperPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualVaultHelperPlugin, Constructor_CreatesPlugin)
+{
+    EXPECT_NE(plugin, nullptr);
+}
+
+TEST_F(UT_VirtualVaultHelperPlugin, initialize_CallsInitEventConnect)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(VaultHelperReceiver, initEventConnect),
+                   [&initCalled](VaultHelperReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initCalled);
+}
+
+TEST_F(UT_VirtualVaultHelperPlugin, start_ReturnsTrue)
+{
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+}
+


### PR DESCRIPTION
Port utils plugin tests from autotests/old, covering bluetooth,
shred, open-with, report log and extension helpers.

从 autotests/old 移植工具插件测试，覆盖蓝牙、文件粉碎、
打开方式、上报日志与扩展辅助。

Log: 新增 dfmplugin-utils 单元测试
Influence: 仅新增测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.