### PR TITLE
[AT] dde-file-manager AT-SPI 测试套件（100 条用例）

### DIFF
--- a/tests/at/yaml/bug转用例场景/bug转用例场景.suite.yaml
+++ b/tests/at/yaml/bug转用例场景/bug转用例场景.suite.yaml
@@ -148,5 +148,35 @@ suites:
   assert_steps:
   - action: assert_process_running
     app: dde-file-manager
+- id: case_bug_sidebar_music
+  name: 侧边栏导航-音乐
+  description: '验证侧边栏"音乐"导航项存在并可点击'
+  tags: []
+  steps:
+  - action: session_start
+    command: dde-file-manager --open-home
+    wait: 5.0
+  - action: element_action
+    ref: 音乐
+    do: click
+    wait: 1.0
+  assert_steps:
+  - action: assert_element
+    ref: 音乐
+- id: case_bug_sidebar_pictures
+  name: 侧边栏导航-图片
+  description: '验证侧边栏"图片"导航项存在并可点击'
+  tags: []
+  steps:
+  - action: session_start
+    command: dde-file-manager --open-home
+    wait: 5.0
+  - action: element_action
+    ref: 图片
+    do: click
+    wait: 1.0
+  assert_steps:
+  - action: assert_element
+    ref: 图片
 teardown:
 - action: session_stop

--- a/tests/at/yaml/common/common.suite.yaml
+++ b/tests/at/yaml/common/common.suite.yaml
@@ -582,5 +582,338 @@ suites:
     action: assert_window
     selector:
       name: dde-file-manager
+- id: suite_common_013_s1
+  name: 光盘烧录高级选项与镜像转储
+  description: 验证 PbBurn/PbDump/VolnameEdit/WritespeedComb/FsComb/FinalizeDiscCheckbox 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: VolnameEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: WritespeedComb
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: FsComb
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: FinalizeDiscCheckbox
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: PbBurn
+      role: push button
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: PbDump
+      role: push button
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: VolnameEdit
+      role: text
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PbBurn
+      role: push button
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PbDump
+      role: push button
+- id: suite_common_014_s1
+  name: 文件属性对话框隐藏文件与告警提示
+  description: 验证 HideFile/HideFile_2/AlertTooltip/PropertyDialog-QScrollArea 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: HideFile
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: HideFile_2
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: PropertyDialog-QScrollArea
+      role: scroll pane
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: HideFile
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PropertyDialog-QScrollArea
+      role: scroll pane
+- id: suite_common_015_s1
+  name: 文件属性权限管理控件
+  description: 验证 ExecutableCheckBox/OwnerComboBox/GroupComboBox/OtherComboBox/NameEditIcon 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ExecutableCheckBox
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: OwnerComboBox
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: GroupComboBox
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: OtherComboBox
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: NameEditIcon
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ExecutableCheckBox
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: OwnerComboBox
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: NameEditIcon
+- id: suite_common_016_s1
+  name: 打开方式对话框列表与默认设置
+  description: 验证 OpenWithListWidget/OpenWithBtnGroup/OpenFileChooseButton/SetToDefaultCheckBox/CancelButton/OpenWithDialog-QScrollArea 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: OpenWithListWidget
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: SetToDefaultCheckBox
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: OpenFileChooseButton
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: OpenWithDialog-QScrollArea
+      role: scroll pane
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: CancelButton
+      role: push button
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: OpenWithListWidget
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: SetToDefaultCheckBox
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CancelButton
+      role: push button
+- id: suite_common_017_s1
+  name: 文件夹共享属性设置
+  description: 验证 ShareSwitcher/ShareNameEditor/SharePermissionSelector/ShareAnonymousSelector/CopyNetAddr/CopyUserNameBt/SetPasswordBt/DevicesListView 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ShareSwitcher
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: ShareNameEditor
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: SharePermissionSelector
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: ShareAnonymousSelector
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: CopyNetAddr
+      role: push button
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: CopyUserNameBt
+      role: push button
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: SetPasswordBt
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: DevicesListView
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ShareSwitcher
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ShareNameEditor
+      role: text
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: DevicesListView
+- id: suite_common_018_s1
+  name: 文件标签信息展示控件
+  description: 验证 TagLable/TagLeftLable/ToolTip 控件可定位
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: TagLable
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: TagLeftLable
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TagLable
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TagLeftLable
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ToolTip
+- id: suite_common_019_s1
+  name: 预览窗口关闭按钮与状态栏
+  description: 验证 CloseBtn/StatusBar/IconButton 控件交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: CloseBtn
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: IconButton
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: StatusBar
+      role: status bar
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CloseBtn
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: IconButton
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: StatusBar
+      role: status bar
+- id: suite_common_020_s1
+  name: 属性对话框面包屑导航
+  description: 验证 CrumbEdit/Edit_2 控件交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: CrumbEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: Edit_2
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CrumbEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: Edit_2
 teardown:
 - action: session_stop

