### PR TITLE
chore: bump version to 6.5.170

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.170) unstable; urgency=medium
+
+  * fix: add metadata::emblems to GIO file attributes query
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 08 Sep 2026 14:04:00 +0800
+
 dde-file-manager (6.5.169) unstable; urgency=medium
 
   * fix: emblem still shows after disabling UDisk emblem


### PR DESCRIPTION
6.5.170

Log:

## Summary by Sourcery

Chores:
- Update the Debian changelog for version 6.5.170.