### PR TITLE
test: add unit tests for dfmplugin-vault

### DIFF
--- a/autotests/plugins/dfmplugin-vault/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-vault/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# dfmplugin-vault unit tests — recompile the vault plugin's own sources into the
+# test binary so stub-ext can access private members. The vault plugin's
+# dependencies.cmake (dfm_setup_vault_dependencies) is auto-applied via
+# dfm_create_plugin_test -> dfm_configure_plugin_dependencies, which adds
+# openssl / libsecret / polkit / libcryptsetup.
+
+dfm_create_plugin_test("dfmplugin-vault" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-vault")
+
+# Vault sources use cross-plugin includes via the filemanager plugins root.
+target_include_directories(ut-dfmplugin-vault PRIVATE
+    "${DFM_SOURCE_DIR}/plugins/filemanager"
+)

--- a/autotests/plugins/dfmplugin-vault/main.cpp
+++ b/autotests/plugins/dfmplugin-vault/main.cpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_vault)

--- a/autotests/plugins/dfmplugin-vault/test_operatorcenter_real.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_operatorcenter_real.cpp
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QString>
+#include <QStringList>
+
+#include "stubext.h"
+
+#include "utils/encryption/operatorcenter.h"
+#include "utils/vaultdefine.h"
+
+DPVAULT_USE_NAMESPACE
+
+// OperatorCenter is a singleton. We test pure-logic methods and filesystem
+// methods that gracefully handle missing files. buildFilePath is a C-style
+// variadic and cannot be stubbed, so we let methods use the real kVaultBasePath
+// and create/remove files there as needed.
+
+class OperatorCenterTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        operatorCenter = OperatorCenter::getInstance();
+        // Ensure vault base dir exists
+        QDir().mkpath(kVaultBasePath);
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        // Clean up test files
+        for (const char *fname : {kPasswordHintFileName, kPasswordFileName, kRSAPUBKeyFileName, kRSACiphertextFileName}) {
+            QFile f(kVaultBasePath + "/" + fname);
+            f.remove();
+        }
+    }
+
+    OperatorCenter *operatorCenter = nullptr;
+};
+
+// --- getUserKey / getSaltAndPasswordCipher / clearSaltAndPasswordCipher ---
+
+TEST_F(OperatorCenterTest, GetUserKey_ReturnsCachedValue)
+{
+    EXPECT_TRUE(operatorCenter->getUserKey().isEmpty());
+}
+
+TEST_F(OperatorCenterTest, GetSaltAndPasswordCipher_ReturnsCachedValue)
+{
+    EXPECT_TRUE(operatorCenter->getSaltAndPasswordCipher().isEmpty());
+}
+
+TEST_F(OperatorCenterTest, ClearSaltAndPasswordCipher_ClearsValue)
+{
+    operatorCenter->clearSaltAndPasswordCipher();
+    EXPECT_TRUE(operatorCenter->getSaltAndPasswordCipher().isEmpty());
+}
+
+// --- getdecryptDirPath ---
+
+TEST_F(OperatorCenterTest, GetDecryptDirPath_ReturnsPath)
+{
+    QString path = operatorCenter->getdecryptDirPath();
+    EXPECT_FALSE(path.isEmpty());
+    EXPECT_TRUE(path.contains(kVaultDecryptDirName));
+}
+
+// --- getConfigFilePath ---
+
+TEST_F(OperatorCenterTest, GetConfigFilePath_ReturnsFourPaths)
+{
+    QStringList paths = operatorCenter->getConfigFilePath();
+    EXPECT_EQ(paths.size(), 4);
+}
+
+// --- autoGeneratePassword ---
+
+TEST_F(OperatorCenterTest, AutoGeneratePassword_TooShort_ReturnsEmpty)
+{
+    EXPECT_TRUE(operatorCenter->autoGeneratePassword(2).isEmpty());
+}
+
+TEST_F(OperatorCenterTest, AutoGeneratePassword_ZeroLength_ReturnsEmpty)
+{
+    EXPECT_TRUE(operatorCenter->autoGeneratePassword(0).isEmpty());
+}
+
+TEST_F(OperatorCenterTest, AutoGeneratePassword_MinLength_ReturnsValidPassword)
+{
+    QString pwd = operatorCenter->autoGeneratePassword(3);
+    EXPECT_EQ(pwd.length(), 3);
+}
+
+TEST_F(OperatorCenterTest, AutoGeneratePassword_LongerLength_ReturnsCorrectSize)
+{
+    QString pwd = operatorCenter->autoGeneratePassword(16);
+    EXPECT_EQ(pwd.length(), 16);
+}
+
+TEST_F(OperatorCenterTest, AutoGeneratePassword_ContainsMixedChars)
+{
+    QString pwd = operatorCenter->autoGeneratePassword(16);
+    bool hasDigit = false, hasLetter = false;
+    for (const QChar &c : pwd) {
+        if (c.isDigit()) hasDigit = true;
+        if (c.isLetter()) hasLetter = true;
+    }
+    EXPECT_TRUE(hasDigit);
+    EXPECT_TRUE(hasLetter);
+}
+
+// (Removed flaky DifferentCalls test: srand seeded by seconds can collide)
+
+// --- getPasswordHint ---
+
+TEST_F(OperatorCenterTest, GetPasswordHint_NoFile_ReturnsFalse)
+{
+    // Remove the file first to ensure it doesn't exist
+    QFile::remove(kVaultBasePath + "/" + kPasswordHintFileName);
+    QString hint;
+    EXPECT_FALSE(operatorCenter->getPasswordHint(hint));
+    EXPECT_TRUE(hint.isEmpty());
+}
+
+TEST_F(OperatorCenterTest, GetPasswordHint_WithFile_ReturnsContent)
+{
+    QString hintPath = kVaultBasePath + "/" + kPasswordHintFileName;
+    QFile hintFile(hintPath);
+    if (hintFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        hintFile.write("myhint");
+        hintFile.close();
+    }
+
+    QString hint;
+    bool ok = operatorCenter->getPasswordHint(hint);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(hint, "myhint");
+}
+
+// --- checkPassword / checkUserKey (with no key files, should fail gracefully) ---
+
+TEST_F(OperatorCenterTest, CheckPassword_NoFiles_ReturnsFalse)
+{
+    QString cipher;
+    EXPECT_FALSE(operatorCenter->checkPassword("testpassword", cipher));
+}
+
+TEST_F(OperatorCenterTest, CheckUserKey_NoFiles_ReturnsFalse)
+{
+    QString cipher;
+    EXPECT_FALSE(operatorCenter->checkUserKey("AAAABBBBCCCC", cipher));
+}
+
+// --- createKey (requires openssl; with no proper setup it should fail gracefully) ---
+
+TEST_F(OperatorCenterTest, CreateKey_NoSetup_ReturnsFalse)
+{
+    EXPECT_NO_FATAL_FAILURE(operatorCenter->createKey("testpassword", 24));
+}
+
+// --- removeVault ---
+
+TEST_F(OperatorCenterTest, RemoveVault_NonExistentDir_NoCrash)
+{
+    QString basePath = kVaultBasePath + "/nonexistent_vault_dir";
+    EXPECT_NO_FATAL_FAILURE(operatorCenter->removeVault(basePath));
+}
+
+TEST_F(OperatorCenterTest, RemoveVault_EmptyDir_RemovesDirectory)
+{
+    QString basePath = kVaultBasePath + "/empty_vault_dir_test";
+    QDir().mkpath(basePath);
+    ASSERT_TRUE(QDir(basePath).exists());
+    // removeVault runs in a background thread; wait via signal
+    QSignalSpy spy(operatorCenter, &OperatorCenter::fileRemovedProgress);
+    operatorCenter->removeVault(basePath);
+    // Wait for the removal to complete (progress signals emitted)
+    if (spy.wait(5000) || spy.count() > 0) {
+        // Give the thread a moment to finish actual rmdir
+        QTest::qWait(200);
+    }
+    EXPECT_FALSE(QDir(basePath).exists());
+}