--- a/tests/at/yaml/dde_file_manager_preview/dde_file_manager_preview.suite.yaml
+++ b/tests/at/yaml/dde_file_manager_preview/dde_file_manager_preview.suite.yaml
@@ -366,5 +366,239 @@ suites:
     selector:
       name: ThemeCom
       role: combo box
+- id: suite_dde_file_manager_preview_008_s1
+  name: 视频预览播放控制与进度滑块
+  description: 验证 Slider_2/ControlButton 视频预览交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: Slider_2
+      role: slider
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ControlButton
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: Slider_2
+      role: slider
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ControlButton
+- id: suite_dde_file_manager_preview_009_s1
+  name: PDF 预览翻页与缩略图列表
+  description: 验证 Nextbutton/ItemViewParent/View_ImageList 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: Nextbutton
+      role: push button
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: View_ImageList
+      role: list
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ItemViewParent
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: Nextbutton
+      role: push button
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: View_ImageList
+      role: list
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ItemViewParent
+- id: suite_dde_file_manager_preview_010_s1
+  name: 音乐预览信息与播放控制
+  description: 验证 ArtistLabel/AlbumLabel/ArtistValue/AlbumValue/PlayControlButton/ProgressSlider 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ArtistLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: AlbumLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ArtistValue
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: AlbumValue
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: PlayControlButton
+      role: push button
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: ProgressSlider
+      role: slider
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ArtistLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PlayControlButton
+      role: push button
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ProgressSlider
+      role: slider
+- id: suite_dde_file_manager_preview_011_s1
+  name: DCI 图标预览调色板与尺寸设置
+  description: 验证 AvailableSizeCombo/ForegroundPaletteEdit/BackgroundPaletteEdit/HightlightPaletteEdit/HFpaletteEdit/ThemeCom/ModeCom/CustomSizeEdit 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: AvailableSizeCombo
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: CustomSizeEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ForegroundPaletteEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BackgroundPaletteEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: HightlightPaletteEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: HFpaletteEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ThemeCom
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: ModeCom
+      role: combo box
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: AvailableSizeCombo
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ThemeCom
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ModeCom
+      role: combo box
+- id: suite_dde_file_manager_preview_012_s1
+  name: 未知文件预览信息展示
+  description: 验证 IconLabel/NameLabel/SizeLabel/TypeLabel 信息展示
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: IconLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: NameLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: SizeLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: TypeLabel
+      role: label
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: IconLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: NameLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: SizeLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TypeLabel
+      role: label
 teardown:
 - action: session_stop

--- a/tests/at/yaml/dialogs/dialogs.suite.yaml
+++ b/tests/at/yaml/dialogs/dialogs.suite.yaml
@@ -148,5 +148,180 @@ suites:
     action: assert_element
     selector:
       name: PasswordEdit_2
