### PR TITLE
fix: eliminate task dialog resize jitter

### DIFF
--- a/autotests/libs/dfm-base/test_taskdialog.cpp
+++ b/autotests/libs/dfm-base/test_taskdialog.cpp
@@ -76,12 +76,12 @@ TEST_F(TaskDialogTest, BlockShutdown)
     EXPECT_NO_FATAL_FAILURE({ d.blockShutdown(); });
 }
 
-TEST_F(TaskDialogTest, AdjustSize)
+TEST_F(TaskDialogTest, ResizeAndCenter)
 {
     TaskDialog d;
     d.initUI();
-    d.adjustSize(100);
-    d.adjustSize(0);
+    d.resizeAndCenter();
+    d.scheduleResize();
 }
 
 TEST_F(TaskDialogTest, MoveYCenter)
@@ -124,11 +124,11 @@ TEST_F(TaskDialogTest, SetTitle_Multiple)
     SUCCEED();
 }
 
-TEST_F(TaskDialogTest, AdjustSize_WithPositiveHeight)
+TEST_F(TaskDialogTest, ResizeAndCenter_WithHeight)
 {
     TaskDialog d;
     d.initUI();
-    d.adjustSize(200);
+    d.resizeAndCenter();
     SUCCEED();
 }
 

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -13,6 +13,7 @@
 #include <QMutex>
 #include <QKeyEvent>
 #include <QScreen>
+#include <QTimer>
 
 using namespace dfmbase;
 
@@ -46,7 +47,7 @@ void TaskDialog::addTask(const JobHandlePointer taskHandler)
 
     wid = new TaskWidget(this);
 
-    connect(wid, &TaskWidget::heightChanged, this, &TaskDialog::adjustSize, Qt::QueuedConnection);
+    connect(wid, &TaskWidget::heightChanged, this, &TaskDialog::scheduleResize, Qt::QueuedConnection);
     connect(this, &TaskDialog::closed, wid, &TaskWidget::parentClose, Qt::QueuedConnection);
     taskHandler->connect(taskHandler.get(), &AbstractJobHandler::requestRemoveTaskWidget, this, &TaskDialog::removeTask);
 
@@ -139,10 +140,7 @@ void TaskDialog::addTaskWidget(const JobHandlePointer taskHandler, TaskWidget *w
 
     setWindowFlags(Qt::WindowMinimizeButtonHint | Qt::WindowCloseButtonHint);
     setTitle(taskListWidget->count());
-    adjustSize();
-
-    if (taskItems.count() == 1)
-        moveToCenter();
+    scheduleResize();
 
     setModal(false);
     show();
@@ -158,18 +156,35 @@ void TaskDialog::setTitle(int taskCount)
 }
 
 /*!
- * \brief TaskDialog::adjustSize 调整整个进度显示的高度，当每个item中的widget发生变化时
+ * \brief TaskDialog::scheduleResize 合并同帧内的多次几何请求，事件循环末帧只执行一次几何更新
+ * 新增/移除任务、widget 内部高度变化都会触发本方法，用布尔标志去重，
+ * 保证单帧内无论触发多少次，都只做一次 resizeAndCenter，从而消除抖动。
  */
-void TaskDialog::adjustSize(int hight)
+void TaskDialog::scheduleResize()
 {
-    auto widgit = sender();
+    if (m_resizeScheduled)
+        return;
+    m_resizeScheduled = true;
+    QTimer::singleShot(0, this, [this]() {
+        m_resizeScheduled = false;
+        resizeAndCenter();
+    });
+}
+
+/*!
+ * \brief TaskDialog::resizeAndCenter 计算任务列表高度并一次性完成窗口高度调整与居中
+ * 将「变高/变矮」与「居中移动」合并到同一次事件处理中，中间不产生错位帧，避免视觉抖动。
+ */
+void TaskDialog::resizeAndCenter()
+{
     int listHeight = 2;
     for (int i = 0; i < taskListWidget->count(); i++) {
         QListWidgetItem *item = taskListWidget->item(i);
         auto wg = taskListWidget->itemWidget(item);
-        int h = widgit == wg && hight > 0 ? hight : wg->height();
-        item->setSizeHint(QSize(item->sizeHint().width(), h));
-        listHeight += h;
+        if (!wg)
+            continue;
+        item->setSizeHint(QSize(item->sizeHint().width(), wg->height()));
+        listHeight += wg->height();
     }
 
     int oldHeight = height();
@@ -182,9 +197,15 @@ void TaskDialog::adjustSize(int hight)
     }
 
     layout()->setSizeConstraint(QLayout::SetNoConstraint);
