### PR TITLE
Revert "fix(at-spi): add accessible names for sidebar items and menu actions"

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -207,7 +207,6 @@ bool SideBarModel::insertRow(int row, SideBarItem *item)
     SideBarItemSeparator *groupItem = dynamic_cast<SideBarItemSeparator *>(item);
     if (groupItem) {   // top item
         QStandardItemModel::insertRow(row + 1, item);   // insert the top item
-        setItemAccessibleName(item);
         return true;
     } else {   // sub item
         int count = this->rowCount();
@@ -220,16 +219,12 @@ bool SideBarModel::insertRow(int row, SideBarItem *item)
             SideBarItem *groupItem = this->itemFromIndex(index);
             if (groupItem) {
                 int rows = groupItem->rowCount();
-                if (row == 0 || (row > 0 && row < rows)) {
+                if (row == 0 || (row > 0 && row < rows))
                     groupItem->insertRow(row, item);
-                    setItemAccessibleName(item);
-                } else if (row >= rows) {
+                else if (row >= rows)
                     groupItem->appendRow(item);
-                    setItemAccessibleName(item);
-                } else if (row == -1) {
+                else if (row == -1)
                     groupItem->insertRow(0, item);
-                    setItemAccessibleName(item);
-                }
             }
             return true;
         }
@@ -254,7 +249,6 @@ int SideBarModel::appendRow(SideBarItem *item, bool direct)
     if (topItem) {   // Top item
         auto t = topItem->group();
         QStandardItemModel::appendRow(item);
-        setItemAccessibleName(item);
         return rowCount() - 1;   // The return value is the index of top item.
     } else {   // Sub item
         int count = this->rowCount();
@@ -281,27 +275,22 @@ int SideBarModel::appendRow(SideBarItem *item, bool direct)
                 bool sorted = { dpfHookSequence->run("dfmplugin_sidebar", "hook_Group_Sort", groupId, item->subGourp(), item->url(), tmpItem->url()) };
                 if (sorted) {
                     groupItem->insertRow(row, item);
-                    setItemAccessibleName(item);
                     itemInserted = true;
                     break;
                 }
             }
-            if (!itemInserted) {
+            if (!itemInserted)
                 groupItem->appendRow(item);
-                setItemAccessibleName(item);
-            }
 
             return row;   // The position after sorted
         }
     }
     if (groupOther && !topItem) {   // If can not find out the parent item, just append it to Group_Other
         groupOther->appendRow(item);
-        setItemAccessibleName(item);
         fmInfo() << "Item added to groupOther";
         return groupOther->rowCount() - 1;
     }
     QStandardItemModel::appendRow(item);
-    setItemAccessibleName(item);
     fmInfo() << "Item added to the end of sidebar.";
     return rowCount() - 1;
 }
@@ -371,7 +360,6 @@ void SideBarModel::updateRow(const QUrl &url, const ItemInfo &newInfo)
                 else
                     flags &= (~Qt::ItemIsEditable);
                 subItem->setFlags(flags);
-                setItemAccessibleName(subItem);
                 return;
             }
         }
@@ -680,7 +668,6 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     }
 
     parentItem->insertRow(insertRow, item);
-    setItemAccessibleName(item);
 }
 
 void SideBarModel::removeSubItem(const QModelIndex &index, const QUrl &url)
@@ -733,18 +720,5 @@ void SideBarModel::removeSubItem(const QModelIndex &index, const QUrl &url)
         SideBarInfoCacheMananger::instance()->removeItemInfoCache(url);
         parentItem->removeRow(index.row());
         fmDebug() << "Item removed from sidebar:" << url;
-    }
-}
-
-void SideBarModel::setItemAccessibleName(SideBarItem *item) const
-{
-    if (!item)
-        return;
-    // Use the display text (already translated) as both objectName and accessibleName
-    // for AT-SPI accessibility tree lookup.
-    const QString &text = item->text();
-    if (!text.isEmpty()) {
-        item->setObjectName(text);
-        item->setAccessibleName(text);
     }
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -61,8 +61,6 @@ private slots:
 
     void addSubItem(const QModelIndex &index, const QUrl &url);
     void removeSubItem(const QModelIndex &index, const QUrl &url);
-    // Set AT-SPI accessible name for sidebar items
-    void setItemAccessibleName(SideBarItem *item) const;
 
 private:
     QMutex locker;

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -97,42 +97,30 @@ void TitleBarHelper::createSettingsMenu(quint64 id)
 
     QAction *action { new QAction(QObject::tr("New window"), menu) };
     action->setData(MenuAction::kNewWindow);
-    action->setObjectName(QObject::tr("New window"));
-    action->setAccessibleName(QObject::tr("New window"));
     menu->addAction(action);
 
     action = new QAction(QObject::tr("New tab"), menu);
     action->setData(MenuAction::kOpenInNewTab);
-    action->setObjectName(QObject::tr("New tab"));
-    action->setAccessibleName(QObject::tr("New tab"));
     menu->addAction(action);
 
     menu->addSeparator();
 
     action = new QAction(QObject::tr("Connect to Server"), menu);
     action->setData(MenuAction::kConnectToServer);
-    action->setObjectName(QObject::tr("Connect to Server"));
-    action->setAccessibleName(QObject::tr("Connect to Server"));
     menu->addAction(action);
 
     action = new QAction(QObject::tr("Set share password"), menu);
     action->setData(MenuAction::kSetUserSharePassword);
-    action->setObjectName(QObject::tr("Set share password"));
-    action->setAccessibleName(QObject::tr("Set share password"));
     menu->addAction(action);
 
     if (DeviceUtils::checkDiskEncrypted()) {
         action = new QAction(QObject::tr("Change disk password"), menu);
         action->setData(MenuAction::kChangeDiskPassword);
-        action->setObjectName(QObject::tr("Change disk password"));
-        action->setAccessibleName(QObject::tr("Change disk password"));
         menu->addAction(action);
     }
 
     action = new QAction(QObject::tr("Settings"), menu);
     action->setData(MenuAction::kSettings);
-    action->setObjectName(QObject::tr("Settings"));
-    action->setAccessibleName(QObject::tr("Settings"));
     menu->addAction(action);
 
     QObject::connect(menu, &QMenu::triggered, [id](QAction *act) {


### PR DESCRIPTION
This reverts commit 8924f4797361fd2fe41d14254a018b59e1f7d128.

## Summary by Sourcery

Revert the accessibility naming changes for sidebar items and title-bar menu actions.

Enhancements:
- Remove sidebar item and title-bar menu accessibility name assignments introduced by the reverted change.

Chores:
- Revert the related accessible-name helper and its declaration.