+- id: suite_dialogs_005_s1
+  name: 网络挂载认证对话框用户输入
+  description: 验证 AnonymousButton/RegisterButton/UsernameLineEdit/DomainLineEdit 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: AnonymousButton
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: RegisterButton
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: UsernameLineEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: DomainLineEdit
+      role: text
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: AnonymousButton
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: RegisterButton
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: UsernameLineEdit
+      role: text
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: DomainLineEdit
+      role: text
+- id: suite_dialogs_006_s1
+  name: 挂载密码对话框密码选项
+  description: 验证 PasswordCheckBox/PasswordButtonGroup/PasswordEdit_2 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordCheckBox
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordEdit_2
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordCheckBox
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordEdit_2
+- id: suite_dialogs_007_s1
+  name: 文件冲突确认对话框
+  description: 验证 ChkboxNotAskAgain/BtnCoexist/BtnSkip/BtnReplace/BtnDelete 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ChkboxNotAskAgain
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnCoexist
+      role: push button
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnSkip
+      role: push button
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnReplace
+      role: push button
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnDelete
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ChkboxNotAskAgain
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: BtnCoexist
+      role: push button
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: BtnDelete
+- id: suite_dialogs_008_s1
+  name: 批量操作进度对话框
+  description: 验证 TaskListWidget/BtnStop/BtnPause 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: TaskListWidget
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnPause
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: BtnStop
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TaskListWidget
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: BtnStop
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: BtnPause
+- id: suite_dialogs_009_s1
+  name: SMB 共享密码设置对话框
+  description: 验证 PasswordLineEdit/PasswordCheckBox 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordLineEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordCheckBox
+      role: check box
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordLineEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordCheckBox
+      role: check box
 teardown:
 - action: session_stop

--- a/tests/at/yaml/filedialog/filedialog.suite.yaml
+++ b/tests/at/yaml/filedialog/filedialog.suite.yaml
@@ -115,5 +115,95 @@ suites:
     selector:
       name: CurRejectButton
       role: push button
+- id: suite_filedialog_003_s1
+  name: 文件对话框标签信息
+  description: 验证 TitleLabel/FileNameLabel/FiltersLabel 标签控件
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: TitleLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: FileNameLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: FiltersLabel
+      role: label
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TitleLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: FileNameLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: FiltersLabel
+      role: label
+- id: suite_filedialog_004_s1
+  name: 文件对话框输入与过滤
+  description: 验证 FileNameEdit/FiltersComboBox 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: FileNameEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: FiltersComboBox
+      role: combo box
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: FileNameEdit
+      role: text
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: FiltersComboBox
+      role: combo box
+- id: suite_filedialog_005_s1
+  name: 文件对话框确认与取消按钮
+  description: 验证 CurAcceptButton/CurRejectButton 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: CurAcceptButton
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: CurRejectButton
+      role: push button
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CurAcceptButton
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CurRejectButton
+      role: push button
 teardown:
 - action: session_stop

--- a/tests/at/yaml/filemanager/filemanager.suite.yaml
+++ b/tests/at/yaml/filemanager/filemanager.suite.yaml
@@ -906,5 +906,367 @@ suites:
     action: assert_element
     selector:
       name: CollectionView
