### PR TITLE
fix: improve share name handling and cursor position

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -462,6 +462,15 @@ void ShareControlWidget::updateShare()
 {
     QString filePath = url.toLocalFile();
 
+    // Revert to the previous share name when the editor is emptied.
+    if (shareNameEditor->text().trimmed().isEmpty()) {
+        QString fallback = UserShareHelperInstance->shareNameByPath(filePath);
+        if (fallback.isEmpty() && info)
+            fallback = info->displayOf(DisPlayInfoType::kFileDisplayName);
+        if (!fallback.isEmpty())
+            shareNameEditor->setText(fallback);
+    }
+
     // Get share info before update
     auto oldShareInfo = UserShareHelperInstance->shareInfoByPath(filePath);
     bool wasAnonymous = oldShareInfo.value(ShareInfoKeys::kAnonymous).toBool();
@@ -602,13 +611,28 @@ void ShareControlWidget::onSambaPasswordSet(bool result)
 void ShareControlWidget::onShareNameChanged(const QString &name)
 {
     static const int kShareNameMaxLen { 150 };
-    QString newText(name.trimmed());
+    QLineEdit *lineEdit = shareNameEditor->lineEdit();
+    const int cursorPos = lineEdit->cursorPosition();
+
+    // Count leading whitespace that trimmed() will strip, so the cursor can be
+    // repositioned correctly after the text is rewritten.
+    int leadingSpaces = 0;
+    while (leadingSpaces < name.size() && name.at(leadingSpaces).isSpace())
+        ++leadingSpaces;
+
+    QString newText = name.trimmed().toLower();
     bool showAlert = false;
     while (newText.toLocal8Bit().length() > kShareNameMaxLen) {
         newText.chop(1);
         showAlert = true;
     }
+
     shareNameEditor->setText(newText);
+    // Keep the cursor right after the just-typed character instead of jumping to
+    // the end, regardless of whether the text was lowercased, trimmed or truncated.
+    const int newCursorPos = qMin(qMax(0, cursorPos - leadingSpaces), newText.size());
+    lineEdit->setCursorPosition(newCursorPos);
+
     QTimer::singleShot(0, shareNameEditor, [this, showAlert] {
         if (showAlert)
             shareNameEditor->showAlertMessage(tr("The shared name is too long and will be truncated."));

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -424,14 +424,24 @@ bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *c
 
     // test tpm
     bool testTPM = (type == kPin || type == kTpm);
-    if (testTPM && tpm_utils::checkTPM() != 0) {
-        fmWarning() << "TPM service is not available for device:" << dev;
-        int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"));
-        // unlock by recovery key.
-        if (ret == 0)
-            *pwd = acquirePassphraseByRec(dev, *cancelled);
+    if (testTPM) {
+        bool authFailed = false;
+        int tpmRet = tpm_utils::checkTPM(&authFailed);
+        if (authFailed) {
+            // PolicyKit authorization failed/cancelled by user, treat as cancel this unlock.
+            fmInfo() << "TPM authorization cancelled by user for device:" << dev;
+            *cancelled = true;
+            return true;
+        }
+        if (tpmRet != 0) {
+            fmWarning() << "TPM service is not available for device:" << dev;
+            int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"));
+            // unlock by recovery key.
+            if (ret == 0)
+                *pwd = acquirePassphraseByRec(dev, *cancelled);
 
-        return true;
+            return true;
+        }
     }
 
     switch (type) {

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -62,8 +62,11 @@ QString config_utils::cipherType()
     return cipher;
 }
 
-int tpm_utils::checkTPM()
+int tpm_utils::checkTPM(bool *authFailed)
 {
+    if (authFailed)
+        *authFailed = false;
+
     QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
     iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
@@ -72,7 +75,17 @@ int tpm_utils::checkTPM()
     }
 
     QDBusReply<int> reply = iface.call("IsTPMAvailable");
-    return reply.isValid() ? reply.value() : -1;
+    if (!reply.isValid()) {
+        fmWarning() << "IsTPMAvailable DBus call failed";
+        return -1;
+    }
+
+    int ret = reply.value();
+    // A valid reply carrying -1 means the service side returned kAuthFailed
+    // (PolicyKit authorization failed/cancelled by user).
+    if (authFailed)
+        *authFailed = (ret == -1);
+    return ret;
 }
 
 int tpm_utils::checkTPMLockoutStatus()

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -18,7 +18,7 @@ typedef QSharedPointer<dfmmount::DBlockDevice> BlockDev;
 namespace dfmplugin_diskenc {
 
 namespace tpm_utils {
-int checkTPM();
+int checkTPM(bool *authFailed = nullptr);
 int checkTPMLockoutStatus();
 int getRandomByTPM(int size, QString *output);
 int isSupportAlgoByTPM(const QString &algoName, bool *support);


### PR DESCRIPTION
1. Revert to the previous share name when the share name editor is
emptied during updates
2. Fall back to the share name from the share helper, then to the file
display name
3. Normalize the share name by trimming whitespace and converting to
lowercase
4. Preserve cursor position after trimming, lowercasing, and truncation
instead of jumping to the end
5. Keep the existing 150-byte truncation limit with the alert message

Log: Fixed share name editing behavior, including empty name fallback
and cursor positioning

Influence:
1. Test clearing the share name and updating the share to verify it
reverts to the previous name
2. Enter leading and trailing spaces and confirm trimming works without
disrupting the cursor
3. Type mixed-case share names and confirm they are lowercased live
4. Paste an extra-long share name and verify truncation and the alert
message appear
5. Test cursor position at the start, middle, and end of the name while
typing or editing
6. Verify the fallback name matches the path-based share name or file
display name when applicable

fix: 优化共享名称处理与光标位置

1. 更新共享时，如果共享名称编辑器被清空，恢复为之前的名称
2. 优先使用共享辅助模块查询到的共享名称，否则使用文件显示名称
3. 将共享名称规范化：去除首尾空白并转换为小写
4. 在修剪、转小写或截断后保持光标位置，避免跳到末尾
5. 保留 150 字节截断限制及对应提示信息

Log: 修复共享名称编辑行为，包括空名称回退与光标定位

Influence:
1. 测试清空共享名称后保存，确认会恢复为之前的名称
2. 输入首尾空格，验证自动修剪且光标位置不受影响
3. 输入大写字母，确认实时转换为小写
4. 粘贴超长名称，验证截断和提示信息正常出现
5. 在名称的开头、中间、结尾编辑时，验证光标位置正确
6. 验证回退名称能正确显示共享路径名或文件名

BUG: https://pms.uniontech.com/bug-view-376373.html

## Summary by Sourcery

Improve share-name editing behavior and distinguish cancelled TPM authorization from unavailable TPM services.

Bug Fixes:
- Restore a previous or fallback file-based share name when a share name edit is cleared during an update.
- Handle cancelled PolicyKit authorization during TPM checks as a cancelled unlock instead of prompting for recovery-key fallback.

Enhancements:
- Normalize share names to trimmed lowercase text while preserving the cursor position through normalization and 150-byte truncation.