--- a/autotests/plugins/dfmplugin-vault/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_realevents.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run Vault::initialize() with REAL connectEvent() (the 25
+// subscribe/follow calls in VaultEventReceiver::connectEvent) NOT stubbed, so
+// production EventHelper<M> templates execute. bindWindows remains stubbed.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "vault.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_vault;
+
+class VaultRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        stub.set_lamda(&Vault::bindWindows, [] { __DBG_STUB_INVOKE__ });
+        ins = new Vault();
+    }
+    void TearDown() override { stub.clear(); delete ins; }
+    stub_ext::StubExt stub;
+    Vault *ins { nullptr };
+};
+
+TEST_F(VaultRealEventsTest, Initialize_RunsRealConnectEvent_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}

--- a/autotests/plugins/dfmplugin-vault/test_servicemanager.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_servicemanager.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+
+#include "stubext.h"
+
+#include "utils/servicemanager.h"
+#include "utils/vaulthelper.h"
+
+using namespace dfmplugin_vault;
+
+class ServiceManagerImpl : public testing::Test
+{
+public:
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(ServiceManagerImpl, BasicViewFieldFunc)
+{
+    QUrl url = QUrl("dfmvault:///foo.txt");
+    ServiceManager::ExpandFieldMap map = ServiceManager::basicViewFieldFunc(url);
+
+    EXPECT_TRUE(map.contains(kFieldReplace));
+    auto basic = map.value(kFieldReplace);
+    EXPECT_TRUE(basic.contains(kFilePosition));
+    auto pair = basic.value(kFilePosition);
+    EXPECT_EQ(pair.second, url.url());
+}
+
+TEST_F(ServiceManagerImpl, DetailViewFieldFunc_RootUrl)
+{
+    ServiceManager::ExpandFieldMap map = ServiceManager::detailViewFieldFunc(VaultHelper::instance()->rootUrl());
+
+    EXPECT_TRUE(map.contains(kFieldInsert));
+    auto basic = map.value(kFieldInsert);
+    EXPECT_TRUE(basic.contains(kFileInterviewTime));
+}
+
+TEST_F(ServiceManagerImpl, DetailViewFieldFunc_NonRootUrl)
+{
+    QUrl url = QUrl("dfmvault:///child.txt");
+    ServiceManager::ExpandFieldMap map = ServiceManager::detailViewFieldFunc(url);
+
+    EXPECT_FALSE(map.contains(kFieldInsert));
+}

--- a/autotests/plugins/dfmplugin-vault/test_unlockview.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_unlockview.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QString>
+#include <QStringList>
+
+#include "stubext.h"
+
+#include "views/unlockview/unlockview.h"
+
+DPVAULT_USE_NAMESPACE
+
+class UnlockViewTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        view = new UnlockView();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        delete view;
+    }
+
+    UnlockView *view = nullptr;
+};
+
+// --- construction (covers initUI) ---
+
+TEST_F(UnlockViewTest, Constructor_CreatesView)
+{
+    EXPECT_NE(view, nullptr);
+}
+
+// --- btnText ---
+
+TEST_F(UnlockViewTest, BtnText_Default_ReturnsUnlockButton)
+{
+    QStringList btns = view->btnText();
+    EXPECT_EQ(btns.size(), 2);
+    // Default: Cancel + Unlock
+    EXPECT_FALSE(btns[1].isEmpty());
+}
+
+TEST_F(UnlockViewTest, BtnText_MigrationMode_ReturnsVerifyPasswordButton)
+{
+    view->setOldPasswordSchemeMigrationMode(true);
+    QStringList btns = view->btnText();
+    EXPECT_EQ(btns.size(), 2);
+}
+
+// --- titleText ---
+
+TEST_F(UnlockViewTest, TitleText_Default_ReturnsUnlockTitle)
+{
+    QString title = view->titleText();
+    EXPECT_FALSE(title.isEmpty());
+}
+
+TEST_F(UnlockViewTest, TitleText_MigrationMode_ReturnsMigrationTitle)
+{
+    view->setOldPasswordSchemeMigrationMode(true);
+    QString title = view->titleText();
+    EXPECT_FALSE(title.isEmpty());
+}
+
+// --- setOldPasswordSchemeMigrationMode / isOldPasswordSchemeMigrationMode ---
+
+TEST_F(UnlockViewTest, IsOldPasswordSchemeMigrationMode_DefaultFalse)
+{
+    EXPECT_FALSE(view->isOldPasswordSchemeMigrationMode());
+}
+
+TEST_F(UnlockViewTest, SetOldPasswordSchemeMigrationMode_True)
+{
+    view->setOldPasswordSchemeMigrationMode(true);
+    EXPECT_TRUE(view->isOldPasswordSchemeMigrationMode());
+}
+
+TEST_F(UnlockViewTest, SetOldPasswordSchemeMigrationMode_False)
+{
+    view->setOldPasswordSchemeMigrationMode(true);
+    view->setOldPasswordSchemeMigrationMode(false);
+    EXPECT_FALSE(view->isOldPasswordSchemeMigrationMode());
+}
+
+// --- onPasswordChanged (slot, changes password state) ---
+
+TEST_F(UnlockViewTest, OnPasswordChanged_Empty_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onPasswordChanged(""));
+}
+
+TEST_F(UnlockViewTest, OnPasswordChanged_NonEmpty_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onPasswordChanged("testpassword"));
+}
+
+// --- onVaultUlocked (slot) ---
+
+TEST_F(UnlockViewTest, OnVaultUlocked_StateZero_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onVaultUlocked(0));
+}
+
+// --- buttonClicked (emits signals) ---
+
+TEST_F(UnlockViewTest, ButtonClicked_CancelIndex_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->buttonClicked(0, "Cancel"));
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaultactivesetunlockmethodview.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaultactivesetunlockmethodview.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QString>
+#include <QStringList>
+
+#include "stubext.h"
+
+#include "views/createvaultview/vaultactivesetunlockmethodview.h"
+#include "utils/encryption/vaultconfig.h"
+
+DPVAULT_USE_NAMESPACE
+
+class VaultActiveSetUnlockMethodViewTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        view = new VaultActiveSetUnlockMethodView();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        delete view;
+    }
+
+    VaultActiveSetUnlockMethodView *view = nullptr;
+};
+
+// --- construction ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, Constructor_CreatesView)
+{
+    EXPECT_NE(view, nullptr);
+}
+
+// --- clearText ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, ClearText_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->clearText());
+}
+
+// --- slotPasswordEditing ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotPasswordEditing_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotPasswordEditing());
+}
+
+// --- slotPasswordEditFinished ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotPasswordEditFinished_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotPasswordEditFinished());
+}
+
+// --- slotRepeatPasswordEditFinished ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotRepeatPasswordEditFinished_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotRepeatPasswordEditFinished());
+}
+
+// --- slotRepeatPasswordEditing ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotRepeatPasswordEditing_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotRepeatPasswordEditing());
+}
+
+// --- slotGenerateEditChanged ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotGenerateEditChanged_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotGenerateEditChanged("test"));
+}
+
+// --- slotTypeChanged ---
+
+TEST_F(VaultActiveSetUnlockMethodViewTest, SlotTypeChanged_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->slotTypeChanged(0));
+    EXPECT_NO_FATAL_FAILURE(view->slotTypeChanged(1));
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaultconfig.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaultconfig.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+
+#include "stubext.h"
+
+#include "utils/encryption/vaultconfig.h"
+
+using namespace dfmplugin_vault;
+
+class VaultConfigImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        tempDir = new QTemporaryDir;
+    }
+
+    void TearDown() override
+    {
+        delete tempDir;
+        stub.clear();
+    }
+
+protected:
+    QTemporaryDir *tempDir { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(VaultConfigImpl, ConstructWithCustomFilePath)
+{
+    QString filePath = tempDir->filePath("vault.ini");
+    {
+        VaultConfig config(filePath);
+        config.set(kConfigNodeName, kConfigKeyVersion, QVariant("1050"));
+    }
+
+    VaultConfig reader(filePath);
+    EXPECT_EQ(reader.get(kConfigNodeName, kConfigKeyVersion).toString(), QString("1050"));
+}
+
+TEST_F(VaultConfigImpl, SetAndGet)
+{
+    VaultConfig config(tempDir->filePath("vault.ini"));
+    config.set("INFO", "cipher", QVariant("saltcipher"));
+
+    EXPECT_EQ(config.get("INFO", "cipher").toString(), QString("saltcipher"));
+}
+
+TEST_F(VaultConfigImpl, GetWithDefaultValue)
+{
+    VaultConfig config(tempDir->filePath("vault.ini"));
+
+    EXPECT_EQ(config.get("INFO", "missing", QVariant("default")).toString(), QString("default"));
+}
+
+TEST_F(VaultConfigImpl, VaultCreationTypeNew)
+{
+    VaultConfig config(tempDir->filePath("vault.ini"));
+    config.setVaultCreationType(kConfigValueVaultCreationTypeNew);
+
+    EXPECT_EQ(config.getVaultCreationType(), QString(kConfigValueVaultCreationTypeNew));
+    EXPECT_TRUE(config.isNewCreated());
+}
+
+TEST_F(VaultConfigImpl, VaultCreationTypeMigrated)
+{
+    VaultConfig config(tempDir->filePath("vault.ini"));
+    config.setVaultCreationType(kConfigValueVaultCreationTypeMigrated);
+
+    EXPECT_EQ(config.getVaultCreationType(), QString(kConfigValueVaultCreationTypeMigrated));
+    EXPECT_FALSE(config.isNewCreated());
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaulteventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaulteventreceiver.cpp
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+
+#include "stubext.h"
+
+#include "events/vaulteventreceiver.h"
+#include "utils/vaulthelper.h"
+#include "utils/pathmanager.h"
+#include "utils/fileencrypthandle.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+DPVAULT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class VaultEventReceiverImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        stub.set_lamda(&PathManager::makeVaultLocalPath, [this](const QString &, const QString &) -> QString {
+            return tempPath;
+        });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    QString tempPath { "/tmp/vault_event_test" };
+};
+
+TEST_F(VaultEventReceiverImpl, Instance)
+{
+    VaultEventReceiver *r = VaultEventReceiver::instance();
+    EXPECT_NE(r, nullptr);
+    EXPECT_EQ(r, VaultEventReceiver::instance());
+}
+
+TEST_F(VaultEventReceiverImpl, ConnectEvent)
+{
+    VaultEventReceiver::instance()->connectEvent();
+    SUCCEED();
+}
+
+TEST_F(VaultEventReceiverImpl, ComputerOpenItem_NonVaultPath)
+{
+    VaultEventReceiver::instance()->computerOpenItem(0, QUrl::fromLocalFile("/tmp/foo"));
+    SUCCEED();
+}
+
+TEST_F(VaultEventReceiverImpl, ComputerOpenItem_Unlocked)
+{
+    using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+    stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                   [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kUnlocked; });
+
+    VaultEventReceiver::instance()->computerOpenItem(1, QUrl::fromLocalFile("/tmp/vault_test"));
+    SUCCEED();
+}
+
+TEST_F(VaultEventReceiverImpl, ComputerOpenItem_Encrypted)
+{
+    using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+    stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                   [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kEncrypted; });
+    using UnlockDialogFunc = void (VaultHelper::*)();
+    bool called = false;
+    stub.set_lamda(static_cast<UnlockDialogFunc>(&VaultHelper::unlockVaultDialog),
+                   [&called](VaultHelper *) { called = true; });
+
+    VaultEventReceiver::instance()->computerOpenItem(1, QUrl::fromLocalFile("/tmp/vault_test"));
+    EXPECT_TRUE(called);
+}
+
+TEST_F(VaultEventReceiverImpl, HandleNotAllowedAppendCompress_Allowed)
+{
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/foo") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/bar");
+    EXPECT_FALSE(VaultEventReceiver::instance()->handleNotAllowedAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleNotAllowedAppendCompress_FromVault)
+{
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &, QList<QUrl> *out) -> bool {
+        if (out)
+            *out << QUrl::fromLocalFile("/tmp/vault_event_test/foo");
+        return true;
+    });
+
+    QList<QUrl> fromUrls = { QUrl::fromLocalFile("/tmp/whatever") };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/bar");
+    EXPECT_TRUE(VaultEventReceiver::instance()->handleNotAllowedAppendCompress(fromUrls, toUrl));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleCurrentUrlChanged_VaultScheme)
+{
+    using FindFunc = FileManagerWindow *(FileManagerWindowsManager::*)(quint64);
+    stub.set_lamda(static_cast<FindFunc>(&FileManagerWindowsManager::findWindowById),
+                   [](FileManagerWindowsManager *, quint64) -> FileManagerWindow * { return nullptr; });
+
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    VaultHelper::instance()->appendWinID(7);
+    VaultEventReceiver::instance()->handleCurrentUrlChanged(7, url);
+    VaultHelper::instance()->removeWinID(7);
+    SUCCEED();
+}
+
+TEST_F(VaultEventReceiverImpl, HandleCurrentUrlChanged_NonVaultScheme)
+{
+    using FindFunc = FileManagerWindow *(FileManagerWindowsManager::*)(quint64);
+    stub.set_lamda(static_cast<FindFunc>(&FileManagerWindowsManager::findWindowById),
+                   [](FileManagerWindowsManager *, quint64) -> FileManagerWindow * { return nullptr; });
+
+    VaultHelper::instance()->appendWinID(8);
+    VaultEventReceiver::instance()->handleCurrentUrlChanged(8, QUrl::fromLocalFile("/tmp/foo"));
+    VaultHelper::instance()->removeWinID(8);
+    SUCCEED();
+}
+
+TEST_F(VaultEventReceiverImpl, HandleSideBarItemDragMoveData_NonTag)
+{
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_FALSE(VaultEventReceiver::instance()->handleSideBarItemDragMoveData({}, QUrl(), &action));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleSideBarItemDragMoveData_TagVaultFile)
+{
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(VaultEventReceiver::instance()->handleSideBarItemDragMoveData({ vaultUrl }, tagUrl, &action));
+    EXPECT_EQ(action, Qt::IgnoreAction);
+}
+
+TEST_F(VaultEventReceiverImpl, HandleShortCutPasteFiles_Empty)
+{
+    EXPECT_FALSE(VaultEventReceiver::instance()->handleShortCutPasteFiles(0, {}, QUrl()));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleShortCutPasteFiles_Allowed)
+{
+    stub.set_lamda(&FileUtils::isTrashFile, [](const QUrl &) -> bool { return true; });
+
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    QList<QUrl> fromUrls = { vaultUrl };
+    QUrl toUrl = QUrl::fromLocalFile("trash:///test");
+    EXPECT_TRUE(VaultEventReceiver::instance()->handleShortCutPasteFiles(0, fromUrls, toUrl));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleShortCutPasteFiles_Disallowed)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    QList<QUrl> fromUrls = { vaultUrl };
+    QUrl toUrl = QUrl::fromLocalFile("/tmp/foo");
+    EXPECT_FALSE(VaultEventReceiver::instance()->handleShortCutPasteFiles(0, fromUrls, toUrl));
+}
+
+TEST_F(VaultEventReceiverImpl, ChangeUrlEventFilter_NonVaultScheme)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/foo");
+    EXPECT_FALSE(VaultEventReceiver::instance()->changeUrlEventFilter(0, url));
+}
+
+TEST_F(VaultEventReceiverImpl, ChangeUrlEventFilter_Unlocked)
+{
+    using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+    stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                   [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kUnlocked; });
+
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    EXPECT_FALSE(VaultEventReceiver::instance()->changeUrlEventFilter(0, url));
+}
+
+TEST_F(VaultEventReceiverImpl, ChangeUrlEventFilter_NotAvailable)
+{
+    using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+    stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                   [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kNotAvailable; });
+    using DialogFunc = void (DialogManager::*)(const QString &, const QString &);
+    bool called = false;
+    stub.set_lamda(VADDR(DialogManager, showErrorDialog),
+                   [&called](DialogManager *, const QString &, const QString &) { called = true; });
+
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    EXPECT_TRUE(VaultEventReceiver::instance()->changeUrlEventFilter(0, url));
+    EXPECT_TRUE(called);
+}
+
+TEST_F(VaultEventReceiverImpl, HandlePathtoVirtual_Empty)
+{
+    QList<QUrl> out;
+    EXPECT_FALSE(VaultEventReceiver::instance()->handlePathtoVirtual({}, &out));
+}
+
+TEST_F(VaultEventReceiverImpl, HandlePathtoVirtual_VaultFiles)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    QList<QUrl> out;
+    EXPECT_TRUE(VaultEventReceiver::instance()->handlePathtoVirtual({ vaultUrl }, &out));
+    EXPECT_FALSE(out.isEmpty());
+}
+
+TEST_F(VaultEventReceiverImpl, DetailViewIcon_RootUrl)
+{
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    QString iconName;
+    EXPECT_TRUE(VaultEventReceiver::instance()->detailViewIcon(url, &iconName));
+    EXPECT_EQ(iconName, QString("drive-harddisk-encrypted"));
+}
+
+TEST_F(VaultEventReceiverImpl, DetailViewIcon_NonRoot)
+{
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/foo");
+    QString iconName;
+    EXPECT_FALSE(VaultEventReceiver::instance()->detailViewIcon(url, &iconName));
+}
+
+TEST_F(VaultEventReceiverImpl, FileDropHandleWithAction_ToVault)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    QUrl localUrl = QUrl::fromLocalFile("/tmp/foo");
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(VaultEventReceiver::instance()->fileDropHandleWithAction({ localUrl }, vaultUrl, &action));
+    EXPECT_EQ(action, Qt::CopyAction);
+}
+
+TEST_F(VaultEventReceiverImpl, HandlePermissionViewAsh_VaultFile)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    bool isAsh = false;
+    EXPECT_TRUE(VaultEventReceiver::instance()->handlePermissionViewAsh(vaultUrl, &isAsh));
+    EXPECT_TRUE(isAsh);
+}
+
+TEST_F(VaultEventReceiverImpl, HandlePermissionViewAsh_NonVaultFile)
+{
+    bool isAsh = false;
+    EXPECT_FALSE(VaultEventReceiver::instance()->handlePermissionViewAsh(QUrl::fromLocalFile("/tmp/foo"), &isAsh));
+}
+
+TEST_F(VaultEventReceiverImpl, HandleFileCanTaged_VaultUrl)
+{
+    QUrl vaultUrl;
+    vaultUrl.setScheme("dfmvault");
+    vaultUrl.setPath("/");
+    bool canTag = true;
+    EXPECT_TRUE(VaultEventReceiver::instance()->handleFileCanTaged(vaultUrl, &canTag));
+    EXPECT_FALSE(canTag);
+}
+
+TEST_F(VaultEventReceiverImpl, HandleFileCanTaged_NonVaultUrl)
+{
+    bool canTag = true;
+    EXPECT_FALSE(VaultEventReceiver::instance()->handleFileCanTaged(QUrl::fromLocalFile("/tmp/foo"), &canTag));
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaultfilehelper.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaultfilehelper.cpp
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QUrl>
+
+#include "stubext.h"
+
+#include "utils/vaultfilehelper.h"
+#include "utils/vaulthelper.h"
+#include "utils/pathmanager.h"
+
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
+
+DPVAULT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class VaultFileHelperImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        testFile = tempDir->path() + "/test.txt";
+        QFile f(testFile);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("hello");
+        f.close();
+
+        stub.set_lamda(&PathManager::makeVaultLocalPath, [this](const QString &, const QString &) -> QString {
+            return tempDir->path();
+        });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+    }
+
+    QUrl vaultUrlFor(const QString &path) const
+    {
+        QUrl url;
+        url.setScheme("dfmvault");
+        url.setPath(path);
+        return url;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    QString testFile;
+};
+
+TEST_F(VaultFileHelperImpl, Scheme)
+{
+    EXPECT_EQ(VaultFileHelper::scheme(), QString("dfmvault"));
+}
+
+TEST_F(VaultFileHelperImpl, CutFile_WrongTargetScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl target = QUrl::fromLocalFile(testFile);
+    EXPECT_FALSE(h->cutFile(0, {}, target, {}));
+}
+
+TEST_F(VaultFileHelperImpl, CutFile_VaultTarget)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl target = vaultUrlFor(tempDir->path());
+    EXPECT_TRUE(h->cutFile(0, {}, target, {}));
+}
+
+TEST_F(VaultFileHelperImpl, CopyFile_WrongTargetScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl target = QUrl::fromLocalFile(testFile);
+    EXPECT_FALSE(h->copyFile(0, {}, target, {}));
+}
+
+TEST_F(VaultFileHelperImpl, CopyFile_VaultTarget)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl target = vaultUrlFor(tempDir->path());
+    EXPECT_TRUE(h->copyFile(0, {}, target, {}));
+}
+
+TEST_F(VaultFileHelperImpl, MoveToTrash_EmptySources)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    EXPECT_FALSE(h->moveToTrash(0, {}, {}));
+}
+
+TEST_F(VaultFileHelperImpl, MoveToTrash_NonVaultSource)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> sources = { QUrl::fromLocalFile("/etc/passwd") };
+    EXPECT_FALSE(h->moveToTrash(0, sources, {}));
+}
+
+TEST_F(VaultFileHelperImpl, MoveToTrash_VaultSource)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> sources = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->moveToTrash(0, sources, {}));
+}
+
+TEST_F(VaultFileHelperImpl, DeleteFile_EmptySources)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    EXPECT_FALSE(h->deleteFile(0, {}, {}));
+}
+
+TEST_F(VaultFileHelperImpl, DeleteFile_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> sources = { QUrl::fromLocalFile(testFile) };
+    EXPECT_FALSE(h->deleteFile(0, sources, {}));
+}
+
+TEST_F(VaultFileHelperImpl, DeleteFile_VaultSource)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> sources = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->deleteFile(0, sources, {}));
+}
+
+TEST_F(VaultFileHelperImpl, OpenFileInPlugin_Empty)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    EXPECT_FALSE(h->openFileInPlugin(0, {}));
+}
+
+TEST_F(VaultFileHelperImpl, OpenFileInPlugin_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { QUrl::fromLocalFile(testFile) };
+    EXPECT_FALSE(h->openFileInPlugin(0, urls));
+}
+
+TEST_F(VaultFileHelperImpl, OpenFileInPlugin_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->openFileInPlugin(0, urls));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFile_WrongOldScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl oldUrl = QUrl::fromLocalFile(testFile);
+    QUrl newUrl = vaultUrlFor(tempDir->path() + "/new.txt");
+    EXPECT_FALSE(h->renameFile(0, oldUrl, newUrl, {}));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFile_VaultUrls)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl oldUrl = vaultUrlFor(testFile);
+    QUrl newUrl = vaultUrlFor(tempDir->path() + "/new.txt");
+    EXPECT_TRUE(h->renameFile(0, oldUrl, newUrl, {}));
+}
+
+TEST_F(VaultFileHelperImpl, MakeDir_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/dir");
+    EXPECT_FALSE(h->makeDir(0, url, {}, {}, nullptr));
+}
+
+TEST_F(VaultFileHelperImpl, MakeDir_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = vaultUrlFor(tempDir->path() + "/dir");
+    EXPECT_TRUE(h->makeDir(0, url, {}, QVariant(), nullptr));
+}
+
+TEST_F(VaultFileHelperImpl, TouchFile_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/file");
+    EXPECT_FALSE(h->touchFile(0, url, {}, DFMGLOBAL_NAMESPACE::CreateFileType::kCreateFileTypeText, "", {}, nullptr, nullptr));
+}
+
+TEST_F(VaultFileHelperImpl, TouchFile_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = vaultUrlFor(tempDir->path() + "/file");
+    bool called = false;
+    auto cb = [&called](const AbstractJobHandler::CallbackArgus &) { called = true; };
+    EXPECT_TRUE(h->touchFile(0, url, {}, DFMGLOBAL_NAMESPACE::CreateFileType::kCreateFileTypeText, "txt", {}, cb, nullptr));
+    EXPECT_TRUE(called);
+}
+
+TEST_F(VaultFileHelperImpl, TouchCustomFile_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = QUrl::fromLocalFile(tempDir->path() + "/file");
+    EXPECT_FALSE(h->touchCustomFile(0, url, {}, {}, "txt", {}, nullptr, nullptr));
+}
+
+TEST_F(VaultFileHelperImpl, TouchCustomFile_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = vaultUrlFor(tempDir->path() + "/file");
+    bool called = false;
+    auto cb = [&called](const AbstractJobHandler::CallbackArgus &) { called = true; };
+    EXPECT_TRUE(h->touchCustomFile(0, url, {}, {}, "txt", {}, cb, nullptr));
+    EXPECT_TRUE(called);
+}
+
+TEST_F(VaultFileHelperImpl, WriteUrlsToClipboard_Empty)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    EXPECT_FALSE(h->writeUrlsToClipboard(0, ClipBoard::kCopyAction, {}));
+}
+
+TEST_F(VaultFileHelperImpl, WriteUrlsToClipboard_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { QUrl::fromLocalFile(testFile) };
+    EXPECT_FALSE(h->writeUrlsToClipboard(0, ClipBoard::kCopyAction, urls));
+}
+
+TEST_F(VaultFileHelperImpl, WriteUrlsToClipboard_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->writeUrlsToClipboard(0, ClipBoard::kCopyAction, urls));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFiles_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { QUrl::fromLocalFile(testFile) };
+    EXPECT_FALSE(h->renameFiles(0, urls, {}, false));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFiles_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->renameFiles(0, urls, { "a", "b" }, false));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFilesAddText_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { QUrl::fromLocalFile(testFile) };
+    EXPECT_FALSE(h->renameFilesAddText(0, urls, { "a", AbstractJobHandler::FileNameAddFlag::kPrefix }));
+}
+
+TEST_F(VaultFileHelperImpl, RenameFilesAddText_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QList<QUrl> urls = { vaultUrlFor(testFile) };
+    EXPECT_TRUE(h->renameFilesAddText(0, urls, { "a", AbstractJobHandler::FileNameAddFlag::kPrefix }));
+}
+
+TEST_F(VaultFileHelperImpl, CheckDragDropAction_Move)
+{
+    stub.set_lamda(&WindowUtils::keyAltIsPressed, []() -> bool { return true; });
+    stub.set_lamda(&WindowUtils::keyCtrlIsPressed, []() -> bool { return false; });
+
+    VaultFileHelper *h = VaultFileHelper::instance();
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(h->checkDragDropAction({ vaultUrlFor(testFile) }, vaultUrlFor(tempDir->path()), &action));
+    EXPECT_EQ(action, Qt::MoveAction);
+}
+
+TEST_F(VaultFileHelperImpl, CheckDragDropAction_Copy)
+{
+    stub.set_lamda(&WindowUtils::keyAltIsPressed, []() -> bool { return false; });
+    stub.set_lamda(&WindowUtils::keyCtrlIsPressed, []() -> bool { return true; });
+
+    VaultFileHelper *h = VaultFileHelper::instance();
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(h->checkDragDropAction({ vaultUrlFor(testFile) }, vaultUrlFor(tempDir->path()), &action));
+    EXPECT_EQ(action, Qt::CopyAction);
+}
+
+TEST_F(VaultFileHelperImpl, CheckDragDropAction_DefaultVaultToVault)
+{
+    stub.set_lamda(&WindowUtils::keyAltIsPressed, []() -> bool { return false; });
+    stub.set_lamda(&WindowUtils::keyCtrlIsPressed, []() -> bool { return false; });
+
+    VaultFileHelper *h = VaultFileHelper::instance();
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(h->checkDragDropAction({ vaultUrlFor(testFile) }, vaultUrlFor(tempDir->path()), &action));
+    EXPECT_EQ(action, Qt::MoveAction);
+}
+
+TEST_F(VaultFileHelperImpl, CheckDragDropAction_DefaultInOut)
+{
+    stub.set_lamda(&WindowUtils::keyAltIsPressed, []() -> bool { return false; });
+    stub.set_lamda(&WindowUtils::keyCtrlIsPressed, []() -> bool { return false; });
+
+    VaultFileHelper *h = VaultFileHelper::instance();
+    Qt::DropAction action = Qt::IgnoreAction;
+    EXPECT_TRUE(h->checkDragDropAction({ QUrl::fromLocalFile("/etc/passwd") }, vaultUrlFor(tempDir->path()), &action));
+    EXPECT_EQ(action, Qt::CopyAction);
+}
+
+TEST_F(VaultFileHelperImpl, HandleDropFiles_Move)
+{
+    stub.set_lamda(&WindowUtils::keyAltIsPressed, []() -> bool { return true; });
+    stub.set_lamda(&WindowUtils::keyCtrlIsPressed, []() -> bool { return false; });
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [](const QList<QUrl> &, QList<QUrl> *out) -> bool {
+        if (out)
+            *out << QUrl::fromLocalFile("/tmp/transformed");
+        return true;
+    });
+
+    VaultFileHelper *h = VaultFileHelper::instance();
+    EXPECT_TRUE(h->handleDropFiles({ vaultUrlFor(testFile) }, vaultUrlFor(tempDir->path())));
+}
+
+TEST_F(VaultFileHelperImpl, SetPermision_WrongScheme)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = QUrl::fromLocalFile(testFile);
+    bool ok = false;
+    QString error;
+    EXPECT_FALSE(h->setPermision(0, url, QFileDevice::ReadOwner, &ok, &error));
+}
+
+TEST_F(VaultFileHelperImpl, SetPermision_VaultUrl)
+{
+    VaultFileHelper *h = VaultFileHelper::instance();
+    QUrl url = vaultUrlFor(testFile);
+    bool ok = false;
+    QString error;
+    EXPECT_TRUE(h->setPermision(0, url, QFileDevice::ReadOwner, &ok, &error));
+    EXPECT_TRUE(ok);
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaultfileinfo_real2.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaultfileinfo_real2.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include "stubext.h"
+
+#include "fileutils/vaultfileinfo.h"
+#include "utils/vaulthelper.h"
+#include "utils/pathmanager.h"
+#include "utils/fileencrypthandle.h"
+
+#include <dfm-io/dfmio_utils.h>
+
+DPVAULT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+static QString gVaultBaseTemp;
+
+QString fakeBuildFilePath(const char *segment, ...)
+{
+    QStringList segs;
+    if (segment) {
+        QString first(segment);
+        if (!gVaultBaseTemp.isEmpty() && first == QDir::homePath() + QString("/.config/Vault")) {
+            first = gVaultBaseTemp;
+        }
+        segs << first;
+    }
+
+    va_list args;
+    va_start(args, segment);
+    const char *arg = nullptr;
+    while ((arg = va_arg(args, const char *)) != nullptr) {
+        segs << QString(arg);
+    }
+    va_end(args);
+
+    QString path;
+    for (const QString &s : segs) {
+        QString part = s;
+        while (part.endsWith('/')) {
+            part.chop(1);
+        }
+        if (part.isEmpty() || part == "/")
+            continue;
+        if (path.isEmpty()) {
+            path = part;
+        } else {
+            path += QDir::separator() + part;
+        }
+    }
+    if (segs.isEmpty())
+        return QString();
+    if (segs.first().startsWith("/"))
+        path = QString("/") + path;
+    return path;
+}
+
+class VaultFileInfoReal2 : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        tempDir.reset(new QTemporaryDir);
+        ASSERT_TRUE(tempDir->isValid());
+        gVaultBaseTemp = tempDir->path();
+
+        // Note: buildFilePath is a C-style variadic function and cannot be stubbed
+        // via stub_ext. Instead, VaultFileInfo operations will use real temp paths.
+
+        using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+        stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                       [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kEncrypted; });
+
+        // Redirect vault URLs to the temp dir so InfoFactory can create a real
+        // proxy FileInfo for the underlying local file.
+        stub.set_lamda(&VaultHelper::vaultToLocalUrl, [](const QUrl &url) -> QUrl {
+            return QUrl::fromLocalFile(gVaultBaseTemp + url.path());
+        });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+        gVaultBaseTemp.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+};
+
+TEST_F(VaultFileInfoReal2, RefreshAndExtendAttributes)
+{
+    QTemporaryFile tmpFile(tempDir->path() + "/XXXXXX.txt");
+    ASSERT_TRUE(tmpFile.open());
+    tmpFile.close();
+
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/" + QFileInfo(tmpFile.fileName()).fileName());
+
+    VaultFileInfo info(url);
+    info.refresh();
+    EXPECT_FALSE(info.extendAttributes(ExtInfoType::kSizeFormat).isNull());
+}
+
+TEST_F(VaultFileInfoReal2, ExtraPropertiesAndViewTip)
+{
+    QTemporaryDir subDir(tempDir->path() + "/sub");
+    ASSERT_TRUE(subDir.isValid());
+
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/sub");
+
+    VaultFileInfo info(url);
+    EXPECT_NO_THROW(info.extraProperties());
+    EXPECT_NO_THROW(info.viewOfTip(FileInfo::ViewType::kEmptyDir));
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaulthelper.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaulthelper.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QUrl>
+
+#include "stubext.h"
+
+#include "utils/vaulthelper.h"
+#include "utils/pathmanager.h"
+#include "utils/fileencrypthandle.h"
+#include "utils/vaultautolock.h"
+#include "dbus/vaultdbusutils.h"
+#include "utils/encryption/operatorcenter.h"
+#include "utils/encryption/vaultconfig.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+
+#include <dfm-framework/event/event.h>
+
+DPVAULT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class VaultHelperImpl : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        VaultHelper::instance()->removeWinID(42);
+        VaultHelper::instance()->removeWinID(43);
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        VaultHelper::instance()->removeWinID(42);
+        VaultHelper::instance()->removeWinID(43);
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(VaultHelperImpl, Scheme)
+{
+    VaultHelper *h = VaultHelper::instance();
+    EXPECT_EQ(h->scheme(), QString("dfmvault"));
+}
+
+TEST_F(VaultHelperImpl, RootUrl)
+{
+    QUrl url = VaultHelper::instance()->rootUrl();
+    EXPECT_EQ(url.scheme(), QString("dfmvault"));
+    EXPECT_EQ(url.path(), QString("/"));
+}
+
+TEST_F(VaultHelperImpl, SourceRootUrl)
+{
+    stub.set_lamda(&PathManager::makeVaultLocalPath, [](const QString &, const QString &) -> QString {
+        return QString("/tmp/vault_unlocked");
+    });
+
+    QUrl url = VaultHelper::instance()->sourceRootUrl();
+    EXPECT_EQ(url.scheme(), QString("dfmvault"));
+    EXPECT_EQ(url.path(), QString("/tmp/vault_unlocked"));
+}
+
+TEST_F(VaultHelperImpl, SourceRootUrlWithSlash)
+{
+    stub.set_lamda(&PathManager::makeVaultLocalPath, [](const QString &, const QString &) -> QString {
+        return QString("/tmp/vault_unlocked");
+    });
+    stub.set_lamda(&PathManager::addPathSlash, [](const QString &) -> QString {
+        return QString("/tmp/vault_unlocked/");
+    });
+
+    QUrl url = VaultHelper::instance()->sourceRootUrlWithSlash();
+    EXPECT_EQ(url.path(), QString("/tmp/vault_unlocked/"));
+}
+
+TEST_F(VaultHelperImpl, PathToVaultVirtualUrl_MatchesSourceRoot)
+{
+    QUrl source = VaultHelper::instance()->sourceRootUrl();
+    QString local = source.path();
+    QUrl virtualUrl = VaultHelper::instance()->pathToVaultVirtualUrl(local);
+    EXPECT_EQ(virtualUrl.path(), QString("/"));
+    EXPECT_EQ(virtualUrl.scheme(), QString("dfmvault"));
+}
+
+TEST_F(VaultHelperImpl, PathToVaultVirtualUrl_ChildPath)
+{
+    QUrl source = VaultHelper::instance()->sourceRootUrl();
+    QString child = source.path() + "/foo/bar.txt";
+    QUrl virtualUrl = VaultHelper::instance()->pathToVaultVirtualUrl(child);
+    EXPECT_EQ(virtualUrl.path(), QString("/foo/bar.txt"));
+}
+
+TEST_F(VaultHelperImpl, PathToVaultVirtualUrl_NoMatch)
+{
+    QUrl virtualUrl = VaultHelper::instance()->pathToVaultVirtualUrl("/tmp/other");
+    EXPECT_TRUE(virtualUrl.isEmpty());
+}
+
+TEST_F(VaultHelperImpl, VaultToLocalUrl_FileScheme)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/foo.txt");
+    QUrl local = VaultHelper::vaultToLocalUrl(fileUrl);
+    EXPECT_EQ(local, fileUrl);
+}
+
+TEST_F(VaultHelperImpl, VaultToLocalUrl_WrongScheme)
+{
+    QUrl wrong;
+    wrong.setScheme("http");
+    wrong.setPath("/tmp/foo.txt");
+    QUrl local = VaultHelper::vaultToLocalUrl(wrong);
+    EXPECT_TRUE(local.isEmpty());
+}
+
+TEST_F(VaultHelperImpl, IsVaultFile_ByScheme)
+{
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    EXPECT_TRUE(VaultHelper::isVaultFile(url));
+}
+
+TEST_F(VaultHelperImpl, UrlsToLocal_NullOutput)
+{
+    QUrl url;
+    url.setScheme("dfmvault");
+    url.setPath("/");
+    EXPECT_FALSE(VaultHelper::instance()->urlsToLocal({ url }, nullptr));
+}
+
+TEST_F(VaultHelperImpl, UrlsToLocal_FileSchemePath)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/foo.txt");
+    QList<QUrl> out;
+    // The source URL is not a vault URL, so it returns false.
+    EXPECT_FALSE(VaultHelper::instance()->urlsToLocal({ fileUrl }, &out));
+}
+
+TEST_F(VaultHelperImpl, CurrentAndWinIDs)
+{
+    VaultHelper *h = VaultHelper::instance();
+    h->appendWinID(42);
+    EXPECT_EQ(h->currentWindowId(), 42u);
+    h->appendWinID(43);
+    EXPECT_EQ(h->currentWindowId(), 43u);
+    h->removeWinID(42);
+    EXPECT_EQ(h->currentWindowId(), 43u);
+    h->removeWinID(43);
+    // removeWinID does not modify currentWinID; it only removes from the list.
+    EXPECT_TRUE(h->currentWindowId() == 43u);
+}
+
+TEST_F(VaultHelperImpl, State_DelegatesToFileEncryptHandle)
+{
+    using StateFunc = VaultState (FileEncryptHandle::*)(const QString &, bool) const;
+    stub.set_lamda(static_cast<StateFunc>(&FileEncryptHandle::state),
+                   [](FileEncryptHandle *, const QString &, bool) -> VaultState { return kUnlocked; });
+
+    EXPECT_EQ(VaultHelper::instance()->state("/tmp"), kUnlocked);
+}
+
+TEST_F(VaultHelperImpl, UpdateState)
+{
+    using UpdateFunc = bool (FileEncryptHandle::*)(VaultState);
+    stub.set_lamda(static_cast<UpdateFunc>(&FileEncryptHandle::updateState),
+                   [](FileEncryptHandle *, VaultState) -> bool { return true; });
+
+    EXPECT_TRUE(VaultHelper::instance()->updateState(kUnlocked));
+}
+
+TEST_F(VaultHelperImpl, EnableUnlockVault_ConfigTrue)
+{
+    using ValueFunc = QVariant (DConfigManager::*)(const QString &, const QString &, const QVariant &) const;
+    stub.set_lamda(static_cast<ValueFunc>(&DConfigManager::value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       return QVariant(true);
+                   });
+
+    EXPECT_TRUE(VaultHelper::instance()->enableUnlockVault());
+}
+
+TEST_F(VaultHelperImpl, EnableUnlockVault_ConfigFalseNoNet)
+{
+    using ValueFunc = QVariant (DConfigManager::*)(const QString &, const QString &, const QVariant &) const;
+    stub.set_lamda(static_cast<ValueFunc>(&DConfigManager::value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       return QVariant(false);
+                   });
+    stub.set_lamda(&VaultDBusUtils::isFullConnectInternet, []() -> bool { return false; });
+
+    EXPECT_TRUE(VaultHelper::instance()->enableUnlockVault());
+}
+
+TEST_F(VaultHelperImpl, EnableUnlockVault_ConfigFalseWithNet)
+{
+    using ValueFunc = QVariant (DConfigManager::*)(const QString &, const QString &, const QVariant &) const;
+    stub.set_lamda(static_cast<ValueFunc>(&DConfigManager::value),
+                   [](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+                       return QVariant(false);
+                   });
+    stub.set_lamda(&VaultDBusUtils::isFullConnectInternet, []() -> bool { return true; });
+
+    EXPECT_FALSE(VaultHelper::instance()->enableUnlockVault());
+}
+
+TEST_F(VaultHelperImpl, SlotLockVault_EmitsLocked)
+{
+    VaultHelper *h = VaultHelper::instance();
+    h->appendWinID(42);
+    QSignalSpy spy(h, &VaultHelper::sigLocked);
+
+    h->slotlockVault(0);
+    EXPECT_EQ(spy.count(), 1);
+    h->removeWinID(42);
+}
+
+TEST_F(VaultHelperImpl, GetVaultVersion)
+{
+    VaultConfig config;
+    config.set(kConfigNodeName, kConfigKeyVersion, QVariant("1050"));
+
+    EXPECT_TRUE(VaultHelper::instance()->getVaultVersion());
+}
+
+TEST_F(VaultHelperImpl, CreateVault_DelegatesToFileEncryptHandle)
+{
+    QString password = "password";
+    using CreateFunc = void (FileEncryptHandle::*)(const QString &, const QString &, const QString &, EncryptType, int);
+    bool called = false;
+    stub.set_lamda(static_cast<CreateFunc>(&FileEncryptHandle::createVault),
+                   [&called](FileEncryptHandle *, const QString &, const QString &, const QString &, EncryptType, int) {
+                       called = true;
+                   });
+    stub.set_lamda(&PathManager::makeVaultLocalPath, [](const QString &, const QString &) -> QString {
+        return QString("/tmp/vault");
+    });
+
+    VaultHelper::instance()->createVault(password);
+    EXPECT_TRUE(called);
+}
+
+TEST_F(VaultHelperImpl, UnlockVault_DelegatesToFileEncryptHandle)
+{
+    using UnlockFunc = bool (FileEncryptHandle::*)(const QString &, const QString &, const QString &);
+    stub.set_lamda(static_cast<UnlockFunc>(&FileEncryptHandle::unlockVault),
+                   [](FileEncryptHandle *, const QString &, const QString &, const QString &) -> bool { return true; });
+    stub.set_lamda(&PathManager::makeVaultLocalPath, [](const QString &, const QString &) -> QString {
+        return QString("/tmp/vault");
+    });
+
+    EXPECT_TRUE(VaultHelper::instance()->unlockVault("password"));
+}
+
+TEST_F(VaultHelperImpl, LockVault_DelegatesToFileEncryptHandle)
+{
+    using LockFunc = bool (FileEncryptHandle::*)(QString, bool);
+    stub.set_lamda(static_cast<LockFunc>(&FileEncryptHandle::lockVault),
+                   [](FileEncryptHandle *, QString, bool) -> bool { return true; });
+
+    EXPECT_TRUE(VaultHelper::instance()->lockVault(false));
+}
+
+TEST_F(VaultHelperImpl, OpenWidWindow)
+{
+    VaultHelper::instance()->appendWinID(100);
+    VaultHelper::instance()->openWidWindow(100, QUrl("dfmvault:///"));
+    SUCCEED();
+}
+
+TEST_F(VaultHelperImpl, DefaultCdAction)
+{
+    VaultHelper::instance()->defaultCdAction(100, QUrl("dfmvault:///"));
+    SUCCEED();
+}
+
+TEST_F(VaultHelperImpl, ShowInProgressDialog_Busy)
+{
+    using DialogFunc = void (DialogManager::*)(const QString &, const QString &);
+    bool called = false;
+    stub.set_lamda(VADDR(DialogManager, showErrorDialog),
+                   [&called](DialogManager *, const QString &, const QString &) { called = true; });
+
+    VaultHelper::instance()->showInProgressDailog("Device or resource busy");
+    EXPECT_TRUE(called);
+}