-    
-    // 如果高度发生了变化，重新居中对话框以避免位置偏移
-    if (oldHeight != height()) {
+
+    // 高度未变化时无需移动，避免无谓的窗口重定位
+    if (oldHeight == height())
+        return;
+
+    // 未显示时整体居中；已显示时仅重算纵向位置，保持水平位置不变
+    if (!isVisible()) {
+        moveToCenter();
+    } else {
         moveYCenter();
     }
 }
@@ -233,7 +254,7 @@ void TaskDialog::removeTask()
     if (taskListWidget->count() == 0) {
         close();
     } else {
-        adjustSize();
+        scheduleResize();
     }
 }
 /*!

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -42,7 +42,8 @@ Q_SIGNALS:
 private Q_SLOTS:
     void moveYCenter();
     void removeTask();
-    void adjustSize(int hight = 0);
+    void scheduleResize();
+    void resizeAndCenter();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -56,6 +57,7 @@ private:
     static constexpr uint32_t kInvalidScreenSaverCookie = 0;
     uint32_t screenSaverCookie { kInvalidScreenSaverCookie };
     static int kMaxHeight;
+    bool m_resizeScheduled { false };
 };
 
 }


### PR DESCRIPTION
1. Coalesce multiple geometry requests within a single frame using
a boolean
   flag and QTimer::singleShot, ensuring only one resize per event loop
cycle
2. Rename adjustSize into scheduleResize and resizeAndCenter to clarify
the
   two-phase approach (schedule then apply)
3. Use each widget's actual height instead of the sender-supplied height
   parameter, making height calculation more reliable
4. Skip window repositioning entirely when the height has not changed,
   avoiding unnecessary window moves
5. When the dialog is already visible, only recalculate the vertical
position
   and keep the horizontal position stable, preventing sideways drift
6. When the dialog is not yet visible, perform a full moveToCenter as
before

Log: 修复任务对话框尺寸变化时的窗口抖动问题，优化窗口居中逻辑

Influence:
1. Test adding multiple tasks to the dialog and verify the dialog
remains
   stable without flickering or jitter during height changes
2. Test removing tasks and confirm the window shrinks smoothly without
   horizontal position drift
3. Test adding the first task and confirm the dialog opens centered
on screen
4. Test continuously adding/removing tasks rapidly to verify all resize
   requests within the same frame are coalesced into one geometry update
5. Test on multi-screen setups to ensure the dialog stays on the correct
   screen when recentering vertically
6. Verify the task progress list remains fully visible after resize
and no
   content is clipped

fix: 消除任务对话框尺寸变化时的窗口抖动

1. 使用布尔标志和 QTimer::singleShot 合并同一帧内的多次几何请求，确保
每个
   事件循环周期只执行一次尺寸调整
2. 将 adjustSize 拆分为 scheduleResize 和 resizeAndCenter，明确两阶段
流程
3. 改用每个 widget 的实际高度而非发送者传入的高度参数，使高度计算更可靠
4. 当高度未变化时直接跳过窗口重定位，避免无意义的窗口移动
5. 窗口已显示时仅重新计算纵向位置，保持水平位置不变，防止横向漂移
6. 窗口未显示时仍然调用 moveToCenter 进行整体居中

Log: 修复任务对话框尺寸变化时的窗口抖动问题，优化窗口居中逻辑

Influence:
1. 测试向对话框中添加多个任务，验证窗口在高度变化过程中保持稳定，
   无闪烁或抖动
2. 测试移除任务，确认窗口平滑收缩且水平位置不偏移
3. 测试添加第一个任务，确认对话框在屏幕上居中显示
4. 测试快速连续添加/移除任务，验证同一帧内的所有尺寸请求被合并
   为一次几何更新
5. 在多屏环境下测试，确保垂直居中时对话框仍停留在正确的屏幕上
6. 确认尺寸调整后任务进度列表完全可见，内容未被裁剪

BUG: https://pms.uniontech.com/bug-view-375283.html

## Summary by Sourcery

Stabilize task dialog geometry updates by coalescing resize requests and separating deferred resizing from conditional centering.

Bug Fixes:
- Eliminate task dialog resize jitter and horizontal drift during task additions, removals, and content height changes.

Enhancements:
- Coalesce resize requests within an event-loop cycle and apply stable centering behavior that preserves the dialog's horizontal position after it is shown.

Tests:
- Update task dialog tests for the split resize scheduling and application APIs.