### PR TITLE
fix: add metadata::emblems to GIO file attributes query

### DIFF
--- a/src/dfm-base/file/local/localfileinfodefs.h
+++ b/src/dfm-base/file/local/localfileinfodefs.h
@@ -21,9 +21,9 @@ DFMBASE_BEGIN_NAMESPACE
 //   mimetype 检测（额外 I/O 开销），而文件管理器通过 QMimeDatabase 独立计算
 //   mimetype，不依赖 GIO 的 content-type。
 inline constexpr char kFileAttributes[] { "standard::name,standard::type,standard::is-file,standard::is-dir,"
-    "standard::display-name,standard::size,standard::is-symlink,standard::symlink-target,standard::is-hidden,"
-    "access::*,time::*,"
-    "owner::*,unix::uid,unix::inode,unix::gid,unix::mode,id::filesystem" };
+                                          "standard::display-name,standard::size,standard::is-symlink,standard::symlink-target,standard::is-hidden,"
+                                          "access::*,time::*,"
+                                          "owner::*,unix::uid,unix::inode,unix::gid,unix::mode,id::filesystem,metadata::emblems" };
 
 DFMBASE_END_NAMESPACE
 


### PR DESCRIPTION
Fixed an issue where emblem setting through GIO was failing due to
missing 'metadata::emblems' attribute in the GFileInfo query. The
kFileAttributes constant was updated to include 'metadata::emblems' in
the list of requested attributes when querying GIO. This ensures that
when setting file emblems via GIO, the necessary metadata attribute
is present and accessible, which was previously causing the operation
to fail.

The change adds 'metadata::emblems' to the end of the attribute list,
ensuring backward compatibility while fixing the specific issue. This
attribute is required for GIO to properly handle emblem operations on
files.

Log: Fixed emblem setting failure via GIO due to missing metadata
attribute

Influence:
1. Test setting emblems on files through the file manager interface
2. Verify emblem display and persistence across file operations
3. Check that other file attributes remain accessible and correct
4. Test emblem operations on both local and remote files if GIO is used
5. Ensure no performance regression in file information queries

fix: 添加 metadata::emblems 到 GIO 文件属性查询

修复了由于GIO查询中缺少'metadata::emblems'属性而导致通过GIO设置文件标记
失败的问题。更新了kFileAttributes常量，在查询GIO时请求的属性列表中包含
了'metadata::emblems'。这确保了通过GIO设置文件标记时，必要的元数据属性存
在且可访问，而之前这会导致操作失败。

此次更改将'metadata::emblems'添加到属性列表的末尾，在修复特定问题的同时
确保向后兼容性。此属性是GIO正确处理文件标记操作所必需的。

Log: 修复因缺少元数据属性导致的GIO标记设置失败问题

Influence:
1. 测试通过文件管理器界面在文件上设置标记
2. 验证标记显示及在文件操作中的持久性
3. 检查其他文件属性是否仍可访问且正确
4. 测试在本地和远程文件上的标记操作（如使用GIO）
5. 确保文件信息查询没有性能回归

## Summary by Sourcery

Bug Fixes:
- Include the GIO metadata::emblems attribute in file information queries so emblem setting and persistence work correctly.