--- a/autotests/plugins/dfmplugin-vault/test_vaultremovebyrecoverykeyview.cpp
+++ b/autotests/plugins/dfmplugin-vault/test_vaultremovebyrecoverykeyview.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QString>
+#include <QStringList>
+
+#include "stubext.h"
+
+#include "views/removevaultview/vaultremovebyrecoverykeyview.h"
+
+DPVAULT_USE_NAMESPACE
+
+class VaultRemoveByRecoverykeyViewTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        view = new VaultRemoveByRecoverykeyView();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        delete view;
+    }
+
+    VaultRemoveByRecoverykeyView *view = nullptr;
+};
+
+// --- construction ---
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, Constructor_CreatesView)
+{
+    EXPECT_NE(view, nullptr);
+}
+
+// --- btnText ---
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, BtnText_ReturnsTwoButtons)
+{
+    QStringList btns = view->btnText();
+    EXPECT_EQ(btns.size(), 2);
+}
+
+// --- titleText ---
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, TitleText_ReturnsNonEmpty)
+{
+    QString title = view->titleText();
+    EXPECT_FALSE(title.isEmpty());
+}
+
+// --- getRecoverykey ---
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, GetRecoverykey_DefaultEmpty)
+{
+    EXPECT_TRUE(view->getRecoverykey().isEmpty());
+}
+
+// --- onRecoveryKeyChanged (crashes due to afterRecoveryKeyChanged heavy deps, excluded) ---
+
+// --- showAlertMessage ---
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, ShowAlertMessage_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->showAlertMessage("test message", 100));
+}
+
+TEST_F(VaultRemoveByRecoverykeyViewTest, ShowAlertMessage_PersistentDisplay_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->showAlertMessage("persistent", -1));
+}


### PR DESCRIPTION
Add a new test binary for the vault plugin, covering unlock views,
operator center, config and vault events.

为保险箱插件新增测试二进制，覆盖解锁视图、操作中心、配置
与保险箱事件。

Log: 新增 dfmplugin-vault 单元测试
Influence: 仅新增测试代码，不影响功能。

---
Verified via `autotests/run-ut.sh` full build with all module commits applied: 41/41 test binaries pass.

## Summary by Sourcery

Expand automated unit-test coverage for the vault plugin across its views, encryption configuration, file and URL helpers, operator workflows, and event handling.

Build:
- Add CMake configuration for building the dfmplugin-vault unit-test binary with the plugin’s dependencies and include paths.

Tests:
- Add unit coverage for vault unlock and removal views, operator-center behavior, vault configuration, helper and file operations, file metadata, service-manager view fields, and vault event handling.
- Add an integration-style event initialization test exercising the vault event subscriptions with production event wiring.