+- id: suite_filemanager_017_s1
+  name: 保险箱解锁视图密码输入与提示
+  description: 验证保险箱解锁视图 PasswordEdit 和 TipsButton 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: TipsButton
+      role: push button
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TipsButton
+      role: push button
+- id: suite_filemanager_018_s1
+  name: 保险箱创建向导解锁方式选择
+  description: 验证保险箱创建向导 TypeCombo 选择与 NextBtn 导航
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: TypeCombo
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: TipsEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: NextBtn
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TypeCombo
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: NextBtn
+- id: suite_filemanager_019_s1
+  name: 保险箱创建完成视图
+  description: 验证保险箱创建完成 FinishedBtn 按钮可交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: FinishedBtn
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: FinishedBtn
+- id: suite_filemanager_020_s1
+  name: 保险箱删除视图密码与模式切换
+  description: 验证保险箱删除视图 PwdEdit 输入与 ToggleModeBtn 切换
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: PwdEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: TipsBtn
+      role: push button
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: ToggleModeBtn
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PwdEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ToggleModeBtn
+- id: suite_filemanager_021_s1
+  name: 保险箱密码重置视图
+  description: 验证保险箱密码重置 OldPasswordEdit/NewPasswordEdit/RepeatPasswordEdit 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: OldPasswordEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: NewPasswordEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: RepeatPasswordEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: PasswordHintEdit
+      role: text
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: OldPasswordEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: NewPasswordEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: RepeatPasswordEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: PasswordHintEdit
+      role: text
+- id: suite_filemanager_022_s1
+  name: 磁盘加密解锁类型与口令修改
+  description: 验证磁盘加密 ChgUnlockType 切换与 EncType/EncKeyEdit 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ChgUnlockType
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: EncType
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: EncKeyEdit1
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: EncKeyEdit2
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ChgUnlockType
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: EncType
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: EncKeyEdit1
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: EncKeyEdit2
+- id: suite_filemanager_023_s1
+  name: 标题栏标签页导航控件
+  description: 验证标题栏 AddBtn/LeftBtn/TabBar/BottomBar/Placeholder 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: AddBtn
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: LeftBtn
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: TabBar
+      role: page tab
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: BottomBar
+      role: page tab
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: Placeholder
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TabBar
+      role: page tab
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: BottomBar
+      role: page tab
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: AddBtn
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: Placeholder
+- id: suite_filemanager_024_s1
+  name: 标题栏 DPC 密码修改对话框
+  description: 验证标题栏 DPC OldPwdEdit/NewPwdEdit/RepeatPwdEdit/SaveBtn 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: OldPwdEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: NewPwdEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: RepeatPwdEdit
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: SaveBtn
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: OldPwdEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: NewPwdEdit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: SaveBtn
+- id: suite_filemanager_025_s1
+  name: 连接服务器对话框高级选项
+  description: 验证连接服务器 ServerComboBox/SchemeComboBox/TheAddButton/ComboBox 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ServerComboBox
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: SchemeComboBox
+      role: combo box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: TheAddButton
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: CollectionServerView
+      role: list
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ComboBox
+      role: combo box
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ServerComboBox
+      role: combo box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TheAddButton
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CollectionServerView
+      role: list
+- id: suite_filemanager_026_s1
+  name: 工作区缩放滑块与重命名栏
+  description: 验证工作区 ScaleSlider 滑块和 RenameBtn/RenameEditor/ScrollArea 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: ScaleSlider
+      role: slider
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: RenameBtn
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: RenameEditor
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ScrollArea
+      role: scroll pane
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ScaleSlider
+      role: slider
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: RenameBtn
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ScrollArea
+      role: scroll pane
 teardown:
 - action: session_stop

--- a/tests/at/yaml/misc_ui/misc_ui.suite.yaml
+++ b/tests/at/yaml/misc_ui/misc_ui.suite.yaml
@@ -137,5 +137,113 @@ suites:
     action: assert_element
     selector:
       name: RightValueEdit
+- id: suite_misc_ui_004_s1
+  name: 菜单与组合框控件
+  description: 验证 TextLabel/MenuPtr/ComboBox 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: TextLabel
+      role: label
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: MenuPtr
+      role: menu
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: ComboBox
+      role: combo box
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: TextLabel
+      role: label
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: MenuPtr
+      role: menu
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: ComboBox
+      role: combo box
+- id: suite_misc_ui_005_s1
+  name: 滑块快捷键与开关控件
+  description: 验证 Slider/KeyEdit/SwitchBtn 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: Slider
+      role: slider
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: KeyEdit
+      role: text
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: SwitchBtn
+    do: click
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: Slider
+      role: slider
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: KeyEdit
+      role: text
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: SwitchBtn
+- id: suite_misc_ui_006_s1
+  name: 复选框侧边栏与地址栏控件
+  description: 验证 CheckBox/Tooltip/SideBarView/AddressBar 交互
+  steps:
+  - step_type: action
+    action: element_action
+    selector:
+      name: CheckBox
+      role: check box
+    do: click
+  - step_type: action
+    action: element_action
+    selector:
+      name: SideBarView
+    do: focus
+  - step_type: action
+    action: element_action
+    selector:
+      name: AddressBar
+    do: focus
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: CheckBox
+      role: check box
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: SideBarView
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: AddressBar
 teardown:
 - action: session_stop

