### PR TITLE
fix: smooth task dialog resize on new task

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -130,8 +130,10 @@ void TaskDialog::addTaskWidget(const JobHandlePointer taskHandler, TaskWidget *w
 
     blockShutdown();
 
+    wid->blockSignals(true);
+
     QListWidgetItem *item = new QListWidgetItem();
-    item->setSizeHint(QSize(wid->width(), wid->height()));
+    item->setSizeHint(QSize(wid->width(), 0));
     item->setFlags(Qt::NoItemFlags);
     taskListWidget->addItem(item);
     taskListWidget->setItemWidget(item, wid);
@@ -147,6 +149,12 @@ void TaskDialog::addTaskWidget(const JobHandlePointer taskHandler, TaskWidget *w
     setModal(false);
     show();
     activateWindow();
+
+    adjustSize();
+    if (taskItems.count() == 1)
+        moveToCenter();
+
+    wid->blockSignals(false);
 }
 /*!
  * \brief TaskDialog::setTitle 设置任务进度对话框的title
@@ -168,7 +176,6 @@ void TaskDialog::adjustSize(int hight)
         QListWidgetItem *item = taskListWidget->item(i);
         auto wg = taskListWidget->itemWidget(item);
         int h = widgit == wg && hight > 0 ? hight : wg->height();
-        item->setSizeHint(QSize(item->sizeHint().width(), h));
         listHeight += h;
     }
 
@@ -186,6 +193,14 @@ void TaskDialog::adjustSize(int hight)
     // 如果高度发生了变化，重新居中对话框以避免位置偏移
     if (oldHeight != height()) {
         moveYCenter();
+    }
+
+    // 对话框尺寸和位置就绪后，才设置 item 的 sizeHint 使新控件显示
+    for (int i = 0; i < taskListWidget->count(); i++) {
+        QListWidgetItem *item = taskListWidget->item(i);
+        auto wg = taskListWidget->itemWidget(item);
+        int h = widgit == wg && hight > 0 ? hight : wg->height();
+        item->setSizeHint(QSize(item->sizeHint().width(), h));
     }
 }
 /*!


### PR DESCRIPTION
fix: smooth task dialog resize on new task

1. Root cause: addTaskWidget set full-height sizeHint before addItem,
   new widget appeared at bottom before dialog resized and recentered
2. Fix: set initial item height to 0, move sizeHint loop in adjustSize
   to after dialog resize and recenter so widget shows in final position
3. Impact: only affects TaskDialog task addition and size adjustment,
   no signature changes, no external callers affected

Log: task progress dialog now expands smoothly without visual jump

Influence:
1. Test adding a single file operation task, verify dialog shows centered
2. Test adding multiple tasks sequentially, verify dialog grows smoothly
3. Test removing tasks, verify dialog shrinks and recenters correctly
4. Test task pause/resume, verify dialog height changes normally

fix: 修复任务进度框新增任务时视觉跳动

1. 根因：addTaskWidget 在 addItem 前设置了完整高度的 sizeHint，
   新控件以完整高度出现在列表底部后才调整对话框尺寸和重新居中
2. 方案：新 item 初始高度设为 0，adjustSize 中将 sizeHint 设置
   移到对话框尺寸调整和居中之后，控件在对话框就位后才显示
3. 影响：仅影响 TaskDialog 的任务添加和尺寸调整逻辑，无签名变更，
   无外部调用者受影响

Log: 任务进度框新增任务时不再先出现在底部再移动居中

Influence:
1. 测试新增单个文件操作任务，验证进度框居中显示
2. 测试连续添加多个任务，验证进度框平滑增大
3. 测试移除任务，验证进度框正确缩小并居中
4. 测试任务暂停/恢复，验证进度框高度变化正常

PMS: BUG-375283

## Summary by Sourcery

Make task progress dialogs resize and recenter smoothly when new tasks are added.

Bug Fixes:
- Prevent visual jumps when adding tasks by ensuring new task widgets appear only after the task dialog has resized and been repositioned.

Enhancements:
- Refine task dialog sizing and centering behavior during task additions while preserving existing interfaces.