### PR TITLE
fix: skip optical drives in USB repair device filter

### DIFF
--- a/src/services/usbrepair/usbrepairmonitor.cpp
+++ b/src/services/usbrepair/usbrepairmonitor.cpp
@@ -228,6 +228,13 @@ bool UsbRepairMonitor::isUsbDevice(const QString &blockObjPath, QString *deviceN
         return false;
     }
 
+    // Skip optical drives (e.g., virtual CD-ROM from Android MTP)
+    bool optical = driveIface.property("Optical").toBool();
+    if (optical) {
+        fmDebug() << "UsbRepairMonitor: optical drive, skipping:" << blockObjPath;
+        return false;
+    }
+
     if (deviceName) {
         *deviceName = driveIface.property("Id").toString();
         QString vendor = driveIface.property("Vendor").toString();


### PR DESCRIPTION
## Root Cause Analysis

The `usbrepair` service's `isUsbDevice()` function only checks `ConnectionBus=="usb"` and `Removable==true`, but does not check the UDisks2 Drive `Optical` property. When an Android phone connects via MTP, it exposes a virtual CD-ROM drive (File-CD Gadget) with `Optical=true`, which passes the USB device filter and enters the filesystem detection flow. Since the ISO9660 filesystem on the virtual optical drive is not recognized, the service falsely reports "device damaged, cannot auto repair."

Key evidence: `isUsbDevice()` (`usbrepairmonitor.cpp:225-247`) missing `Optical` check; `checkMissingFilesystem()` (`usbrepairmonitor.cpp:330-358`) unable to parse ISO9660 from `file -s` output, leading to `emit errorDetected(..., "unknown", ..., false, ...)`.

## Fix

Add an `Optical` property check in `isUsbDevice()` — if the drive is optical, return `false` to skip it before any filesystem detection. This filters all optical drives (including MTP virtual CD-ROM) at the entry point, preventing false damage reports. Only the root cause layer fix is applied (no symptom-layer filesystem recognition changes needed), as optical drives should never be processed by the USB repair service.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Target lines were all introduced in feature commits (not previous bug fixes), so this change does not revert any historical fix
- Both call sites (`checkDeviceHealth()` and `checkMissingFilesystem()`) already handle `isUsbDevice() == false` gracefully with early return

### Business Impact Scope

The USB repair monitoring service's device filtering logic is the only affected module. Users connecting Android phones via MTP will no longer see false "device damaged" notifications. Normal USB flash drive repair functionality is unaffected — non-optical removable USB devices still pass the filter as before.

### Verification Suggestion

Test Android phone MTP connection to confirm no false damage alert appears. Test a corrupted USB flash drive to verify repair detection still works. Check debug logs to confirm optical drives are logged as skipped.

---

## 根因分析

`usbrepair` 服务的 `isUsbDevice()` 函数仅检查 `ConnectionBus=="usb"` 和 `Removable==true`，未检查 UDisks2 Drive 的 `Optical` 属性。安卓手机通过 MTP 连接时会暴露虚拟光驱（File-CD Gadget，`Optical=true`），该设备通过 USB 设备过滤进入文件系统检测流程。由于虚拟光驱的 ISO9660 文件系统不被识别，服务误报"设备已损坏，无法自动修复"。

关键证据：`isUsbDevice()`（`usbrepairmonitor.cpp:225-247`）缺少 `Optical` 检查；`checkMissingFilesystem()`（`usbrepairmonitor.cpp:330-358`）无法从 `file -s` 输出中解析 ISO9660，导致 `emit errorDetected(..., "unknown", ..., false, ...)` 误报。

## 修复方案

在 `isUsbDevice()` 中增加 `Optical` 属性检查——若设备是光驱则返回 `false`，在任何文件系统检测之前跳过。这从入口过滤所有光驱设备（包括 MTP 虚拟光驱），防止误报。仅实施根因层修复（不需要症状层文件系统识别改动），因为光驱设备本不应被 USB 修复服务处理。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标行段全部由功能新增提交引入（非历史 bug 修复），本次改动不会撤销任何已有修复
- 两个调用点（`checkDeviceHealth()` 和 `checkMissingFilesystem()`）已有对 `isUsbDevice() == false` 的优雅处理（提前返回）

### 业务影响范围

USB 修复监控服务的设备过滤逻辑是唯一受影响的模块。用户通过 MTP 连接安卓手机时不再出现"设备损坏"误报。正常 U 盘修复功能不受影响——非光驱可移动 USB 设备仍和以前一样通过过滤。

### 验证建议

测试安卓手机 MTP 连接，确认不再出现设备损坏误报。测试损坏的 U 盘，验证修复检测仍正常工作。检查调试日志确认光驱设备被正确跳过。

## Summary by Sourcery

Bug Fixes:
- Prevent false USB damage reports by excluding optical drives, including virtual CD-ROM devices exposed by Android MTP connections, from repair monitoring.