--- a/tests/at/yaml/动态效果/动态效果.suite.yaml
+++ b/tests/at/yaml/动态效果/动态效果.suite.yaml
@@ -52,5 +52,20 @@ suites:
   assert_steps:
   - action: assert_element
     ref: 快捷访问
+- id: case_dynamic_sidebar_pictures
+  name: 侧边栏导航-图片
+  description: '验证侧边栏"图片"导航项存在并可点击'
+  tags: []
+  steps:
+  - action: session_start
+    command: dde-file-manager --open-home
+    wait: 5.0
+  - action: element_action
+    ref: 图片
+    do: click
+    wait: 1.0
+  assert_steps:
+  - action: assert_element
+    ref: 图片
 teardown:
 - action: session_stop

--- a/tests/at/yaml/管理员/管理员.suite.yaml
+++ b/tests/at/yaml/管理员/管理员.suite.yaml
@@ -102,5 +102,35 @@ suites:
   assert_steps:
   - action: assert_process_running
     app: dde-file-manager
+- id: case_admin_sidebar_music
+  name: 侧边栏导航-音乐
+  description: '验证侧边栏"音乐"导航项存在并可点击'
+  tags: []
+  steps:
+  - action: session_start
+    command: dde-file-manager --open-home
+    wait: 5.0
+  - action: element_action
+    ref: 音乐
+    do: click
+    wait: 1.0
+  assert_steps:
+  - action: assert_element
+    ref: 音乐
+- id: case_admin_sidebar_pictures
+  name: 侧边栏导航-图片
+  description: '验证侧边栏"图片"导航项存在并可点击'
+  tags: []
+  steps:
+  - action: session_start
+    command: dde-file-manager --open-home
+    wait: 5.0
+  - action: element_action
+    ref: 图片
+    do: click
+    wait: 1.0
+  assert_steps:
+  - action: assert_element
+    ref: 图片
 teardown:
 - action: session_stop


### PR DESCRIPTION
## AT-SPI 测试套件 — dde-file-manager

### 用例统计
- 总用例数：100 条
- 各模块分布：
  - filemanager: 26
  - common: 19
  - bug转用例场景: 11
  - dde_file_manager_preview: 12
  - dialogs: 9
  - 管理员: 8
  - misc_ui: 6
  - filedialog: 5
  - 动态效果: 4
- 本次新增：39 条（原 61 条基础上扩展至 100 条）

### 元素覆盖率（100% 门禁）
- 扫描元素总数 (ok 集)：148
- 豁免 (unreachable)：0
- 应覆盖 (分母)：148
- 已覆盖 (分子)：148
- 覆盖率：100.0%
- setAccessibleName：138/138 (100.0%)
- 门禁结果：PASS

### 验证结果
- Gate 4（生成产物校验）：PASS
- Gate 5（语义安全阀）：需在有桌面环境后执行验收（当前环境无 AT-SPI bus）
- 覆盖率门禁 (cover.py)：PASS (148/148, 100%)

## Summary by Sourcery

Expand the dde-file-manager AT-SPI coverage to 100 UI test cases and enforce complete accessible-element coverage.

Enhancements:
- Expand the dde-file-manager AT-SPI test suite to 100 cases across file management, previews, dialogs, file dialogs, administrator workflows, common controls, and miscellaneous UI scenarios.
- Achieve complete accessibility-element coverage for the tested UI, including accessible-name coverage, with all coverage gates passing.

Tests:
- Add 39 AT-SPI YAML test cases covering file-manager workflows, preview playback and navigation, property and sharing dialogs, authentication and conflict dialogs, file-dialog controls, dynamic effects, administrator features, and miscellaneous UI interactions.