### PR TITLE
test: add event dispatch and view behavior tests for four plugins

### DIFF
--- a/autotests/plugins/ddplugin-canvas/test_canvasview_events.cpp
+++ b/autotests/plugins/ddplugin-canvas/test_canvasview_events.cpp
@@ -1,0 +1,862 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "canvas_test_common.h"
+
+#include "plugins/desktop/ddplugin-canvas/view/canvasview.h"
+#include "plugins/desktop/ddplugin-canvas/view/canvasview_p.h"
+#include "plugins/desktop/ddplugin-canvas/view/viewhookinterface.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/viewsettingutil.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/viewpainter.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/dodgeoper.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/keyselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/clickselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/boxselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasproxymodel.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.h"
+#include "plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h"
+
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/base/application/application.h>
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QStandardItemModel>
+#include <QItemSelectionModel>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QWheelEvent>
+#include <QFocusEvent>
+#include <QPaintEvent>
+#include <QContextMenuEvent>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDragLeaveEvent>
+#include <QDropEvent>
+#include <QMimeData>
+
+using namespace ddplugin_canvas;
+DFMBASE_USE_NAMESPACE
+
+namespace {
+class TestProxyModel : public CanvasProxyModel
+{
+public:
+    Qt::ItemFlags flags(const QModelIndex &) const override
+    {
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    }
+
+    QVariant data(const QModelIndex &, int) const override
+    {
+        return dataResult;
+    }
+
+    QVariant dataResult = QVariant(QString("apple"));
+};
+
+class DummyViewHook : public ViewHookInterface
+{
+public:
+    bool keyPress(int, int, int, void * = nullptr) const override { keyPressCount++; return keyPressResult; }
+    bool mousePress(int, int, const QPoint &, void * = nullptr) const override { mousePressCount++; return mousePressResult; }
+    bool wheel(int, const QPoint &, void * = nullptr) const override { wheelCount++; return wheelResult; }
+    bool startDrag(int, int, void * = nullptr) const override { startDragCount++; return startDragResult; }
+
+    mutable int keyPressCount = 0;
+    mutable int mousePressCount = 0;
+    mutable int wheelCount = 0;
+    mutable int startDragCount = 0;
+    bool keyPressResult = false;
+    bool mousePressResult = false;
+    bool wheelResult = false;
+    bool startDragResult = false;
+};
+}   // namespace
+
+class CanvasViewEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(VADDR(QWidget, show), [](QWidget *) { __DBG_STUB_INVOKE__; });
+        stub.set_lamda(VADDR(QWidget, setVisible), [](QWidget *, bool) { __DBG_STUB_INVOKE__; });
+        // CanvasView::reset calls model()->rootIndex() through the proxy cast.
+        stub.set_lamda(VADDR(CanvasView, reset), [](CanvasView *) { __DBG_STUB_INVOKE__; });
+
+        view = new CanvasView(nullptr);
+        // Valid grid metrics so real CanvasViewPrivate::gridAt never divides by zero.
+        view->d->canvasInfo = CanvasViewPrivate::CanvasInfo(2, 2, 100, 100);
+
+        proxyModel = new CanvasProxyModel();
+        // CanvasView::selectionModel() qobject_casts to CanvasSelectionModel, so a
+        // plain QItemSelectionModel would surface as null inside the view. Qt also
+        // requires the selection model to work on the same model as the view.
+        mockSelectionModel = new CanvasSelectionModel(proxyModel, proxyModel);
+        view->setModel(proxyModel);
+        view->setSelectionModel(mockSelectionModel);
+        // Plain model only used to fabricate QModelIndex values in tests.
+        mockModel = new QStandardItemModel();
+
+        stub.set_lamda(ADDR(CanvasView, model),
+                       [this](const CanvasView *) -> CanvasProxyModel * {
+                           return proxyModel;
+                       });
+        view->setItemDelegate(new CanvasItemDelegate(view));
+
+        hook = new DummyViewHook();
+        view->setViewHook(hook);
+    }
+
+    void TearDown() override
+    {
+        view->setViewHook(nullptr);
+        delete view;
+        delete proxyModel;
+        delete hook;
+        delete mockModel;   // deletes mockSelectionModel as its child
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    CanvasView *view = nullptr;
+    QStandardItemModel *mockModel = nullptr;
+    CanvasSelectionModel *mockSelectionModel = nullptr;
+    CanvasProxyModel *proxyModel = nullptr;
+    DummyViewHook *hook = nullptr;
+};
+
+TEST_F(CanvasViewEventTest, ViewHook_SetAndGet_ReturnsSameInterface)
+{
+    // Arrange
+    DummyViewHook otherHook;
+
+    // Act
+    view->setViewHook(&otherHook);
+
+    // Assert
+    EXPECT_EQ(view->viewHook(), &otherHook);
+    view->setViewHook(hook);
+    EXPECT_EQ(view->viewHook(), hook);
+    EXPECT_NE(view->viewHook(), &otherHook);
+}
+
+TEST_F(CanvasViewEventTest, SetSelection_RectAndFlags_SelectionRemainsEmpty)
+{
+    // Arrange
+    QStandardItem *item = new QStandardItem("a");
+    mockModel->appendRow(item);
+    EXPECT_TRUE(view->selectionModel()->selectedIndexes().isEmpty());
+
+    // Act: CanvasView::setSelection is intentionally a no-op.
+    view->setSelection(QRect(0, 0, 100, 100), QItemSelectionModel::ClearAndSelect);
+
+    // Assert
+    EXPECT_TRUE(view->selectionModel()->selectedIndexes().isEmpty());
+    EXPECT_EQ(view->selectionModel()->selectedIndexes().size(), 0);
+}
+
+TEST_F(CanvasViewEventTest, VisualRegionForSelection_EmptySelection_ReturnsEmptyRegion)
+{
+    // Arrange
+    QItemSelection emptySelection;
+
+    // Act
+    QRegion region = view->visualRegionForSelection(emptySelection);
+
+    // Assert
+    EXPECT_TRUE(region.isEmpty());
+    EXPECT_TRUE(region.boundingRect().isNull());
+}
+
+TEST_F(CanvasViewEventTest, KeyboardSearch_ValidSearch_ForwardedToSelector)
+{
+    // Arrange
+    QString captured;
+    stub.set_lamda(ADDR(KeySelector, keyboardSearch),
+                   [&captured](KeySelector *, const QString &search) {
+                       captured = search;
+                   });
+
+    // Act
+    view->keyboardSearch(QString("abc"));
+
+    // Assert
+    EXPECT_EQ(captured, QString("abc"));
+}
+
+TEST_F(CanvasViewEventTest, PaintEvent_NormalState_AllPaintStagesExecuted)
+{
+    // Arrange
+    bool gridInfosDrawn = false;
+    bool moveDrawn = false;
+    bool dodgeDrawn = false;
+    bool filesPainted = false;
+    stub.set_lamda(ADDR(ViewPainter, drawGirdInfos),
+                   [&gridInfosDrawn](ViewPainter *) {
+                       gridInfosDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, drawMove),
+                   [&moveDrawn](ViewPainter *, QStyleOptionViewItem) {
+                       moveDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, drawDodge),
+                   [&dodgeDrawn](ViewPainter *, QStyleOptionViewItem) {
+                       dodgeDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, paintFiles),
+                   [&filesPainted](ViewPainter *, QStyleOptionViewItem, QPaintEvent *) {
+                       filesPainted = true;
+                   });
+    view->d->flicker = false;
+
+    // Act
+    QPaintEvent event(QRect(0, 0, 400, 300));
+    view->paintEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(gridInfosDrawn);
+    EXPECT_TRUE(moveDrawn);
+    EXPECT_TRUE(dodgeDrawn);
+    EXPECT_TRUE(filesPainted);
+}
+
+TEST_F(CanvasViewEventTest, ContextMenuEvent_EmptyArea_ShowsEmptyAreaMenu)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, disableMenu),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(WindowUtils, isWayLand),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    bool editorReverted = false;
+    stub.set_lamda(ADDR(CanvasItemDelegate, revertAndcloseEditor),
+                   [&editorReverted](CanvasItemDelegate *) {
+                       editorReverted = true;
+                   });
+    QPoint capturedGridPos(-1, -1);
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, showEmptyAreaMenu),
+                   [&capturedGridPos](CanvasViewMenuProxy *, const Qt::ItemFlags &, const QPoint gridPos) {
+                       capturedGridPos = gridPos;
+                   });
+
+    // Act
+    QContextMenuEvent event(QContextMenuEvent::Mouse, QPoint(20, 20), QPoint(120, 120));
+    view->contextMenuEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(editorReverted);
+    EXPECT_EQ(capturedGridPos, view->d->gridAt(QPoint(20, 20)));
+}
+
+TEST_F(CanvasViewEventTest, StartDrag_DelayDragEnabled_ReturnsWithoutDrag)
+{
+    // Arrange
+    stub.set_lamda(ADDR(ViewSettingUtil, isDelayDrag),
+                   [](const ViewSettingUtil *) -> bool {
+                       return true;
+                   });
+
+    // Act
+    view->startDrag(Qt::CopyAction);
+
+    // Assert
+    EXPECT_EQ(hook->startDragCount, 0);
+}
+
+TEST_F(CanvasViewEventTest, StartDrag_ExtendHookHandlesDrag_SkipsDefaultDrag)
+{
+    // Arrange
+    stub.set_lamda(ADDR(ViewSettingUtil, isDelayDrag),
+                   [](const ViewSettingUtil *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(VADDR(QAbstractItemView, closePersistentEditor), [](QAbstractItemView *, const QModelIndex &) { __DBG_STUB_INVOKE__; });
+    hook->startDragResult = true;
+
+    // Act
+    view->startDrag(Qt::CopyAction);
+
+    // Assert
+    EXPECT_EQ(hook->startDragCount, 1);
+}
+
+TEST_F(CanvasViewEventTest, DragEvents_OperHandlesEvent_BaseBehaviourSkipped)
+{
+    // Arrange
+    bool enterHandled = false;
+    bool moveHandled = false;
+    bool leaveHandled = false;
+    stub.set_lamda(ADDR(DragDropOper, enter),
+                   [&enterHandled](DragDropOper *, QDragEnterEvent *) -> bool {
+                       enterHandled = true;
+                       return true;
+                   });
+    stub.set_lamda(ADDR(DragDropOper, move),
+                   [&moveHandled](DragDropOper *, QDragMoveEvent *) -> bool {
+                       moveHandled = true;
+                       return true;
+                   });
+    stub.set_lamda(ADDR(DragDropOper, leave),
+                   [&leaveHandled](DragDropOper *, QDragLeaveEvent *) {
+                       leaveHandled = true;
+                   });
+
+    QMimeData mimeData;
+    // Act
+    QDragEnterEvent enterEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dragEnterEvent(&enterEvent);
+    QDragMoveEvent moveEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dragMoveEvent(&moveEvent);
+    QDragLeaveEvent leaveEvent;
+    view->dragLeaveEvent(&leaveEvent);
+
+    // Assert
+    EXPECT_TRUE(enterHandled);
+    EXPECT_TRUE(moveHandled);
+    EXPECT_TRUE(leaveHandled);
+}
+
+TEST_F(CanvasViewEventTest, DropEvent_OperHandlesDrop_ActivatesWindowAndResetsState)
+{
+    // Arrange
+    QDropEvent *capturedEvent = nullptr;
+    stub.set_lamda(ADDR(DragDropOper, drop),
+                   [&capturedEvent](DragDropOper *, QDropEvent *event) -> bool {
+                       capturedEvent = event;
+                       return true;
+                   });
+    stub.set_lamda(VADDR(QWidget, activateWindow), [](QWidget *) { __DBG_STUB_INVOKE__; });
+
+    // Act
+    QMimeData mimeData;
+    QDropEvent dropEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dropEvent(&dropEvent);
+
+    // Assert
+    EXPECT_EQ(capturedEvent, &dropEvent);
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+}
+
+TEST_F(CanvasViewEventTest, FocusInEvent_InputMethodEnabled_AttributeEnabled)
+{
+    // Arrange
+    view->d->imEnabled = true;
+    view->setAttribute(Qt::WA_InputMethodEnabled, false);
+    QFocusEvent event(QEvent::FocusIn);
+
+    // Act
+    view->focusInEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(view->testAttribute(Qt::WA_InputMethodEnabled));
+}
+
+TEST_F(CanvasViewEventTest, FocusOutEvent_AnyFocusOut_StopsDelayDodge)
+{
+    // Arrange
+    bool delayStopped = false;
+    bool prepareUpdated = false;
+    stub.set_lamda(ADDR(DodgeOper, stopDelayDodge),
+                   [&delayStopped](DodgeOper *) {
+                       delayStopped = true;
+                   });
+    stub.set_lamda(ADDR(DodgeOper, updatePrepareDodgeValue),
+                   [&prepareUpdated](DodgeOper *, QEvent *) {
+                       prepareUpdated = true;
+                   });
+    QFocusEvent event(QEvent::FocusOut);
+
+    // Act
+    view->focusOutEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(delayStopped);
+    EXPECT_TRUE(prepareUpdated);
+}
+
+TEST_F(CanvasViewEventTest, Edit_NoSelection_ReturnsFalse)
+{
+    // Arrange
+    mockModel->appendRow(new QStandardItem("a"));
+    EXPECT_EQ(view->selectionModel()->selectedRows().size(), 0);
+    QKeyEvent keyEvent(QEvent::MouseButtonPress, Qt::Key_F2, Qt::NoModifier);
+
+    // Act
+    bool edited = view->edit(mockModel->index(0, 0), QAbstractItemView::AllEditTriggers, &keyEvent);
+
+    // Assert
+    EXPECT_FALSE(edited);
+    EXPECT_EQ(view->selectionModel()->selectedRows().size(), 0);
+}
+
+TEST_F(CanvasViewEventTest, KeyPressEvent_HookConsumesKey_EventNotPropagated)
+{
+    // Arrange
+    hook->keyPressResult = true;
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Delete, Qt::NoModifier);
+
+    // Act
+    view->keyPressEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->keyPressCount, 1);
+}
+
+TEST_F(CanvasViewEventTest, MousePressEvent_EmptyAreaLeftButton_StartsBoxSelection)
+{
+    // Arrange
+    hook->mousePressResult = false;
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    bool touchChecked = false;
+    stub.set_lamda(ADDR(ViewSettingUtil, checkTouchDrag),
+                   [&touchChecked](ViewSettingUtil *, QMouseEvent *) {
+                       touchChecked = true;
+                   });
+    bool committed = false;
+    stub.set_lamda(ADDR(CanvasItemDelegate, commitDataAndCloseEditor),
+                   [&committed](CanvasItemDelegate *) {
+                       committed = true;
+                   });
+    bool boxBegin = false;
+    stub.set_lamda(ADDR(BoxSelector, beginSelect),
+                   [&boxBegin](BoxSelector *, const QPoint &, bool) {
+                       boxBegin = true;
+                   });
+    QModelIndex clickedIndex(0, 0, nullptr, mockModel);
+    bool clickCaptured = false;
+    stub.set_lamda(ADDR(ClickSelector, click),
+                   [&clickCaptured](ClickSelector *, const QModelIndex &) {
+                       clickCaptured = true;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(touchChecked);
+    EXPECT_TRUE(committed);
+    EXPECT_TRUE(boxBegin);
+    EXPECT_TRUE(clickCaptured);
+    EXPECT_EQ(view->state(), QAbstractItemView::DragSelectingState);
+}
+
+TEST_F(CanvasViewEventTest, MouseMoveEvent_PlainMove_StateUnchanged)
+{
+    // Arrange
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+
+    // Act
+    QMouseEvent event(QEvent::MouseMove, QPointF(50, 50), QPointF(50, 50),
+                      QPointF(150, 150), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseMoveEvent(&event);
+
+    // Assert
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+}
+
+TEST_F(CanvasViewEventTest, MouseReleaseEvent_LeftButtonOnEmpty_ForwardsToClickSelector)
+{
+    // Arrange
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    QModelIndex released(-1, -1, nullptr, nullptr);
+    stub.set_lamda(ADDR(ClickSelector, release),
+                   [&released](ClickSelector *, const QModelIndex &index) {
+                       released = index;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    // Assert
+    EXPECT_FALSE(released.isValid());
+    EXPECT_EQ(released.model(), nullptr);
+}
+
+TEST_F(CanvasViewEventTest, MouseReleaseEvent_RightButton_SkipsClickSelector)
+{
+    // Arrange
+    bool releaseCalled = false;
+    stub.set_lamda(ADDR(ClickSelector, release),
+                   [&releaseCalled](ClickSelector *, const QModelIndex &) {
+                       releaseCalled = true;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    // Assert
+    EXPECT_FALSE(releaseCalled);
+}
+
+TEST_F(CanvasViewEventTest, WheelEvent_HookConsumsWheel_ChangeIconLevelSkipped)
+{
+    // Arrange
+    hook->wheelResult = true;
+    bool iconLevelChanged = false;
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, changeIconLevel),
+                   [&iconLevelChanged](CanvasViewMenuProxy *, bool) {
+                       iconLevelChanged = true;
+                   });
+
+    // Act
+    QWheelEvent event(QPointF(50, 50), QPointF(150, 150), QPoint(0, 120), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    view->wheelEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->wheelCount, 1);
+    EXPECT_FALSE(iconLevelChanged);
+}
+
+TEST_F(CanvasViewEventTest, WheelEvent_NoCtrlWheel_DoesNotChangeIconLevel)
+{
+    // Arrange
+    hook->wheelResult = false;
+    bool iconLevelChanged = false;
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, changeIconLevel),
+                   [&iconLevelChanged](CanvasViewMenuProxy *, bool) {
+                       iconLevelChanged = true;
+                   });
+
+    // Act
+    QWheelEvent event(QPointF(50, 50), QPointF(150, 150), QPoint(0, 120), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    view->wheelEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->wheelCount, 1);
+    EXPECT_FALSE(iconLevelChanged);
+}
+
+TEST_F(CanvasViewEventTest, ItemRect_UnknownItem_ReturnsInvalidRect)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileUrl),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> QUrl {
+                       return QUrl();
+                   });
+
+    // Act
+    QRect rect = view->itemRect(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_TRUE(rect.isNull());
+    EXPECT_EQ(rect, QRect());
+}
+
+TEST_F(CanvasViewEventTest, ItemRect_KnownGridItem_ReturnsGridRect)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileUrl),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> QUrl {
+                       return QUrl("file:///home/a");
+                   });
+    bool gridPosFound = false;
+    stub.set_lamda(ADDR(CanvasViewPrivate, itemGridpos),
+                   [&gridPosFound](const CanvasViewPrivate *, const QString &item, QPoint &gridPos) {
+                       gridPosFound = item == QString("file:///home/a");
+                       gridPos = QPoint(1, 1);
+                       return gridPosFound;
+                   });
+    QRect canned(7, 8, 100, 100);
+    stub.set_lamda(ADDR(CanvasViewPrivate, itemRect),
+                   [&canned](const CanvasViewPrivate *, const QPoint &) -> QRect {
+                       return canned;
+                   });
+
+    // Act
+    QRect rect = view->itemRect(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_TRUE(gridPosFound);
+    EXPECT_EQ(rect, canned);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndexByClicked_MatchingActionWithNullInfo_DoesNotOpen)
+{
+    // Arrange
+    TestProxyModel testProxy;   // flags() reports enabled so the handler reaches openIndex
+    stub.set_lamda(ADDR(CanvasView, model),
+                   [&testProxy](const CanvasView *) -> CanvasProxyModel * {
+                       return &testProxy;
+                   });
+    stub.set_lamda(ADDR(Application, instance), []() -> Application * {
+        return canvas_test::sharedApp();
+    });
+    stub.set_lamda(ADDR(Application, appAttribute),
+                   [](Application::ApplicationAttribute) -> QVariant {
+                       return QVariant(static_cast<int>(CanvasViewPrivate::ClickedAction::kClicked));
+                   });
+    stub.set_lamda(ADDR(WindowUtils, keyCtrlIsPressed),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(WindowUtils, keyShiftIsPressed),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasProxyModel, fileInfo),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> FileInfoPointer {
+                       return FileInfoPointer();
+                   });
+    bool openFilesCalled = false;
+    stub.set_lamda(static_cast<void (FileOperatorProxy::*)(const CanvasView *, const QList<QUrl> &)>(&FileOperatorProxy::openFiles),
+                   [&openFilesCalled](FileOperatorProxy *, const CanvasView *, const QList<QUrl> &) {
+                       openFilesCalled = true;
+                   });
+
+    // Act
+    view->d->openIndexByClicked(CanvasViewPrivate::ClickedAction::kClicked, QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert: flags on an empty proxy model lack ItemIsEnabled, so no open happens.
+    EXPECT_FALSE(openFilesCalled);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndex_NullFileInfo_DoesNotOpenFiles)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileInfo),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> FileInfoPointer {
+                       return FileInfoPointer();
+                   });
+    bool openFilesCalled = false;
+    stub.set_lamda(static_cast<void (FileOperatorProxy::*)(const CanvasView *, const QList<QUrl> &)>(&FileOperatorProxy::openFiles),
+                   [&openFilesCalled](FileOperatorProxy *, const CanvasView *, const QList<QUrl> &) {
+                       openFilesCalled = true;
+                   });
+
+    // Act
+    view->d->openIndex(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_FALSE(openFilesCalled);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndexByClicked_NonMatchingAction_SkipsOpen)
+{
+    // Arrange
+    stub.set_lamda(ADDR(Application, instance), []() -> Application * {
+        return canvas_test::sharedApp();
+    });
+    stub.set_lamda(ADDR(Application, appAttribute),
+                   [](Application::ApplicationAttribute) -> QVariant {
+                       return QVariant(static_cast<int>(CanvasViewPrivate::ClickedAction::kDoubleClicked));
+                   });
+    bool openIndexCalled = false;
+    stub.set_lamda(ADDR(CanvasViewPrivate, openIndex),
+                   [&openIndexCalled](CanvasViewPrivate *, const QModelIndex &) {
+                       openIndexCalled = true;
+                   });
+
+    // Act
+    view->d->openIndexByClicked(CanvasViewPrivate::ClickedAction::kClicked, QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_FALSE(openIndexCalled);
+}
+
+TEST_F(CanvasViewEventTest, FindIndex_EmptyGrid_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasGrid, item),
+                   [](const CanvasGrid *, int, const QPoint &) -> QString {
+                       return QString();
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return QModelIndex();
+                   });
+
+    // Act
+    QModelIndex found = view->d->findIndex(QString("a"), true, QModelIndex(), false, false);
+
+    // Assert
+    EXPECT_FALSE(found.isValid());
+    EXPECT_EQ(found, QModelIndex());
+}
+
+TEST_F(CanvasViewEventTest, FindIndex_MatchingPinyinName_ReturnsModelIndex)
+{
+    // Arrange
+    TestProxyModel testProxy;   // data() reports a matching pinyin name
+    stub.set_lamda(ADDR(CanvasView, model),
+                   [&testProxy](const CanvasView *) -> CanvasProxyModel * {
+                       return &testProxy;
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+
+    // Act
+    QModelIndex found = view->d->findIndex(QString("app"), true, QModelIndex(), false, false);
+
+    // Assert
+    EXPECT_TRUE(found.isValid());
+    EXPECT_EQ(found, canned);
+}
+
+TEST_F(CanvasViewEventTest, LastIndex_WithOverloadItem_ReturnsOverloadModelIndex)
+{
+    // Arrange
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    QUrl capturedUrl;
+    stub.set_lamda(ADDR(CanvasGrid, overloadItems),
+                   [](const CanvasGrid *, int) -> QStringList {
+                       return { QString("file:///home/overload") };
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned, &capturedUrl](const CanvasProxyModel *, const QUrl &url, int) -> QModelIndex {
+                       capturedUrl = url;
+                       return canned;
+                   });
+
+    // Act
+    QModelIndex last = view->d->lastIndex();
+
+    // Assert
+    EXPECT_EQ(capturedUrl, QUrl("file:///home/overload"));
+    EXPECT_TRUE(last.isValid());
+    EXPECT_EQ(last, canned);
+}
+
+TEST_F(CanvasViewEventTest, LastIndex_EmptyGrid_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasGrid, overloadItems),
+                   [](const CanvasGrid *, int) -> QStringList {
+                       return QStringList();
+                   });
+    stub.set_lamda(ADDR(CanvasGrid, item),
+                   [](const CanvasGrid *, int, const QPoint &) -> QString {
+                       return QString();
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return QModelIndex();
+                   });
+
+    // Act
+    QModelIndex last = view->d->lastIndex();
+
+    // Assert
+    EXPECT_FALSE(last.isValid());
+    EXPECT_EQ(last, QModelIndex());
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_PointInsideIconRect_ReturnsItemIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 100, 100), QRect(0, 100, 100, 40) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(50, 50));
+
+    // Assert
+    EXPECT_TRUE(at.isValid());
+    EXPECT_EQ(at, canned);
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_ExpandedItemInsideIconRect_ReturnsCurrentIndex)
+{
+    // Arrange: expanded item branch exercises indexAt's own checkRect lambda.
+    QModelIndex current(0, 0, nullptr, mockModel);
+    stub.set_lamda(VADDR(QAbstractItemView, currentIndex),
+                   [&current](const QAbstractItemView *) -> QModelIndex {
+                       return current;
+                   });
+    stub.set_lamda(VADDR(QAbstractItemView, isPersistentEditorOpen),
+                   [](const QAbstractItemView *, const QModelIndex &) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return true;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 100, 100), QRect(0, 100, 100, 40) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(50, 50));
+
+    // Assert
+    EXPECT_TRUE(at.isValid());
+    EXPECT_EQ(at, current);
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_PointOutsideAllRects_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 10, 10) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(500, 500));
+
+    // Assert
+    EXPECT_FALSE(at.isValid());
+    EXPECT_NE(at, canned);
+}

--- a/autotests/plugins/ddplugin-canvas/test_eventdispatch.cpp
+++ b/autotests/plugins/ddplugin-canvas/test_eventdispatch.cpp
@@ -1,0 +1,824 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "plugins/desktop/ddplugin-canvas/broker/canvasgridbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasviewbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasmodelbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasmanagerbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/fileinfomodelbroker.h"
+#include "plugins/desktop/ddplugin-canvas/canvasmanager.h"
+#include "plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h"
+#include "plugins/desktop/ddplugin-canvas/grid/canvasgrid.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasproxymodel.h"
+#include "plugins/desktop/ddplugin-canvas/model/fileinfomodel.h"
+#include "plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/dfm_event_defines.h>
+
+#include <dlfcn.h>
+
+#include <gtest/gtest.h>
+#include <QHash>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QVariant>
+#include <QStandardItemModel>
+#include <QAbstractItemView>
+#include <QItemSelectionModel>
+
+DPF_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace ddplugin_canvas;
+
+namespace {
+// Maps "space::topic" to a stable id inside the custom event type range so
+// dpfSlotChannel / dpfSignalDispatcher resolve topics in the test process.
+int canvasTestEventConverter(const QString &space, const QString &topic)
+{
+    static QHash<QString, int> mapping;
+    const QString key = space + "::" + topic;
+    const auto it = mapping.constFind(key);
+    if (it != mapping.constEnd())
+        return it.value();
+    const int id = static_cast<int>(EventTypeScope::kCustomBase) + mapping.size();
+    mapping.insert(key, id);
+    return id;
+}
+
+void installCanvasTestConverter()
+{
+    // Construct the framework Event singleton first: its constructor registers
+    // the production converter exactly once (std::call_once) and would clobber
+    // a direct assignment made before the first dpfEvent evaluation.
+    dpf::Event::instance();
+    // C++17 inline variables get separate instances in the test executable and
+    // in libdfm6-framework.so (the two are not unified at dynamic link). Assign
+    // every reachable instance so dpfSlotChannel/dpfSignalDispatcher resolve
+    // topics no matter which TU the inline call site was instantiated in.
+    EventConverter::convertFunc = &canvasTestEventConverter;
+    if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                dlsym(RTLD_DEFAULT, "_ZN3dpf14EventConverter11convertFuncE"))) {
+        *func = &canvasTestEventConverter;
+    }
+    if (void *framework = dlopen("libdfm6-framework.so.1", RTLD_LAZY | RTLD_NOLOAD)) {
+        if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                    dlsym(framework, "_ZN3dpf14EventConverter11convertFuncE"))) {
+            *func = &canvasTestEventConverter;
+        }
+    }
+}
+}   // namespace
+
+static constexpr auto kCanvasSpace = "ddplugin_canvas";
+
+class CanvasGridBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        grid = new CanvasGrid(nullptr);
+        broker = new CanvasGridBroker(grid);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete grid;
+        stub.clear();
+    }
+
+    CanvasGrid *grid = nullptr;
+    CanvasGridBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridItems_InvokesBrokerMethod)
+{
+    QStringList canned { "file:///home/a", "file:///home/b" };
+    int capturedIndex = -1;
+    stub.set_lamda(ADDR(CanvasGridBroker, items),
+                   [&canned, &capturedIndex](CanvasGridBroker *, int index) -> QStringList {
+                       __DBG_STUB_INVOKE__
+                       capturedIndex = index;
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Items", 2);
+    EXPECT_EQ(capturedIndex, 2);
+    EXPECT_EQ(ret.value<QStringList>(), canned);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridItem_InvokesBrokerMethod)
+{
+    QString canned("file:///home/a");
+    int capturedIndex = -1;
+    QPoint capturedPos(-1, -1);
+    stub.set_lamda(ADDR(CanvasGridBroker, item),
+                   [&canned, &capturedIndex, &capturedPos](CanvasGridBroker *, int index, const QPoint &pos) -> QString {
+                       capturedIndex = index;
+                       capturedPos = pos;
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Item", 1, QPoint(3, 4));
+    EXPECT_EQ(capturedIndex, 1);
+    EXPECT_EQ(capturedPos, QPoint(3, 4));
+    EXPECT_EQ(ret.toString(), canned);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridPoint_InvokesBrokerMethod)
+{
+    const QString item("file:///home/a");
+    int capturedScreen = -2;
+    stub.set_lamda(ADDR(CanvasGridBroker, point),
+                   [&capturedScreen](CanvasGridBroker *, const QString &, QPoint *pos) -> int {
+                       if (pos)
+                           *pos = QPoint(7, 8);
+                       capturedScreen = 1;
+                       return 1;
+                   });
+
+    QPoint pos;
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Point",
+                                        item, QVariant::fromValue(&pos));
+    EXPECT_EQ(capturedScreen, 1);
+    EXPECT_EQ(pos, QPoint(7, 8));
+    EXPECT_EQ(ret.toInt(), 1);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridTryAppendAfter_InvokesBrokerMethod)
+{
+    bool invoked = false;
+    QStringList capturedItems;
+    stub.set_lamda(ADDR(CanvasGridBroker, tryAppendAfter),
+                   [&invoked, &capturedItems](CanvasGridBroker *, const QStringList &items, int, const QPoint &) {
+                       invoked = true;
+                       capturedItems = items;
+                   });
+
+    QStringList input { "x", "y" };
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_TryAppendAfter", input, 0, QPoint(0, 0));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(capturedItems, input);
+}
+
+class CanvasViewBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+        broker = new CanvasViewBroker(manager);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    CanvasViewBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushVisualRect_InvokesBrokerMethod)
+{
+    QRect canned(1, 2, 30, 30);
+    QUrl capturedUrl;
+    stub.set_lamda(ADDR(CanvasViewBroker, visualRect),
+                   [&canned, &capturedUrl](CanvasViewBroker *, int, const QUrl &url) -> QRect {
+                       capturedUrl = url;
+                       return canned;
+                   });
+
+    QUrl url("file:///home/a.txt");
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_VisualRect", 1, url);
+    EXPECT_EQ(capturedUrl, url);
+    EXPECT_EQ(ret.value<QRect>(), canned);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushGridPosAndGridVisualRect_InvokesBrokerMethods)
+{
+    QPoint cannedPos(11, 12);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridPos),
+                   [&cannedPos](CanvasViewBroker *, int, const QPoint &) -> QPoint {
+                       return cannedPos;
+                   });
+    QRect cannedRect(5, 6, 80, 90);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridVisualRect),
+                   [&cannedRect](CanvasViewBroker *, int, const QPoint &) -> QRect {
+                       return cannedRect;
+                   });
+
+    QVariant pos = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridPos", 1, QPoint(50, 60));
+    QVariant rect = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridVisualRect", 1, QPoint(0, 1));
+    EXPECT_EQ(pos.value<QPoint>(), cannedPos);
+    EXPECT_EQ(rect.value<QRect>(), cannedRect);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushGridSize_InvokesBrokerMethod)
+{
+    QSize canned(10, 8);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridSize),
+                   [&canned](CanvasViewBroker *, int) -> QSize {
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridSize", 1);
+    EXPECT_EQ(ret.value<QSize>(), canned);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushRefreshAndUpdate_InvokesBrokerMethods)
+{
+    int refreshIdx = -1;
+    int updateIdx = -1;
+    stub.set_lamda(ADDR(CanvasViewBroker, refresh),
+                   [&refreshIdx](CanvasViewBroker *, int idx) {
+                       refreshIdx = idx;
+                   });
+    stub.set_lamda(ADDR(CanvasViewBroker, update),
+                   [&updateIdx](CanvasViewBroker *, int idx) {
+                       updateIdx = idx;
+                   });
+
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Refresh", 3);
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Update", -1);
+    EXPECT_EQ(refreshIdx, 3);
+    EXPECT_EQ(updateIdx, -1);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushSelectAndSelectedUrls_InvokesBrokerMethods)
+{
+    QList<QUrl> capturedSelect;
+    stub.set_lamda(ADDR(CanvasViewBroker, select),
+                   [&capturedSelect](CanvasViewBroker *, const QList<QUrl> &urls) {
+                       capturedSelect = urls;
+                   });
+    QList<QUrl> cannedSelected { QUrl("file:///home/s1") };
+    stub.set_lamda(ADDR(CanvasViewBroker, selectedUrls),
+                   [&cannedSelected](CanvasViewBroker *, int) -> QList<QUrl> {
+                       return cannedSelected;
+                   });
+
+    QList<QUrl> input { QUrl("file:///home/a"), QUrl("file:///home/b") };
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Select", input);
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_SelectedUrls", 0);
+    EXPECT_EQ(capturedSelect, input);
+    EXPECT_EQ(ret.value<QList<QUrl>>(), cannedSelected);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushFileOperatorAndIconRect_InvokesBrokerMethods)
+{
+    QObject cannedOperator;
+    stub.set_lamda(ADDR(CanvasViewBroker, fileOperator),
+                   [&cannedOperator](CanvasViewBroker *) -> QObject * {
+                       return &cannedOperator;
+                   });
+    QRect cannedIcon(2, 3, 40, 40);
+    stub.set_lamda(ADDR(CanvasViewBroker, iconRect),
+                   [&cannedIcon](CanvasViewBroker *, int, QRect) -> QRect {
+                       return cannedIcon;
+                   });
+
+    QVariant op = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasViewPrivate_FileOperator");
+    QVariant icon = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasItemDelegate_IconRect", 1, QRect(0, 0, 100, 100));
+    EXPECT_EQ(op.value<QObject *>(), &cannedOperator);
+    EXPECT_EQ(icon.value<QRect>(), cannedIcon);
+}
+
+class CanvasModelBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        model = new CanvasProxyModel();
+        broker = new CanvasModelBroker(model);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete model;
+        stub.clear();
+    }
+
+    CanvasProxyModel *model = nullptr;
+    CanvasModelBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushUrlQueries_InvokesBrokerMethods)
+{
+    QUrl cannedRoot("file:///home");
+    stub.set_lamda(ADDR(CanvasModelBroker, rootUrl),
+                   [&cannedRoot](CanvasModelBroker *) -> QUrl {
+                       return cannedRoot;
+                   });
+    QModelIndex cannedIndex(0, 0, nullptr, model);
+    stub.set_lamda(ADDR(CanvasModelBroker, urlIndex),
+                   [&cannedIndex](CanvasModelBroker *, const QUrl &) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    stub.set_lamda(ADDR(CanvasModelBroker, index),
+                   [&cannedIndex](CanvasModelBroker *, int) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    QUrl cannedUrl("file:///home/a");
+    stub.set_lamda(ADDR(CanvasModelBroker, fileUrl),
+                   [&cannedUrl](CanvasModelBroker *, const QModelIndex &) -> QUrl {
+                       return cannedUrl;
+                   });
+    QList<QUrl> cannedFiles { QUrl("file:///home/f1") };
+    stub.set_lamda(ADDR(CanvasModelBroker, files),
+                   [&cannedFiles](CanvasModelBroker *) -> QList<QUrl> {
+                       return cannedFiles;
+                   });
+
+    QUrl input("file:///home/in");
+    QVariant root = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_RootUrl");
+    QVariant urlIndex = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_UrlIndex", input);
+    QVariant row = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Index", 0);
+    QVariant fileUrl = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_FileUrl", QVariant::fromValue(cannedIndex));
+    QVariant files = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Files");
+    EXPECT_EQ(root.value<QUrl>(), cannedRoot);
+    EXPECT_EQ(urlIndex.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(row.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(fileUrl.value<QUrl>(), cannedUrl);
+    EXPECT_EQ(files.value<QList<QUrl>>(), cannedFiles);
+}
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushFlagsAndSortSettings_InvokesBrokerMethods)
+{
+    bool cannedHidden = true;
+    stub.set_lamda(ADDR(CanvasModelBroker, showHiddenFiles),
+                   [&cannedHidden](CanvasModelBroker *) -> bool {
+                       return cannedHidden;
+                   });
+    int capturedShow = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setShowHiddenFiles),
+                   [&capturedShow](CanvasModelBroker *, bool show) {
+                       capturedShow = static_cast<int>(show);
+                   });
+    int cannedOrder = Qt::DescendingOrder;
+    stub.set_lamda(ADDR(CanvasModelBroker, sortOrder),
+                   [&cannedOrder](CanvasModelBroker *) -> int {
+                       return cannedOrder;
+                   });
+    int capturedOrder = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setSortOrder),
+                   [&capturedOrder](CanvasModelBroker *, int order) {
+                       capturedOrder = order;
+                   });
+    int cannedRole = 257;
+    stub.set_lamda(ADDR(CanvasModelBroker, sortRole),
+                   [&cannedRole](CanvasModelBroker *) -> int {
+                       return cannedRole;
+                   });
+    int capturedRole = -1;
+    int capturedRoleOrder = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setSortRole),
+                   [&capturedRole, &capturedRoleOrder](CanvasModelBroker *, int role, int order) {
+                       capturedRole = role;
+                       capturedRoleOrder = order;
+                   });
+    int cannedRowCount = 42;
+    stub.set_lamda(ADDR(CanvasModelBroker, rowCount),
+                   [&cannedRowCount](CanvasModelBroker *) -> int {
+                       return cannedRowCount;
+                   });
+
+    QVariant hidden = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_ShowHiddenFiles");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetShowHiddenFiles", true);
+    QVariant order = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SortOrder");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetSortOrder", 1);
+    QVariant role = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SortRole");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetSortRole", 257, 1);
+    QVariant rows = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_RowCount");
+    EXPECT_TRUE(hidden.toBool());
+    EXPECT_EQ(capturedShow, 1);
+    EXPECT_EQ(order.toInt(), Qt::DescendingOrder);
+    EXPECT_EQ(capturedOrder, 1);
+    EXPECT_EQ(role.toInt(), 257);
+    EXPECT_EQ(capturedRole, 257);
+    EXPECT_EQ(capturedRoleOrder, 1);
+    EXPECT_EQ(rows.toInt(), 42);
+}
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushDataSortRefreshFetchTake_InvokesBrokerMethods)
+{
+    QVariant cannedData("icon-name");
+    QUrl capturedDataUrl;
+    int capturedDataRole = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, data),
+                   [&cannedData, &capturedDataUrl, &capturedDataRole](CanvasModelBroker *, const QUrl &url, int role) -> QVariant {
+                       capturedDataUrl = url;
+                       capturedDataRole = role;
+                       return cannedData;
+                   });
+    bool sortInvoked = false;
+    stub.set_lamda(ADDR(CanvasModelBroker, sort),
+                   [&sortInvoked](CanvasModelBroker *) {
+                       sortInvoked = true;
+                   });
+    int capturedGlobal = -1;
+    int capturedMs = -1;
+    int capturedUpdate = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, refresh),
+                   [&capturedGlobal, &capturedMs, &capturedUpdate](CanvasModelBroker *, bool global, int ms, bool updateFile) {
+                       capturedGlobal = static_cast<int>(global);
+                       capturedMs = ms;
+                       capturedUpdate = static_cast<int>(updateFile);
+                   });
+    bool cannedFetch = true;
+    stub.set_lamda(ADDR(CanvasModelBroker, fetch),
+                   [&cannedFetch](CanvasModelBroker *, const QUrl &) -> bool {
+                       return cannedFetch;
+                   });
+    bool cannedTake = false;
+    stub.set_lamda(ADDR(CanvasModelBroker, take),
+                   [&cannedTake](CanvasModelBroker *, const QUrl &) -> bool {
+                       return cannedTake;
+                   });
+
+    QUrl input("file:///home/data.txt");
+    QVariant data = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Data", input, 257);
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Sort");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Refresh", false, 200, true);
+    QVariant fetch = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Fetch", input);
+    QVariant take = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Take", input);
+    EXPECT_EQ(capturedDataUrl, input);
+    EXPECT_EQ(capturedDataRole, 257);
+    EXPECT_EQ(data.value<QVariant>().toString(), QString("icon-name"));   // QVariant return is wrapped
+    EXPECT_TRUE(sortInvoked);
+    EXPECT_EQ(capturedGlobal, 0);
+    EXPECT_EQ(capturedMs, 200);
+    EXPECT_EQ(capturedUpdate, 1);
+    EXPECT_TRUE(fetch.toBool());
+    EXPECT_FALSE(take.toBool());
+}
+
+class CanvasManagerBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+        broker = new CanvasManagerBroker(manager);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    CanvasManagerBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasManagerBrokerEventTest, SlotChannel_PushVoidAndValueQueries_InvokesBrokerMethods)
+{
+    bool updateInvoked = false;
+    stub.set_lamda(ADDR(CanvasManagerBroker, update),
+                   [&updateInvoked](CanvasManagerBroker *) {
+                       updateInvoked = true;
+                   });
+    QStandardItemModel cannedModel;
+    stub.set_lamda(ADDR(CanvasManagerBroker, fileInfoModel),
+                   [&cannedModel](CanvasManagerBroker *) -> QAbstractItemModel * {
+                       return &cannedModel;
+                   });
+    int cannedLevel = 3;
+    stub.set_lamda(ADDR(CanvasManagerBroker, iconLevel),
+                   [&cannedLevel](CanvasManagerBroker *) -> int {
+                       return cannedLevel;
+                   });
+    int capturedLevel = -1;
+    stub.set_lamda(ADDR(CanvasManagerBroker, setIconLevel),
+                   [&capturedLevel](CanvasManagerBroker *, int lv) {
+                       capturedLevel = lv;
+                   });
+    bool cannedArrange = true;
+    stub.set_lamda(ADDR(CanvasManagerBroker, autoArrange),
+                   [&cannedArrange](CanvasManagerBroker *) -> bool {
+                       return cannedArrange;
+                   });
+    int capturedArrange = -1;
+    stub.set_lamda(ADDR(CanvasManagerBroker, setAutoArrange),
+                   [&capturedArrange](CanvasManagerBroker *, bool on) {
+                       capturedArrange = static_cast<int>(on);
+                   });
+    QUrl capturedEditUrl;
+    stub.set_lamda(ADDR(CanvasManagerBroker, edit),
+                   [&capturedEditUrl](CanvasManagerBroker *, const QUrl &url) {
+                       capturedEditUrl = url;
+                   });
+
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_Update");
+    QVariant model = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_FileInfoModel");
+    QVariant level = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_IconLevel");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SetIconLevel", 4);
+    QVariant arrange = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_AutoArrange");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SetAutoArrange", true);
+    QUrl editUrl("file:///home/edit.txt");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_Edit", editUrl);
+    EXPECT_TRUE(updateInvoked);
+    EXPECT_EQ(model.value<QAbstractItemModel *>(), &cannedModel);
+    EXPECT_EQ(level.toInt(), 3);
+    EXPECT_EQ(capturedLevel, 4);
+    EXPECT_TRUE(arrange.toBool());
+    EXPECT_EQ(capturedArrange, 1);
+    EXPECT_EQ(capturedEditUrl, editUrl);
+}
+
+TEST_F(CanvasManagerBrokerEventTest, SlotChannel_PushViewAndSelectionModel_InvokesBrokerMethods)
+{
+    QAbstractItemView *cannedView = reinterpret_cast<QAbstractItemView *>(0x10);
+    stub.set_lamda(ADDR(CanvasManagerBroker, view),
+                   [cannedView](CanvasManagerBroker *, int) -> QAbstractItemView * {
+                       return cannedView;
+                   });
+    QItemSelectionModel *cannedSelection = reinterpret_cast<QItemSelectionModel *>(0x20);
+    stub.set_lamda(ADDR(CanvasManagerBroker, selectionModel),
+                   [cannedSelection](CanvasManagerBroker *) -> QItemSelectionModel * {
+                       return cannedSelection;
+                   });
+
+    QVariant view = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_View", 1);
+    QVariant selection = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SelectionModel");
+    EXPECT_EQ(view.value<QAbstractItemView *>(), cannedView);
+    EXPECT_EQ(selection.value<QItemSelectionModel *>(), cannedSelection);
+}
+
+class FileInfoModelBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        model = new FileInfoModel();
+        broker = new FileInfoModelBroker(model);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete model;
+        stub.clear();
+    }
+
+    FileInfoModel *model = nullptr;
+    FileInfoModelBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(FileInfoModelBrokerEventTest, SlotChannel_PushUrlAndIndexQueries_InvokesBrokerMethods)
+{
+    QUrl cannedRoot("file:///home");
+    stub.set_lamda(ADDR(FileInfoModelBroker, rootUrl),
+                   [&cannedRoot](FileInfoModelBroker *) -> QUrl {
+                       return cannedRoot;
+                   });
+    QModelIndex cannedRootIndex(0, 0, nullptr, model);
+    stub.set_lamda(ADDR(FileInfoModelBroker, rootIndex),
+                   [&cannedRootIndex](FileInfoModelBroker *) -> QModelIndex {
+                       return cannedRootIndex;
+                   });
+    QModelIndex cannedIndex(1, 0, nullptr, model);
+    stub.set_lamda(ADDR(FileInfoModelBroker, urlIndex),
+                   [&cannedIndex](FileInfoModelBroker *, const QUrl &) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    QUrl cannedUrl("file:///home/index-url");
+    stub.set_lamda(ADDR(FileInfoModelBroker, indexUrl),
+                   [&cannedUrl](FileInfoModelBroker *, const QModelIndex &) -> QUrl {
+                       return cannedUrl;
+                   });
+    QList<QUrl> cannedFiles { QUrl("file:///home/x") };
+    stub.set_lamda(ADDR(FileInfoModelBroker, files),
+                   [&cannedFiles](FileInfoModelBroker *) -> QList<QUrl> {
+                       return cannedFiles;
+                   });
+    int cannedState = 2;
+    stub.set_lamda(ADDR(FileInfoModelBroker, modelState),
+                   [&cannedState](FileInfoModelBroker *) -> int {
+                       return cannedState;
+                   });
+
+    QUrl input("file:///home/q");
+    QVariant root = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_RootUrl");
+    QVariant rootIndex = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_RootIndex");
+    QVariant urlIndex = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_UrlIndex", input);
+    QVariant indexUrl = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_IndexUrl", QVariant::fromValue(cannedIndex));
+    QVariant files = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_Files");
+    QVariant state = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_ModelState");
+    EXPECT_EQ(root.value<QUrl>(), cannedRoot);
+    EXPECT_EQ(rootIndex.value<QModelIndex>(), cannedRootIndex);
+    EXPECT_EQ(urlIndex.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(indexUrl.value<QUrl>(), cannedUrl);
+    EXPECT_EQ(files.value<QList<QUrl>>(), cannedFiles);
+    EXPECT_EQ(state.toInt(), 2);
+}
+
+TEST_F(FileInfoModelBrokerEventTest, SlotChannel_PushFileInfoRefreshUpdateFile_InvokesBrokerMethods)
+{
+    FileInfoPointer cannedInfo;
+    stub.set_lamda(ADDR(FileInfoModelBroker, fileInfo),
+                   [&cannedInfo](FileInfoModelBroker *, const QModelIndex &) -> FileInfoPointer {
+                       return cannedInfo;
+                   });
+    QModelIndex capturedRefresh;
+    stub.set_lamda(ADDR(FileInfoModelBroker, refresh),
+                   [&capturedRefresh](FileInfoModelBroker *, const QModelIndex &parent) {
+                       capturedRefresh = parent;
+                   });
+    QUrl capturedUpdateUrl;
+    stub.set_lamda(ADDR(FileInfoModelBroker, updateFile),
+                   [&capturedUpdateUrl](FileInfoModelBroker *, const QUrl &url) {
+                       capturedUpdateUrl = url;
+                   });
+
+    QModelIndex input(3, 0, nullptr, model);
+    QVariant info = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_FileInfo", QVariant::fromValue(input));
+    dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_Refresh", QVariant::fromValue(input));
+    QUrl updateUrl("file:///home/update.txt");
+    dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_UpdateFile", updateUrl);
+    EXPECT_EQ(info.value<FileInfoPointer>(), cannedInfo);
+    EXPECT_EQ(capturedRefresh, input);
+    EXPECT_EQ(capturedUpdateUrl, updateUrl);
+}
+
+class CanvasManagerSignalTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+    }
+
+    void TearDown() override
+    {
+        // Remove the handlers registered by the tests so later suites never
+        // dispatch into stale objects.
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_GeometryChanged", manager, &CanvasManager::onGeometryChanged);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged", manager, &CanvasManager::onGeometryChanged);
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishWindowAboutToBeBuilded_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onDetachWindows),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishWindowBuilded_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onCanvasBuild),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowBuilded"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishGeometryChanged_InvokesHandler)
+{
+    int invoked = 0;
+    stub.set_lamda(ADDR(CanvasManager, onGeometryChanged),
+                   [&invoked](CanvasManager *) {
+                       ++invoked;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_GeometryChanged", manager, &CanvasManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged", manager, &CanvasManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_GeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged"));
+    EXPECT_EQ(invoked, 2);
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishTrashStateChanged_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onTrashStateChanged),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", manager, &CanvasManager::onTrashStateChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", manager, &CanvasManager::onTrashStateChanged));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_RealInitSubscriptions_AllHandlersInvokedAndRemoved)
+{
+    // Arrange: run the production init() so the subscribe sites inside
+    // canvasmanager.cpp register the real handlers, with heavy internals
+    // stubbed away.
+    int detachCount = 0;
+    int buildCount = 0;
+    int geometryCount = 0;
+    int trashCount = 0;
+    stub.set_lamda(ADDR(CanvasManager, onDetachWindows),
+                   [&detachCount](CanvasManager *) { ++detachCount; });
+    stub.set_lamda(ADDR(CanvasManager, onCanvasBuild),
+                   [&buildCount](CanvasManager *) { ++buildCount; });
+    stub.set_lamda(ADDR(CanvasManager, onGeometryChanged),
+                   [&geometryCount](CanvasManager *) { ++geometryCount; });
+    stub.set_lamda(ADDR(CanvasManager, onTrashStateChanged),
+                   [&trashCount](CanvasManager *) { ++trashCount; });
+    int recentCount = 0;
+    stub.set_lamda(ADDR(CanvasRecentProxy, handleReloadRecentFiles),
+                   [&recentCount](CanvasRecentProxy *, const QList<QUrl> &, bool, const QString &) { ++recentCount; });
+    stub.set_lamda(ADDR(CanvasManagerPrivate, initModel), [](CanvasManagerPrivate *) { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(CanvasManagerPrivate, initSetting), [](CanvasManagerPrivate *) { __DBG_STUB_INVOKE__ });
+
+    manager->init();
+
+    // Act: fire every subscribed signal through the real dispatcher.
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowBuilded"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_GeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    QList<QUrl> urls { QUrl("file:///home/r") };
+    EXPECT_TRUE(dpfSignalDispatcher->publish(static_cast<int>(GlobalEventType::kMoveToTrashResult), urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(static_cast<int>(GlobalEventType::kDeleteFilesResult), urls, true, QString()));
+
+    // Assert
+    EXPECT_EQ(detachCount, 1);
+    EXPECT_EQ(buildCount, 1);
+    EXPECT_EQ(geometryCount, 2);
+    EXPECT_EQ(trashCount, 1);
+    EXPECT_EQ(recentCount, 2);
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishJobResults_InvokesRecentProxyHandler)
+{
+    CanvasRecentProxy proxy;
+    QList<QUrl> capturedUrls;
+    bool capturedOk = false;
+    QString capturedMsg;
+    stub.set_lamda(ADDR(CanvasRecentProxy, handleReloadRecentFiles),
+                   [&capturedUrls, &capturedOk, &capturedMsg](CanvasRecentProxy *, const QList<QUrl> &urls, bool ok, const QString &errMsg) {
+                       capturedUrls = urls;
+                       capturedOk = ok;
+                       capturedMsg = errMsg;
+                   });
+
+    const int movedToTrash = static_cast<int>(GlobalEventType::kMoveToTrashResult);
+    const int deleteFiles = static_cast<int>(GlobalEventType::kDeleteFilesResult);
+    QList<QUrl> input { QUrl("file:///home/recent.txt") };
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(movedToTrash, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(movedToTrash, input, true, QString("done")));
+    EXPECT_EQ(capturedUrls, input);
+    EXPECT_TRUE(capturedOk);
+    EXPECT_EQ(capturedMsg, QString("done"));
+
+    capturedUrls.clear();
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(deleteFiles, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(deleteFiles, input, false, QString("")));
+    EXPECT_EQ(capturedUrls, input);
+    EXPECT_FALSE(capturedOk);
+
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(movedToTrash, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(deleteFiles, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+}

--- a/autotests/plugins/dfmplugin-fileoperations/test_realevents_dispatch.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_realevents_dispatch.cpp
@@ -1,0 +1,1339 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real event-dispatch tests: wire handlers through the production
+// FileOperations::initialize() subscription list (plus a manual hook follow
+// for hook_Url_IsSubFile) and then PUBLISH the real GlobalEventType events
+// with exactly-typed QVariant arguments, so every EventHelper<M>::invoke /
+// EventHelper<M>::EventHelper template instantiation owned by
+// dfmplugin_fileoperations in include/dfm-framework/event/eventhelper.h
+// actually executes. Heavy handler dependencies (FileCopyMoveJob,
+// DialogManager, ClipBoard, LocalFileHandler, QProcess, OperationsStackProxy)
+// are stubbed and their arguments captured for exact-value assertions.
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QFileInfo>
+#include <QMimeData>
+#include <QProcess>
+#include <QDialog>
+#include <QApplication>
+#include <QImage>
+#include <QClipboard>
+
+#include "stubext.h"
+#include "dfm_hookreg.h"
+
+#include "fileoperations.h"
+#include "fileoperationsevent/fileoperationseventreceiver.h"
+#include "fileoperationsevent/trashfileeventreceiver.h"
+#include "fileoperations/filecopymovejob.h"
+#include "fileoperations/operationsstackproxy.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/hidefilehelper.h>
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+#include <DDesktopServices>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+using namespace dfmplugin_fileoperations;
+
+namespace {
+
+// ---------- captured arguments / call flags (reset in SetUp) ----------
+bool g_copyCalled = false;
+bool g_cutCalled = false;
+bool g_deletesCalled = false;
+bool g_moveToTrashCalled = false;
+bool g_restoreFromTrashCalled = false;
+bool g_copyFromTrashCalled = false;
+bool g_cleanTrashCalled = false;
+bool g_initArgsCalled = false;
+bool g_mkdirCalled = false;
+bool g_touchFileCalled = false;
+bool g_renameFileCalled = false;
+bool g_renameBatchCalled = false;
+bool g_openFilesCalled = false;
+bool g_openFilesByAppCalled = false;
+bool g_setPermsCalled = false;
+bool g_linkCalled = false;
+bool g_clipboardUrlsCalled = false;
+bool g_clipboardDataCalled = false;
+bool g_replaceClipCalled = false;
+bool g_hideSaveCalled = false;
+bool g_saveOpsCalled = false;
+bool g_saveRedoOpsCalled = false;
+bool g_cleanOpsCalled = false;
+bool g_cleanOpsByUrlsCalled = false;
+bool g_detached2Called = false;
+bool g_detached3Called = false;
+bool g_soundPlayed = false;
+bool g_noPermDialogCalled = false;
+bool g_deleteDialogShown = false;
+bool g_handleCbCalled = false;
+
+QList<QUrl> g_lastCopySources;
+QUrl g_lastCopyTarget;
+QList<QUrl> g_lastCutSources;
+QUrl g_lastCutTarget;
+QList<QUrl> g_lastDeleteSources;
+QList<QUrl> g_lastMoveTrashSources;
+AbstractJobHandler::JobFlags g_lastMoveTrashFlags;
+QList<QUrl> g_lastRestoreSources;
+QUrl g_lastRestoreTarget;
+QList<QUrl> g_lastCopyTrashSources;
+QUrl g_lastCopyTrashTarget;
+QList<QUrl> g_lastCleanTrashUrls;
+QUrl g_lastMkdirUrl;
+QUrl g_lastTouchUrl;
+QUrl g_lastTouchTempUrl;
+QUrl g_lastRenameOld;
+QUrl g_lastRenameNew;
+QMap<QUrl, QUrl> g_lastBatchMap;
+QList<QUrl> g_lastOpenUrls;
+QString g_lastOpenApp;
+QFileDevice::Permissions g_lastPerms;
+QUrl g_lastLinkSource;
+QUrl g_lastLinkTarget;
+ClipBoard::ClipboardAction g_lastClipAction = ClipBoard::ClipboardAction::kCopyAction;
+QList<QUrl> g_lastClipUrls;
+QMimeData *g_lastMimeData = nullptr;
+QString g_lastClipboardText;
+QStringList g_lastCleanOpsUrls;
+QStringList g_lastDetached2Args;
+QString g_lastDetachedProgram;
+QVariantMap g_lastSavedOps;
+QVariantMap g_lastSavedRedoOps;
+
+// operator-callback capture
+struct CallbackState
+{
+    bool called = false;
+    QVariant custom;
+    quint64 windowId = 0;
+    bool success = false;
+    bool hasHandle = false;
+    QList<QUrl> sourceUrls;
+};
+CallbackState g_opCb;
+
+void resetCaptures()
+{
+    g_copyCalled = g_cutCalled = g_deletesCalled = g_moveToTrashCalled = false;
+    g_restoreFromTrashCalled = g_copyFromTrashCalled = g_cleanTrashCalled = false;
+    g_initArgsCalled = g_mkdirCalled = g_touchFileCalled = g_renameFileCalled = false;
+    g_renameBatchCalled = g_openFilesCalled = g_openFilesByAppCalled = false;
+    g_setPermsCalled = g_linkCalled = g_clipboardUrlsCalled = g_clipboardDataCalled = false;
+    g_replaceClipCalled = g_hideSaveCalled = g_saveOpsCalled = g_saveRedoOpsCalled = false;
+    g_cleanOpsCalled = g_cleanOpsByUrlsCalled = g_detached2Called = g_detached3Called = false;
+    g_soundPlayed = g_noPermDialogCalled = g_deleteDialogShown = g_handleCbCalled = false;
+
+    g_lastCopySources.clear();
+    g_lastCopyTarget = QUrl();
+    g_lastCutSources.clear();
+    g_lastCutTarget = QUrl();
+    g_lastDeleteSources.clear();
+    g_lastMoveTrashSources.clear();
+    g_lastMoveTrashFlags = AbstractJobHandler::JobFlags(AbstractJobHandler::JobFlag::kNoHint);
+    g_lastRestoreSources.clear();
+    g_lastRestoreTarget = QUrl();
+    g_lastCopyTrashSources.clear();
+    g_lastCopyTrashTarget = QUrl();
+    g_lastCleanTrashUrls.clear();
+    g_lastMkdirUrl = QUrl();
+    g_lastTouchUrl = QUrl();
+    g_lastTouchTempUrl = QUrl();
+    g_lastRenameOld = QUrl();
+    g_lastRenameNew = QUrl();
+    g_lastBatchMap.clear();
+    g_lastOpenUrls.clear();
+    g_lastOpenApp = QString();
+    g_lastPerms = QFileDevice::Permissions();
+    g_lastLinkSource = QUrl();
+    g_lastLinkTarget = QUrl();
+    g_lastClipUrls.clear();
+    g_lastMimeData = nullptr;
+    g_lastClipboardText = QString();
+    g_lastCleanOpsUrls.clear();
+    g_lastDetached2Args.clear();
+    g_lastDetachedProgram = QString();
+    g_lastSavedOps.clear();
+    g_lastSavedRedoOps.clear();
+    g_opCb = CallbackState();
+}
+
+// captureless callbacks so they can travel inside QVariant::fromValue
+void takeHandleCallback(const JobHandlePointer &handle)
+{
+    g_handleCbCalled = handle != nullptr;
+}
+
+void takeOperatorCallback(const AbstractJobHandler::CallbackArgus &args)
+{
+    g_opCb.called = true;
+    g_opCb.custom = args->value(AbstractJobHandler::CallbackKey::kCustom);
+    g_opCb.windowId = args->value(AbstractJobHandler::CallbackKey::kWindowId).toULongLong();
+    g_opCb.success = args->value(AbstractJobHandler::CallbackKey::kSuccessed).toBool();
+    g_opCb.hasHandle = args->contains(AbstractJobHandler::CallbackKey::kJobHandle);
+    const auto &srcs = args->value(AbstractJobHandler::CallbackKey::kSourceUrls);
+    if (srcs.canConvert<QList<QUrl>>())
+        g_opCb.sourceUrls = srcs.value<QList<QUrl>>();
+}
+
+// wrap the free functions into the exact std::function types the handlers
+// expect, otherwise QVariant::fromValue would store a raw function pointer
+QVariant makeHandleCallback()
+{
+    return QVariant::fromValue(AbstractJobHandler::OperatorHandleCallback(takeHandleCallback));
+}
+
+QVariant makeOperatorCallback()
+{
+    return QVariant::fromValue(AbstractJobHandler::OperatorCallback(takeOperatorCallback));
+}
+
+std::once_flag g_wiringOnce;
+
+// Subscribe the full production event wiring exactly once for the process:
+// real initEventHandle() (dispatcher subscribe + slot channel connect) and
+// followEvents() (hook follows). Slot/hook topics must be registered first
+// so EventConverter::convert() yields a valid id.
+void ensureEventWiring()
+{
+    std::call_once(g_wiringOnce, []() {
+        dfmtest_hooks::registerAllHookEvents();
+        dpf::Event::instance()->registerEventType(dpf::EventStratege::kSlot,
+                                                  "dfmplugin_fileoperations",
+                                                  "slot_Operation_FilesPreview");
+        FileOperations ops;
+        ops.initialize();
+        // hook_Url_IsSubFile is only followed in production after the search
+        // plugin starts; follow it directly here so its EventHelper<...> runs.
+        dpfHookSequence->follow("dfmplugin_search", "hook_Url_IsSubFile",
+                                FileOperationsEventReceiver::instance(),
+                                &FileOperationsEventReceiver::handleIsSubFile);
+    });
+}
+
+}   // namespace
+
+class FileOpsEventDispatchTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        resetCaptures();
+
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        ensureEventWiring();
+        installCommonStubs();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+    }
+
+    QUrl createTestFile(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.write("dispatch");
+        f.close();
+        return QUrl::fromLocalFile(path);
+    }
+
+    QUrl makeUrl(const QString &name) const
+    {
+        return QUrl::fromLocalFile(tempDir->path() + "/" + name);
+    }
+
+    void installCommonStubs()
+    {
+        stub.set_lamda(&FileCopyMoveJob::copy,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources, const QUrl &target,
+                          const AbstractJobHandler::JobFlags &) -> JobHandlePointer {
+                           g_copyCalled = true;
+                           g_lastCopySources = sources;
+                           g_lastCopyTarget = target;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::cut,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources, const QUrl &target,
+                          const AbstractJobHandler::JobFlags &, bool) -> JobHandlePointer {
+                           g_cutCalled = true;
+                           g_lastCutSources = sources;
+                           g_lastCutTarget = target;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::deletes,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources,
+                          const AbstractJobHandler::JobFlags &, bool) -> JobHandlePointer {
+                           g_deletesCalled = true;
+                           g_lastDeleteSources = sources;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::moveToTrash,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources,
+                          const AbstractJobHandler::JobFlags &flags, bool) -> JobHandlePointer {
+                           g_moveToTrashCalled = true;
+                           g_lastMoveTrashSources = sources;
+                           g_lastMoveTrashFlags = flags;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::restoreFromTrash,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources, const QUrl &target,
+                          const AbstractJobHandler::JobFlags &, bool) -> JobHandlePointer {
+                           g_restoreFromTrashCalled = true;
+                           g_lastRestoreSources = sources;
+                           g_lastRestoreTarget = target;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::copyFromTrash,
+                       [](FileCopyMoveJob *, const QList<QUrl> &sources, const QUrl &target,
+                          const AbstractJobHandler::JobFlags &) -> JobHandlePointer {
+                           g_copyFromTrashCalled = true;
+                           g_lastCopyTrashSources = sources;
+                           g_lastCopyTrashTarget = target;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::cleanTrash,
+                       [](FileCopyMoveJob *, const QList<QUrl> &urls) -> JobHandlePointer {
+                           g_cleanTrashCalled = true;
+                           g_lastCleanTrashUrls = urls;
+                           return JobHandlePointer(new AbstractJobHandler());
+                       });
+        stub.set_lamda(&FileCopyMoveJob::initArguments,
+                       [](FileCopyMoveJob *, const JobHandlePointer, const AbstractJobHandler::JobFlags &) {
+                           g_initArgsCalled = true;
+                       });
+
+        stub.set_lamda(&DialogManager::showDeleteFilesDialog, []() -> int {
+            g_deleteDialogShown = true;
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(&DialogManager::showClearTrashDialog, []() -> int {
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(&DialogManager::showNormalDeleteConfirmDialog, []() -> int {
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(&DialogManager::showRestoreDeleteFilesDialog, []() -> int {
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(&DialogManager::showDeleteSystemPathWarnDialog, []() {});
+        stub.set_lamda(&DialogManager::showNoPermissionDialog, []() {
+            g_noPermDialogCalled = true;
+        });
+        stub.set_lamda(&DialogManager::showErrorDialog, []() {});
+        stub.set_lamda(&DialogManager::showRenameNameSameErrorDialog, []() -> int {
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(&DialogManager::showRenameBusyErrDialog, []() {});
+
+        stub.set_lamda(&SystemPathUtil::checkContainsSystemPath,
+                       [](SystemPathUtil *, const QList<QUrl> &) -> bool { return false; });
+        stub.set_lamda(&FileUtils::fileCanTrash, [](const QUrl &) -> bool { return true; });
+        stub.set_lamda(&Application::genericAttribute, [](Application::GenericAttribute ga) -> QVariant {
+            return ga == Application::kShowDeleteConfirmDialog ? QVariant(false) : QVariant();
+        });
+
+        stub.set_lamda(&LocalFileHandler::mkdir, [](LocalFileHandler *, const QUrl &dir) -> bool {
+            g_mkdirCalled = true;
+            g_lastMkdirUrl = dir;
+            return true;
+        });
+        stub.set_lamda(&LocalFileHandler::touchFile, [](LocalFileHandler *, const QUrl &url, const QUrl &temp) -> QUrl {
+            g_touchFileCalled = true;
+            g_lastTouchUrl = url;
+            g_lastTouchTempUrl = temp;
+            return url;
+        });
+        stub.set_lamda(&LocalFileHandler::renameFile,
+                       [](LocalFileHandler *, const QUrl &oldUrl, const QUrl &newUrl, bool) -> bool {
+                           g_renameFileCalled = true;
+                           g_lastRenameOld = oldUrl;
+                           g_lastRenameNew = newUrl;
+                           return true;
+                       });
+        stub.set_lamda(&LocalFileHandler::renameFilesBatch,
+                       [](LocalFileHandler *, const QMap<QUrl, QUrl> &urls, QMap<QUrl, QUrl> &successUrls) -> bool {
+                           g_renameBatchCalled = true;
+                           g_lastBatchMap = urls;
+                           successUrls = urls;
+                           return true;
+                       });
+        stub.set_lamda(&LocalFileHandler::openFiles, [](LocalFileHandler *, const QList<QUrl> &files) -> bool {
+            g_openFilesCalled = true;
+            g_lastOpenUrls = files;
+            return true;
+        });
+        stub.set_lamda(&LocalFileHandler::openFilesByApp,
+                       [](LocalFileHandler *, const QList<QUrl> &files, const QString &app) -> bool {
+                           g_openFilesByAppCalled = true;
+                           g_lastOpenUrls = files;
+                           g_lastOpenApp = app;
+                           return true;
+                       });
+        stub.set_lamda(&LocalFileHandler::setPermissions,
+                       [](LocalFileHandler *, const QUrl &, QFileDevice::Permissions permissions) -> bool {
+                           g_setPermsCalled = true;
+                           g_lastPerms = permissions;
+                           return true;
+                       });
+        stub.set_lamda(&LocalFileHandler::createSystemLink,
+                       [](LocalFileHandler *, const QUrl &source, const QUrl &link) -> bool {
+                           g_linkCalled = true;
+                           g_lastLinkSource = source;
+                           g_lastLinkTarget = link;
+                           return true;
+                       });
+
+        stub.set_lamda(&ClipBoard::setUrlsToClipboard,
+                       [](const QList<QUrl> &list, ClipBoard::ClipboardAction action, QMimeData *) {
+                           g_clipboardUrlsCalled = true;
+                           g_lastClipUrls = list;
+                           g_lastClipAction = action;
+                       });
+        stub.set_lamda(&ClipBoard::setDataToClipboard, [](QMimeData *mimeData) {
+            g_clipboardDataCalled = true;
+            g_lastMimeData = mimeData;
+        });
+        stub.set_lamda(&ClipBoard::replaceClipboardUrl, []() {
+            g_replaceClipCalled = true;
+        });
+
+        stub.set_lamda(static_cast<bool (*)(const QString &, const QStringList &, const QString &, qint64 *)>(&QProcess::startDetached),
+                       [](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                           g_detached2Called = true;
+                           g_lastDetached2Args = args;
+                           g_lastDetachedProgram = program;
+                           return true;
+                       });
+
+        stub.set_lamda(static_cast<bool (*)(const DDesktopServices::SystemSoundEffect &)>(&DDesktopServices::playSystemSoundEffect),
+                       [](const DDesktopServices::SystemSoundEffect &) -> bool {
+                           g_soundPlayed = true;
+                           return true;
+                       });
+        stub.set_lamda(&FileUtils::notifyFileChangeManual,
+                       [](DFMBASE_NAMESPACE::Global::FileNotifyType, const QUrl &) {});
+        stub.set_lamda(&HideFileHelper::save, []() -> bool {
+            g_hideSaveCalled = true;
+            return true;
+        });
+
+        stub.set_lamda(&OperationsStackProxy::saveOperations, []() {
+            g_saveOpsCalled = true;
+        });
+        stub.set_lamda(&OperationsStackProxy::cleanOperations, []() {
+            g_cleanOpsCalled = true;
+        });
+        stub.set_lamda(&OperationsStackProxy::SaveRedoOperations, []() {
+            g_saveRedoOpsCalled = true;
+        });
+        stub.set_lamda(&OperationsStackProxy::CleanOperationsByUrl, []() {
+            g_cleanOpsByUrlsCalled = true;
+        });
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+};
+
+// ========== kCopy / kCutFile / kDeleteFiles ==========
+
+TEST_F(FileOpsEventDispatchTest, CopyEvent_PublishFiveArgs_JobReceivesExactSources)
+{
+    QUrl src = createTestFile("copy_src.txt");
+    QUrl dst = makeUrl("copy_dst_dir");
+    QList<QUrl> sources { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCopy, quint64(7), sources, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint,
+                                                  makeHandleCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_copyCalled);
+    EXPECT_EQ(g_lastCopySources, sources);
+    EXPECT_EQ(g_lastCopyTarget, dst);
+    EXPECT_TRUE(g_handleCbCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, CopyEvent_PublishSevenArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("copy_cb.txt");
+    QUrl dst = makeUrl("copy_cb_dir");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCopy, quint64(9), QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("copy-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_copyCalled);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("copy-custom"));
+    EXPECT_EQ(g_opCb.windowId, quint64(9));
+    EXPECT_TRUE(g_opCb.hasHandle);
+}
+
+TEST_F(FileOpsEventDispatchTest, CutEvent_PublishFiveArgs_JobReceivesExactSources)
+{
+    QUrl src = createTestFile("cut_src.txt");
+    QUrl dst = makeUrl("cut_dst_dir");
+    QList<QUrl> sources { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCutFile, quint64(3), sources, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_cutCalled);
+    EXPECT_EQ(g_lastCutSources, sources);
+    EXPECT_EQ(g_lastCutTarget, dst);
+}
+
+TEST_F(FileOpsEventDispatchTest, CutEvent_PublishSevenArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("cut_cb.txt");
+    QUrl dst = makeUrl("cut_cb_dir");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCutFile, quint64(4), QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("cut-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_cutCalled);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("cut-custom"));
+    EXPECT_EQ(g_opCb.windowId, quint64(4));
+}
+
+TEST_F(FileOpsEventDispatchTest, DeleteEvent_PublishFourArgs_DeleteJobRunsAfterConfirm)
+{
+    QUrl src = createTestFile("del_src.txt");
+    QList<QUrl> sources { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kDeleteFiles, quint64(5), sources,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_deleteDialogShown);
+    ASSERT_TRUE(g_deletesCalled);
+    EXPECT_EQ(g_lastDeleteSources, sources);
+}
+
+TEST_F(FileOpsEventDispatchTest, DeleteEvent_PublishSixArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("del_cb.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kDeleteFiles, quint64(6), QList<QUrl> { src },
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("del-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_deletesCalled);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("del-custom"));
+    EXPECT_EQ(g_opCb.windowId, quint64(6));
+}
+
+// ========== kOpenFiles / kOpenFilesByApp / kOpenInTerminal ==========
+
+TEST_F(FileOpsEventDispatchTest, OpenFilesEvent_PublishTwoArgs_FilesOpened)
+{
+    QUrl src = createTestFile("open_me.txt");
+    QList<QUrl> urls { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, quint64(2), urls);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_openFilesCalled);
+    EXPECT_EQ(g_lastOpenUrls, urls);
+    EXPECT_FALSE(g_clipboardDataCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, OpenFilesEvent_PublishThreeArgs_BoolOutParamPreserved)
+{
+    QUrl src = createTestFile("open_boolp.txt");
+    bool okFlag = false;
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, quint64(2),
+                                                  QList<QUrl> { src }, QVariant::fromValue(&okFlag));
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_openFilesCalled);
+    // local file: hook does not intercept, out-param must stay untouched
+    EXPECT_FALSE(okFlag);
+}
+
+TEST_F(FileOpsEventDispatchTest, OpenFilesEvent_PublishFourArgs_CallbackReportsSuccess)
+{
+    QUrl src = createTestFile("open_cb.txt");
+    QList<QUrl> urls { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, quint64(8), urls,
+                                                  QVariant("open-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("open-custom"));
+    EXPECT_TRUE(g_opCb.success);
+    EXPECT_EQ(g_opCb.sourceUrls, urls);
+}
+
+TEST_F(FileOpsEventDispatchTest, OpenFilesByAppEvent_PublishThreeArgs_AppNamePassedThrough)
+{
+    QUrl src = createTestFile("byapp.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenFilesByApp, quint64(11),
+                                                  QList<QUrl> { src }, QList<QString> { "org.test.editor" });
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_openFilesByAppCalled);
+    EXPECT_EQ(g_lastOpenApp, QString("org.test.editor"));
+}
+
+TEST_F(FileOpsEventDispatchTest, OpenFilesByAppEvent_PublishFiveArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("byapp_cb.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenFilesByApp, quint64(12),
+                                                  QList<QUrl> { src }, QList<QString> { "org.test.editor" },
+                                                  QVariant("app-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("app-custom"));
+    EXPECT_TRUE(g_openFilesByAppCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, OpenInTerminalEvent_PublishTwoArgs_ProcessDetached)
+{
+    QDir().mkpath(tempDir->path() + "/term_dir");
+    QUrl src = createTestFile("term_dir/terminal_here.txt");
+
+    // force a terminal to be found regardless of the host environment
+    stub.set_lamda(static_cast<bool (*)(const QString &)>(&QFileInfo::exists),
+                   [](const QString &) -> bool { return true; });
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenInTerminal, quint64(13), QList<QUrl> { src });
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_detached2Called);
+    EXPECT_FALSE(g_lastDetachedProgram.isEmpty());
+    EXPECT_TRUE(g_lastDetached2Args.isEmpty() || g_lastDetached2Args.contains("-w"));
+}
+
+// ========== kRenameFile / kRenameFiles ==========
+
+TEST_F(FileOpsEventDispatchTest, RenameFileEvent_PublishFourArgs_RenameDoneAndOperationSaved)
+{
+    stub.set_lamda(&OperationsStackProxy::saveOperations,
+                   [](OperationsStackProxy *, const QVariantMap &values) {
+                       g_saveOpsCalled = true;
+                       g_lastSavedOps = values;
+                   });
+
+    QUrl oldUrl = createTestFile("rn_old.txt");
+    QUrl newUrl = makeUrl("rn_new.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFile, quint64(14), oldUrl, newUrl,
+                                                  AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_renameFileCalled);
+    EXPECT_EQ(g_lastRenameOld, oldUrl);
+    EXPECT_EQ(g_lastRenameNew, newUrl);
+    ASSERT_TRUE(g_saveOpsCalled);
+    EXPECT_EQ(g_lastSavedOps.value("undoevent").value<uint16_t>(),
+              static_cast<uint16_t>(GlobalEventType::kRenameFile));
+    EXPECT_EQ(g_lastSavedOps.value("undosources").toStringList(), QUrl::toStringList({ newUrl }));
+}
+
+TEST_F(FileOpsEventDispatchTest, RenameFileEvent_PublishSixArgs_OperatorCallbackGetsCustom)
+{
+    QUrl oldUrl = createTestFile("rn_cb_old.txt");
+    QUrl newUrl = makeUrl("rn_cb_new.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFile, quint64(15), oldUrl, newUrl,
+                                                  AbstractJobHandler::JobFlag::kNoHint, QVariant("rn-custom"),
+                                                  makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("rn-custom"));
+    EXPECT_TRUE(g_renameFileCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RenameFilesEvent_ReplaceText_BatchRenameMapGenerated)
+{
+    QUrl src = createTestFile("aa_1.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFiles, quint64(16), QList<QUrl> { src },
+                                                  qMakePair(QString("aa"), QString("bb")), true);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_renameBatchCalled);
+    ASSERT_EQ(g_lastBatchMap.size(), 1);
+    EXPECT_EQ(g_lastBatchMap.firstKey(), src);
+    EXPECT_EQ(g_lastBatchMap.first().fileName(), QString("bb_1.txt"));
+}
+
+TEST_F(FileOpsEventDispatchTest, RenameFilesEvent_ReplaceWithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("cbrep.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFiles, quint64(17), QList<QUrl> { src },
+                                                  qMakePair(QString("cbrep"), QString("xcbrep")), false,
+                                                  QVariant("rep-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("rep-custom"));
+    EXPECT_TRUE(g_renameBatchCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RenameFilesEvent_AddPrefixText_UrlsPrefixed)
+{
+    QUrl src = createTestFile("addme.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFiles, quint64(18), QList<QUrl> { src },
+                                                  qMakePair(QString("pre_"),
+                                                            AbstractJobHandler::FileNameAddFlag::kPrefix));
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_renameBatchCalled);
+    ASSERT_EQ(g_lastBatchMap.size(), 1);
+    EXPECT_EQ(g_lastBatchMap.firstKey(), src);
+    EXPECT_EQ(g_lastBatchMap.first().fileName(), QString("pre_addme.txt"));
+}
+
+TEST_F(FileOpsEventDispatchTest, RenameFilesEvent_AddTextWithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("appended.log");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRenameFiles, quint64(19), QList<QUrl> { src },
+                                                  qMakePair(QString("_tail"),
+                                                            AbstractJobHandler::FileNameAddFlag::kSuffix),
+                                                  QVariant("add-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("add-custom"));
+    EXPECT_TRUE(g_renameBatchCalled);
+}
+
+// ========== kMkdir / kTouchFile ==========
+
+TEST_F(FileOpsEventDispatchTest, MkdirEvent_PublishTwoArgs_DirectoryCreatedInTargetDir)
+{
+    stub.set_lamda(&OperationsStackProxy::saveOperations,
+                   [](OperationsStackProxy *, const QVariantMap &values) {
+                       g_saveOpsCalled = true;
+                       g_lastSavedOps = values;
+                   });
+
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kMkdir, quint64(20), dirUrl);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_mkdirCalled);
+    EXPECT_EQ(g_lastMkdirUrl.scheme(), QString("file"));
+    EXPECT_TRUE(g_lastMkdirUrl.path().startsWith(tempDir->path() + "/"));
+    ASSERT_TRUE(g_saveOpsCalled);
+    EXPECT_EQ(g_lastSavedOps.value("redoevent").value<uint16_t>(),
+              static_cast<uint16_t>(GlobalEventType::kMkdir));
+}
+
+TEST_F(FileOpsEventDispatchTest, MkdirEvent_PublishFourArgs_OperatorCallbackGetsCustom)
+{
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kMkdir, quint64(21), dirUrl,
+                                                  QVariant("mkdir-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("mkdir-custom"));
+    EXPECT_TRUE(g_mkdirCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, TouchFileEvent_CreateTextFile_SuffixAppliedAndSaved)
+{
+    stub.set_lamda(&OperationsStackProxy::saveOperations,
+                   [](OperationsStackProxy *, const QVariantMap &values) {
+                       g_saveOpsCalled = true;
+                       g_lastSavedOps = values;
+                   });
+
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kTouchFile, quint64(22), dirUrl,
+                                                  Global::CreateFileType::kCreateFileTypeText, QString("txt"));
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_touchFileCalled);
+    EXPECT_TRUE(g_lastTouchUrl.path().endsWith(".txt"));
+    EXPECT_TRUE(g_lastTouchUrl.path().startsWith(tempDir->path() + "/"));
+    ASSERT_TRUE(g_saveOpsCalled);
+    EXPECT_EQ(g_lastSavedOps.value("redoevent").value<uint16_t>(),
+              static_cast<uint16_t>(GlobalEventType::kTouchFile));
+}
+
+TEST_F(FileOpsEventDispatchTest, TouchFileEvent_FromTemplate_TemplateUrlForwarded)
+{
+    QUrl tpl = createTestFile("tpl.odt");
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kTouchFile, quint64(23), dirUrl, tpl,
+                                                  QString());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_touchFileCalled);
+    EXPECT_TRUE(g_lastTouchUrl.path().endsWith(".odt"));
+    EXPECT_TRUE(g_lastTouchUrl.path().startsWith(tempDir->path() + "/"));
+    // the template overload must have forwarded the real template url
+    EXPECT_EQ(g_lastTouchTempUrl, tpl);
+}
+
+TEST_F(FileOpsEventDispatchTest, TouchFileEvent_CreateWithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kTouchFile, quint64(24), dirUrl,
+                                                  Global::CreateFileType::kCreateFileTypeText, QString("txt"),
+                                                  QVariant("touch-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("touch-custom"));
+    EXPECT_TRUE(g_touchFileCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, TouchFileEvent_TemplateWithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl tpl = createTestFile("tpl2.xlsx");
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kTouchFile, quint64(25), dirUrl, tpl,
+                                                  QString("xlsx"), QVariant("tpl-custom"),
+                                                  makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("tpl-custom"));
+    EXPECT_EQ(g_lastTouchTempUrl, tpl);
+}
+
+// ========== kCreateSymlink / kSetPermission ==========
+
+TEST_F(FileOpsEventDispatchTest, CreateSymlinkEvent_SilentExplicitTarget_LinkCreated)
+{
+    QUrl src = createTestFile("link_src.txt");
+    QUrl link = makeUrl("the_link.lnk");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCreateSymlink, quint64(26), src, link,
+                                                  false, true);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_linkCalled);
+    EXPECT_EQ(g_lastLinkSource, src);
+    EXPECT_EQ(g_lastLinkTarget, link);
+}
+
+TEST_F(FileOpsEventDispatchTest, CreateSymlinkEvent_WithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("link_cb.txt");
+    QUrl link = makeUrl("cb_link.lnk");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCreateSymlink, quint64(27), src, link,
+                                                  false, true, QVariant("link-custom"),
+                                                  makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("link-custom"));
+    EXPECT_TRUE(g_linkCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, SetPermissionEvent_PublishThreeArgs_ExactPermissionsApplied)
+{
+    QUrl src = createTestFile("perm.txt");
+    QFileDevice::Permissions perms = QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kSetPermission, quint64(28), src, perms);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_setPermsCalled);
+    EXPECT_EQ(g_lastPerms, perms);
+    EXPECT_EQ(int(g_lastPerms), 0x6000);
+}
+
+TEST_F(FileOpsEventDispatchTest, SetPermissionEvent_PublishFiveArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("perm_cb.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kSetPermission, quint64(29), src,
+                                                  QFileDevice::ReadOwner, QVariant("perm-custom"),
+                                                  makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("perm-custom"));
+    EXPECT_TRUE(g_setPermsCalled);
+}
+
+// ========== clipboard events ==========
+
+TEST_F(FileOpsEventDispatchTest, WriteUrlsToClipboardEvent_CutAction_ActionAndUrlsDelivered)
+{
+    QUrl src = createTestFile("clip.txt");
+    QList<QUrl> urls { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kWriteUrlsToClipboard, quint64(30),
+                                                  ClipBoard::ClipboardAction::kCutAction, urls);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_clipboardUrlsCalled);
+    EXPECT_EQ(g_lastClipAction, ClipBoard::ClipboardAction::kCutAction);
+    EXPECT_EQ(g_lastClipUrls, urls);
+}
+
+TEST_F(FileOpsEventDispatchTest, WriteCustomClipboardEvent_ValidMimeData_DataForwarded)
+{
+    QMimeData data;
+    data.setText("mime-payload");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kWriteCustomToClipboard, quint64(31), &data);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_clipboardDataCalled);
+    EXPECT_EQ(g_lastMimeData, &data);
+}
+
+TEST_F(FileOpsEventDispatchTest, WriteCustomClipboardEvent_NullMimeData_Rejected)
+{
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kWriteCustomToClipboard, quint64(32),
+                                                  static_cast<QMimeData *>(nullptr));
+
+    EXPECT_TRUE(published);
+    EXPECT_FALSE(g_clipboardDataCalled);
+}
+
+// ========== operation-stack events ==========
+
+TEST_F(FileOpsEventDispatchTest, SaveOperatorEvent_OperationMap_SavedVerbatim)
+{
+    QVariantMap values;
+    values.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kCopy)));
+    values.insert("undosources", QUrl::toStringList({ makeUrl("s1.txt") }));
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kSaveOperator, values);
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_saveOpsCalled);
+    EXPECT_FALSE(g_saveRedoOpsCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, SaveRedoOperatorEvent_OperationMap_SavedVerbatim)
+{
+    QVariantMap values;
+    values.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kRenameFile)));
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kSaveRedoOperator, values);
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_saveRedoOpsCalled);
+    EXPECT_FALSE(g_saveOpsCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, CleanSaveOperatorEvent_NoParams_OperationsStackCleaned)
+{
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCleanSaveOperator);
+
+    EXPECT_TRUE(published);
+    EXPECT_TRUE(g_cleanOpsCalled);
+    EXPECT_FALSE(g_cleanOpsByUrlsCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, CleanSaveOperatorByUrlsEvent_UrlList_ConvertedToStrings)
+{
+    stub.set_lamda(&OperationsStackProxy::CleanOperationsByUrl,
+                   [](OperationsStackProxy *, const QStringList &urls) {
+                       g_cleanOpsByUrlsCalled = true;
+                       g_lastCleanOpsUrls = urls;
+                   });
+
+    QList<QUrl> urls { makeUrl("gone1.txt"), makeUrl("gone2.txt") };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCleanSaveOperatorByUrls, urls);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_cleanOpsByUrlsCalled);
+    EXPECT_EQ(g_lastCleanOpsUrls, QUrl::toStringList(urls));
+    EXPECT_EQ(g_lastCleanOpsUrls.size(), 2);
+}
+
+TEST_F(FileOpsEventDispatchTest, CopyFilePathEvent_LocalUrls_PathsWrittenToClipboard)
+{
+    stub.set_lamda(&ClipBoard::setDataToClipboard, [](QMimeData *mimeData) {
+        g_clipboardDataCalled = true;
+        g_lastClipboardText = mimeData->text();
+    });
+
+    QUrl src = createTestFile("pathcopy.txt");
+    QList<QUrl> urls { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCopyFilePath, urls);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_clipboardDataCalled);
+    EXPECT_EQ(g_lastClipboardText, src.toLocalFile());
+    EXPECT_FALSE(g_lastClipboardText.isEmpty());
+}
+
+// ========== undo / redo events ==========
+
+TEST_F(FileOpsEventDispatchTest, RevocationEvent_UndoCut_CutJobAndInitArgumentsInvoked)
+{
+    QUrl src = createTestFile("undo_cut.txt");
+    QUrl dst = makeUrl("undo_cut_dst");
+
+    QVariantMap op;
+    op.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kCutFile)));
+    op.insert("undosources", QUrl::toStringList({ src }));
+    op.insert("undotargets", QUrl::toStringList({ dst }));
+    stub.set_lamda(&OperationsStackProxy::revocationOperations,
+                   [&op](OperationsStackProxy *) -> QVariantMap { return op; });
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRevocation, quint64(33),
+                                                  makeHandleCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_cutCalled);
+    EXPECT_EQ(g_lastCutSources, QList<QUrl> { src });
+    EXPECT_EQ(g_lastCutTarget, dst);
+    EXPECT_TRUE(g_initArgsCalled);
+    EXPECT_TRUE(g_handleCbCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RedoEvent_UndoMkdir_MkdirReexecutedWithUrlPath)
+{
+    QUrl dirUrl = makeUrl("redo_dir");
+
+    QVariantMap op;
+    op.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kMkdir)));
+    op.insert("undosources", QUrl::toStringList({ dirUrl }));
+    op.insert("undotargets", QUrl::toStringList({ dirUrl }));
+    stub.set_lamda(&OperationsStackProxy::RevocationRedoOperations,
+                   [&op](OperationsStackProxy *) -> QVariantMap { return op; });
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRedo, quint64(34), nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_mkdirCalled);
+    EXPECT_EQ(g_lastMkdirUrl, dirUrl);
+}
+
+// ========== kHideFiles ==========
+
+TEST_F(FileOpsEventDispatchTest, HideFilesEvent_PublishTwoArgs_HiddenListSaved)
+{
+    QUrl src = createTestFile("hide_me.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kHideFiles, quint64(35), QList<QUrl> { src });
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_hideSaveCalled);
+    EXPECT_FALSE(g_noPermDialogCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, HideFilesEvent_ParentWithList_FileMarkedHidden)
+{
+    QUrl parent = QUrl::fromLocalFile(tempDir->path());
+    QUrl src = createTestFile("hide_flagged.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kHideFiles, quint64(36), parent,
+                                                  QList<QUrl> { src }, true);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_hideSaveCalled);
+    EXPECT_FALSE(g_cleanOpsCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, HideFilesEvent_WithCallback_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("hide_cb.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kHideFiles, quint64(37), QList<QUrl> { src },
+                                                  QVariant("hide-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("hide-custom"));
+    EXPECT_TRUE(g_hideSaveCalled);
+}
+
+// ========== slot channel + hook strategies ==========
+
+TEST_F(FileOpsEventDispatchTest, FilesPreviewSlot_PushValidLists_PreviewToolLaunchedWithTempFile)
+{
+    QUrl selected = createTestFile("preview.txt");
+    QList<QUrl> selectUrls { selected };
+    QList<QUrl> dirUrls { QUrl::fromLocalFile(tempDir->path()) };
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_fileoperations", "slot_Operation_FilesPreview",
+                                        quint64(38), selectUrls, dirUrls);
+
+    EXPECT_TRUE(ret.isNull());
+    ASSERT_TRUE(g_detached2Called);
+    ASSERT_EQ(g_lastDetached2Args.size(), 1);
+    QString tempFileName = g_lastDetached2Args.first();
+    EXPECT_TRUE(QFileInfo(tempFileName).exists());
+    QFile::remove(tempFileName);   // handler sets autoRemove(false): clean up
+}
+
+TEST_F(FileOpsEventDispatchTest, IsSubFileHook_RunNestedUrl_ReturnsTrue)
+{
+    QUrl parent = QUrl::fromLocalFile(tempDir->path() + "/nested");
+    QUrl sub = QUrl::fromLocalFile(tempDir->path() + "/nested/inner/file.txt");
+
+    bool nested = dpfHookSequence->run("dfmplugin_search", "hook_Url_IsSubFile", parent, sub);
+    bool foreign = dpfHookSequence->run("dfmplugin_search", "hook_Url_IsSubFile",
+                                        QUrl::fromLocalFile(tempDir->path() + "/other"), sub);
+
+    EXPECT_TRUE(nested);
+    EXPECT_FALSE(foreign);
+}
+
+TEST_F(FileOpsEventDispatchTest, ShortcutHooks_WritableTargets_NotBlocked)
+{
+    QUrl root = QUrl::fromLocalFile(tempDir->path());
+    QUrl src = createTestFile("shortcut.txt");
+    QList<QUrl> urls { src };
+
+    bool deleteBlocked = dpfHookSequence->run("dfmplugin_workspace", "hook_ShortCut_DeleteFiles",
+                                              quint64(39), urls, root);
+    bool pasteBlocked = dpfHookSequence->run("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
+                                             quint64(40), urls, root);
+
+    EXPECT_FALSE(deleteBlocked);
+    EXPECT_FALSE(pasteBlocked);
+    EXPECT_FALSE(g_noPermDialogCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RevocationEvent_UndoMoveToTrash_TrashJobAndInitArgumentsInvoked)
+{
+    QUrl src = createTestFile("undo_trash.txt");
+
+    QVariantMap op;
+    op.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kMoveToTrash)));
+    op.insert("undosources", QUrl::toStringList({ src }));
+    op.insert("undotargets", QUrl::toStringList({ makeUrl("nowhere") }));
+    stub.set_lamda(&OperationsStackProxy::revocationOperations,
+                   [&op](OperationsStackProxy *) -> QVariantMap { return op; });
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRevocation, quint64(49), nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_moveToTrashCalled);
+    EXPECT_EQ(g_lastMoveTrashSources, QList<QUrl> { src });
+    EXPECT_EQ(g_lastMoveTrashFlags,
+              AbstractJobHandler::JobFlags(AbstractJobHandler::JobFlag::kRevocation));
+    EXPECT_TRUE(g_initArgsCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RevocationEvent_UndoRestoreFromTrash_RestoreJobInvoked)
+{
+    QUrl src = makeUrl("trash/undo_restore.txt");
+
+    QVariantMap op;
+    op.insert("undoevent", QVariant::fromValue(static_cast<uint16_t>(GlobalEventType::kRestoreFromTrash)));
+    op.insert("undosources", QUrl::toStringList({ src }));
+    op.insert("undotargets", QUrl::toStringList({ src }));
+    stub.set_lamda(&OperationsStackProxy::revocationOperations,
+                   [&op](OperationsStackProxy *) -> QVariantMap { return op; });
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRevocation, quint64(50),
+                                                  makeHandleCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_restoreFromTrashCalled);
+    EXPECT_EQ(g_lastRestoreSources, QList<QUrl> { src });
+    EXPECT_TRUE(g_initArgsCalled);
+    EXPECT_TRUE(g_handleCbCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, TouchFileEvent_ClipboardImageRequest_PngSavedFromClipboard)
+{
+    QImage image(4, 4, QImage::Format_ARGB32);
+    image.fill(Qt::red);
+    QApplication::clipboard()->setImage(image);
+
+    QVariantMap custom;
+    custom.insert("clipboardImage", true);
+    QUrl dirUrl = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kTouchFile, quint64(51), dirUrl,
+                                                  Global::CreateFileType::kCreateFileTypeText,
+                                                  QString("png"), custom, nullptr);
+
+    EXPECT_TRUE(published);
+    QDir dir(tempDir->path());
+    // other fixtures may have added duplicate subscriptions of the same
+    // handler, so at least one image must exist, each with a proper name
+    const auto pngs = dir.entryList({ "image_*.png" }, QDir::Files);
+    EXPECT_GE(pngs.size(), 1);
+    for (const QString &name : pngs) {
+        EXPECT_TRUE(name.startsWith("image_"));
+        EXPECT_GT(QFile(dir.filePath(name)).size(), 0);
+    }
+}
+
+// ========== TrashFileEventReceiver events ==========
+
+TEST_F(FileOpsEventDispatchTest, MoveToTrashEvent_PublishFourArgs_TrashJobStarted)
+{
+    QUrl src = createTestFile("totrash.txt");
+    QList<QUrl> sources { src };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrash, quint64(41), sources,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_moveToTrashCalled);
+    EXPECT_EQ(g_lastMoveTrashSources, sources);
+    EXPECT_EQ(g_lastMoveTrashFlags, AbstractJobHandler::JobFlags(AbstractJobHandler::JobFlag::kNoHint));
+}
+
+TEST_F(FileOpsEventDispatchTest, MoveToTrashEvent_PublishSixArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = createTestFile("totrash_cb.txt");
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrash, quint64(42), QList<QUrl> { src },
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("trash-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("trash-custom"));
+    EXPECT_TRUE(g_moveToTrashCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, RestoreFromTrashEvent_PublishFiveArgs_RestoreJobStarted)
+{
+    QUrl src = makeUrl("trash/item.txt");
+    QUrl dst = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrash, quint64(43),
+                                                  QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_restoreFromTrashCalled);
+    EXPECT_EQ(g_lastRestoreSources, QList<QUrl> { src });
+    EXPECT_EQ(g_lastRestoreTarget, dst);
+}
+
+TEST_F(FileOpsEventDispatchTest, RestoreFromTrashEvent_PublishSevenArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = makeUrl("trash/item_cb.txt");
+    QUrl dst = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrash, quint64(44),
+                                                  QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("restore-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("restore-custom"));
+    EXPECT_TRUE(g_restoreFromTrashCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, CopyFromTrashEvent_PublishFiveArgs_CopyJobStarted)
+{
+    QUrl src = makeUrl("trash/copyme.txt");
+    QUrl dst = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCopyFromTrash, quint64(45),
+                                                  QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_copyFromTrashCalled);
+    EXPECT_EQ(g_lastCopyTrashSources, QList<QUrl> { src });
+    EXPECT_EQ(g_lastCopyTrashTarget, dst);
+}
+
+TEST_F(FileOpsEventDispatchTest, CopyFromTrashEvent_PublishSevenArgs_OperatorCallbackGetsCustom)
+{
+    QUrl src = makeUrl("trash/copyme_cb.txt");
+    QUrl dst = QUrl::fromLocalFile(tempDir->path());
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCopyFromTrash, quint64(46),
+                                                  QList<QUrl> { src }, dst,
+                                                  AbstractJobHandler::JobFlag::kNoHint, nullptr,
+                                                  QVariant("copytrash-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("copytrash-custom"));
+    EXPECT_TRUE(g_copyFromTrashCalled);
+}
+
+TEST_F(FileOpsEventDispatchTest, CleanTrashEvent_PublishFourArgs_TrashCleanedAfterConfirm)
+{
+    QList<QUrl> urls { makeUrl("trash/stale1.txt"), makeUrl("trash/stale2.txt") };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCleanTrash, quint64(47), urls,
+                                                  AbstractJobHandler::DeleteDialogNoticeType::kEmptyTrash, nullptr);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_deleteDialogShown);
+    ASSERT_TRUE(g_cleanTrashCalled);
+    EXPECT_EQ(g_lastCleanTrashUrls, urls);
+    EXPECT_TRUE(g_soundPlayed);
+}
+
+TEST_F(FileOpsEventDispatchTest, CleanTrashEvent_PublishFiveArgs_OperatorCallbackGetsCustom)
+{
+    QList<QUrl> urls { makeUrl("trash/cb1.txt") };
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kCleanTrash, quint64(48), urls, nullptr,
+                                                  QVariant("clean-custom"), makeOperatorCallback());
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_opCb.called);
+    EXPECT_EQ(g_opCb.custom.toString(), QString("clean-custom"));
+    EXPECT_TRUE(g_cleanTrashCalled);
+    EXPECT_TRUE(g_opCb.hasHandle);
+}

--- a/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
@@ -11,16 +11,26 @@
 #include "utils/recentmanager.h"
 #include "utils/recentfilehelper.h"
 #include "events/recenteventreceiver.h"
+#include "events/recenteventcaller.h"
 
 #include <dfm-framework/dpf.h>
 #include <dfm-framework/event/event.h>
 #include <dfm-framework/event/eventhelper.h>
 
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+#include <DDialog>
+
 #include <gtest/gtest.h>
+
+#include <QTemporaryDir>
+#include <QTemporaryFile>
 
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_recent;
 using namespace dpf;
+DWIDGET_USE_NAMESPACE
 
 Q_DECLARE_METATYPE(QString *)
 Q_DECLARE_METATYPE(bool *)
@@ -58,6 +68,17 @@ static void registerRecentHookEvents(dpf::Event *evt)
     evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_SetPermission");
 }
 
+// Initialize the plugin exactly once for the whole binary: repeating
+// followEvents()/bindEvents() would append duplicate followers and make
+// per-signal invocation counts non-deterministic.
+static Recent &recentPluginInstance()
+{
+    static Recent instance;
+    static std::once_flag once;
+    std::call_once(once, [&instance] { instance.initialize(); });
+    return instance;
+}
+
 class RecentFollowEventsTest : public testing::Test
 {
 protected:
@@ -67,15 +88,220 @@ protected:
         // Only stub the genuinely unsafe paths; let followEvents/bindEvents run for real.
         stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
         stub.set_lamda(&Recent::bindWindows, [] { __DBG_STUB_INVOKE__ });
+        // removeRecent() shows a modal DDialog and then calls DBus; intercept it
+        // (a plain namespace function, safe to stub) so drop/trash hooks stay headless.
+        removeRecentCalls = 0;
+        stub.set_lamda(&RecentHelper::removeRecent, [this](const QList<QUrl> &) {
+            __DBG_STUB_INVOKE__
+            ++removeRecentCalls;
+        });
+        reloadCount = 0;
+        stub.set_lamda(&RecentManager::reloadRecent, [this] { __DBG_STUB_INVOKE__ ++reloadCount; });
+        // Perform the one-time real followEvents()/bindEvents() registration.
+        recentPluginInstance();
     }
-    void TearDown() override { stub.clear(); }
+    void TearDown() override
+    {
+        RecentManager::instance()->recentItems.clear();
+        stub.clear();
+    }
     stub_ext::StubExt stub;
-    Recent ins;
+    int reloadCount { 0 };
+    int removeRecentCalls { 0 };
 };
 
-// Run the real followEvents + bindEvents path (initialize calls both) so the
-// EventHelper<M> template instantiations in recent.cpp execute and get covered.
+// The real followEvents + bindEvents path must have run (via the shared
+// instance) without crashing, registering every hook/signal follower.
 TEST_F(RecentFollowEventsTest, Initialize_RunsRealFollowAndBindEvents_NoCrash)
 {
-    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+    EXPECT_NE(&recentPluginInstance(), nullptr);
+    // Proof that the followers were really registered:
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_propertydialog",
+                                     "hook_PropertyDialog_Disable",
+                                     RecentHelper::rootUrl()));
+}
+
+// Trigger every workspace/detailspace/titlebar/propertydialog hook through the
+// real EventSequenceManager so each followed EventHelper<RecentEventReceiver>
+// is constructed and invoked with exact-signature arguments.
+TEST_F(RecentFollowEventsTest, HookRun_RecentSchemeHooks_InvokeReceiverHandlers)
+{
+    const QUrl recentRoot { RecentHelper::rootUrl() };
+    const QUrl recentItem { "recent:///tmp/follow_item.txt" };
+
+    QList<Global::ItemRoles> roles;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles",
+                                     recentRoot, &roles));
+    EXPECT_TRUE(roles.contains(Global::ItemRoles::kItemFilePathRole));
+    EXPECT_TRUE(roles.contains(Global::ItemRoles::kItemFileLastReadRole));
+
+    QString displayName;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName",
+                                     recentItem, Global::ItemRoles::kItemFilePathRole, &displayName));
+    EXPECT_EQ(displayName.toStdString(), "Path");
+
+    Global::TransparentStatus status { Global::TransparentStatus::kTransparent };
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_CheckTransparent",
+                                     recentItem, &status));
+    EXPECT_EQ(status, Global::TransparentStatus::kUntransparent);
+
+    Qt::DropAction action { Qt::IgnoreAction };
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction",
+                                     QList<QUrl> { recentItem }, recentRoot, &action));
+    EXPECT_EQ(action, Qt::CopyAction);
+
+    // Drops from recent:// into trash:// trigger the removal flow (stubbed).
+    const int removesBefore = removeRecentCalls;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                     QList<QUrl> { recentItem }, QUrl("trash:///")));
+    EXPECT_EQ(removeRecentCalls, removesBefore + 1);
+
+    QString iconName;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_detailspace", "hook_Icon_Fetch",
+                                     recentRoot, &iconName));
+    EXPECT_EQ(iconName.toStdString(), "dfm_recent");
+
+    QList<QVariantMap> crumbs;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate",
+                                     recentItem, &crumbs));
+    ASSERT_EQ(crumbs.size(), 1);
+    EXPECT_EQ(crumbs.first().value("CrumbData_Key_Url").toUrl(), recentRoot);
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_propertydialog", "hook_PropertyDialog_Disable",
+                                     recentRoot));
+}
+
+// Trigger every fileoperations hook so the followed
+// EventHelper<RecentFileHelper> instantiations are constructed and invoked.
+TEST_F(RecentFollowEventsTest, HookRun_FileOperationHooks_InvokeHelperHandlers)
+{
+    const QUrl recentRoot { RecentHelper::rootUrl() };
+    const QUrl recentItem { "recent:///tmp/follow_op.txt" };
+    const AbstractJobHandler::JobFlags noFlags {};
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_CutToFile",
+                                     quint64(1), QList<QUrl> { recentItem }, recentRoot, noFlags));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_CopyFile",
+                                     quint64(1), QList<QUrl> { recentItem }, recentRoot, noFlags));
+    // moveToTrash triggers the removal flow (stubbed) and succeeds.
+    const int removesBefore = removeRecentCalls;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                     quint64(1), QList<QUrl> { recentItem }, noFlags));
+    EXPECT_EQ(removeRecentCalls, removesBefore + 1);
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                     quint64(1), QList<QUrl> { recentItem }));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_WriteUrlsToClipboard",
+                                     quint64(1), ClipBoard::ClipboardAction::kCopyAction,
+                                     QList<QUrl> { recentItem }));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenInTerminal",
+                                     quint64(1), QList<QUrl> { recentItem }));
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString filePath = dir.filePath("perm.txt");
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const QUrl recentPerm { RecentHelper::recentUrl(filePath) };
+    bool ok = false;
+    QString error;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_SetPermission",
+                                     quint64(1), recentPerm,
+                                     QFileDevice::Permissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner),
+                                     &ok, &error));
+    EXPECT_TRUE(ok);
+    // The handler applied the owner read/write permission set (dfm-io may
+    // additionally mirror owner bits onto user bits).
+    const QFileDevice::Permissions perms = file.permissions();
+    EXPECT_TRUE(perms & QFileDevice::ReadOwner);
+    EXPECT_TRUE(perms & QFileDevice::WriteOwner);
+}
+
+// Non-recent inputs must make every hooked handler return false, which makes
+// the whole hook traversal fail -> covers the negative branches of the
+// EventHelper invocations.
+TEST_F(RecentFollowEventsTest, HookRun_NonRecentInputs_TraversalFails)
+{
+    const QUrl plainFile { "file:///tmp/not_recent.txt" };
+    QList<Global::ItemRoles> roles;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles",
+                                      plainFile, &roles));
+    EXPECT_TRUE(roles.isEmpty());
+
+    Global::TransparentStatus status {};
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_CheckTransparent",
+                                      plainFile, &status));
+
+    Qt::DropAction action { Qt::IgnoreAction };
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction",
+                                      QList<QUrl> { plainFile }, plainFile, &action));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                      QList<QUrl> { plainFile }, QUrl("trash:///")));
+
+    QList<QVariantMap> crumbs;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate",
+                                      plainFile, &crumbs));
+
+    QString iconName;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_detailspace", "hook_Icon_Fetch",
+                                      QUrl("recent:///not_root.txt"), &iconName));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_propertydialog", "hook_PropertyDialog_Disable",
+                                      QUrl("recent:///not_root.txt")));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                      quint64(1), QList<QUrl> { plainFile },
+                                      AbstractJobHandler::JobFlags {}));
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                      quint64(1), QList<QUrl> {}));
+}
+
+// Publish the GlobalEventType signals Recent::bindEvents() subscribed to so the
+// EventHelper<void (RecentEventReceiver::*)(...)> dispatch instantiations run.
+TEST_F(RecentFollowEventsTest, SignalPublish_BoundEvents_InvokeReceiverHandlers)
+{
+    const QList<QUrl> urls { QUrl("recent:///tmp/cut_src.txt") };
+    const QList<QUrl> dests { QUrl("file:///tmp/cut_dst.txt") };
+    const QMap<QUrl, QUrl> renamed { { QUrl("recent:///tmp/a.txt"), QUrl("file:///tmp/b.txt") } };
+
+    EXPECT_EQ(reloadCount, 0);
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, dests, true, QString()));
+    EXPECT_EQ(reloadCount, 1);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, true, QString()));
+    EXPECT_EQ(reloadCount, 2);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, urls, true, QString()));
+    EXPECT_EQ(reloadCount, 3);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1), renamed, true, QString()));
+    EXPECT_EQ(reloadCount, 4);
+
+    // Window url change on the recent scheme only posts a deferred slot push;
+    // it must succeed without any registered slot consumer.
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, quint64(1),
+                                             QUrl("recent:///")));
+}
+
+// Failed operations must not reload the recent cache: the receiver handlers
+// short-circuit, covering the negative branches behind the dispatch helpers.
+TEST_F(RecentFollowEventsTest, SignalPublish_FailedOperations_DoNotReload)
+{
+    const QList<QUrl> urls { QUrl("recent:///tmp/failed.txt") };
+
+    EXPECT_EQ(reloadCount, 0);
+    dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, false, QString("boom"));
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, QList<QUrl> {}, true, QString());
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, QList<QUrl> {}, false, QString("boom"));
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1),
+                                 QMap<QUrl, QUrl> {}, true, QString());
+    EXPECT_EQ(reloadCount, 0);
 }

--- a/autotests/plugins/dfmplugin-recent/test_recent.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recent.cpp
@@ -116,33 +116,33 @@ TEST_F(RecentTest, FollowEvents)
 {
     stub_ext::StubExt st;
     st.set_lamda(&RecentManager::init, []() {});
-    // type of RecentManager::customColumnRole
-    typedef bool (RecentManager::*HookFunc1)(const QUrl &, QList<Global::ItemRoles> *);
-    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentManager *, HookFunc1);
+    // type of RecentEventReceiver::customColumnRole
+    typedef bool (RecentEventReceiver::*HookFunc1)(const QUrl &, QList<Global::ItemRoles> *);
+    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentEventReceiver *, HookFunc1);
 
-    // type of RecentManager::customRoleDisplayName
-    typedef bool (RecentManager::*HookFunc2)(const QUrl &, const Global::ItemRoles, QString *);
-    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, RecentManager *, HookFunc2);
+    // type of RecentEventReceiver::customRoleDisplayName
+    typedef bool (RecentEventReceiver::*HookFunc2)(const QUrl &, const Global::ItemRoles, QString *);
+    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, RecentEventReceiver *, HookFunc2);
 
-    // type of RecentManager::isTransparent
-    typedef bool (RecentManager::*HookFunc3)(const QUrl &, DFMGLOBAL_NAMESPACE::TransparentStatus *);
-    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, RecentManager *, HookFunc3);
+    // type of RecentEventReceiver::isTransparent
+    typedef bool (RecentEventReceiver::*HookFunc3)(const QUrl &, DFMGLOBAL_NAMESPACE::TransparentStatus *);
+    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, RecentEventReceiver *, HookFunc3);
 
-    // type of RecentManager::checkDragDropAction
-    typedef bool (RecentManager::*HookFunc4)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
-    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, RecentManager *, HookFunc4);
+    // type of RecentEventReceiver::checkDragDropAction
+    typedef bool (RecentEventReceiver::*HookFunc4)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
+    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, RecentEventReceiver *, HookFunc4);
 
-    // type of RecentManager::handleDropFiles
-    typedef bool (RecentManager::*HookFunc5)(const QList<QUrl> &, const QUrl &);
-    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, RecentManager *, HookFunc5);
+    // type of RecentEventReceiver::handleDropFiles
+    typedef bool (RecentEventReceiver::*HookFunc5)(const QList<QUrl> &, const QUrl &);
+    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, RecentEventReceiver *, HookFunc5);
 
-    // type of RecentManager::detailViewIcon
-    typedef bool (RecentManager::*HookFunc6)(const QUrl &, QString *);
-    typedef bool (EventSequenceManager::*HookType6)(const QString &, const QString &, RecentManager *, HookFunc6);
+    // type of RecentEventReceiver::detailViewIcon
+    typedef bool (RecentEventReceiver::*HookFunc6)(const QUrl &, QString *);
+    typedef bool (EventSequenceManager::*HookType6)(const QString &, const QString &, RecentEventReceiver *, HookFunc6);
 
-    // type of RecentManager::sepateTitlebarCrumb
-    typedef bool (RecentManager::*HookFunc7)(const QUrl &, QList<QVariantMap> *);
-    typedef bool (EventSequenceManager::*HookType7)(const QString &, const QString &, RecentManager *, HookFunc7);
+    // type of RecentEventReceiver::sepateTitlebarCrumb
+    typedef bool (RecentEventReceiver::*HookFunc7)(const QUrl &, QList<QVariantMap> *);
+    typedef bool (EventSequenceManager::*HookType7)(const QString &, const QString &, RecentEventReceiver *, HookFunc7);
 
     // type of RecentFileHelper::cutFile
     typedef bool (RecentFileHelper::*HookFunc8)(const quint64, const QList<QUrl>,
@@ -166,8 +166,8 @@ TEST_F(RecentTest, FollowEvents)
     typedef bool (RecentFileHelper::*HookFunc12)(quint64, QList<QUrl>);
     typedef bool (EventSequenceManager::*HookType12)(const QString &, const QString &, RecentFileHelper *, HookFunc12);
 
-    // type of RecentFileHelper::linkFile
-    typedef bool (RecentFileHelper::*HookFunc13)(const quint64, const QUrl, const QUrl, const bool, const bool);
+    // type of RecentFileHelper::setPermissionHandle
+    typedef bool (RecentFileHelper::*HookFunc13)(const quint64, const QUrl, QFileDevice::Permissions, bool *, QString *);
     typedef bool (EventSequenceManager::*HookType13)(const QString &, const QString &, RecentFileHelper *, HookFunc13);
 
     // type of RecentFileHelper::writeUrlsToClipboard

--- a/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
@@ -15,15 +15,27 @@
 
 // 包含待测试的类
 #include "utils/recentmanager.h"
+#include "files/recentfileinfo.h"
+#include "events/recenteventcaller.h"
 #include "dfmplugin_recent_global.h"
 
 // 包含依赖的头文件
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
 #include <dfm-base/interfaces/abstractfilewatcher.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/sysinfoutils.h>
+
+#include <DDesktopServices>
+#include <QDBusArgument>
+#include <QAction>
+#include <QMenu>
+#include <QProcess>
 
 DPRECENT_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 /**
  * @brief RecentManager类单元测试
@@ -41,10 +53,27 @@ class RecentManagerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        // Mock QCoreApplication thread check
-        stub.set_lamda(&QThread::currentThread, []() {
-            __DBG_STUB_INVOKE__
-            return QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+        // NOTE: do NOT stub QThread::currentThread here: InfoCache's worker
+        // thread asserts `qApp->thread() != currentThread()` and a global
+        // currentThread stub breaks that worker thread.
+
+        // Register the "recent" scheme exactly once for the whole binary so
+        // InfoFactory::create<FileInfo>(recent://...) returns a RecentFileInfo.
+        // Also register "file" so RecentFileInfo gets a real proxy and
+        // urlOf(kRedirectedFileUrl) resolves to the local file path.
+        static std::once_flag schemeOnce;
+        std::call_once(schemeOnce, [] {
+            if (!UrlRoute::hasScheme(RecentHelper::scheme()))
+                UrlRoute::regScheme(RecentHelper::scheme(), "/", RecentHelper::icon(),
+                                    true, QStringLiteral("Recent"));
+            InfoFactory::regClass<RecentFileInfo>(RecentHelper::scheme());
+            // "file" needs both UrlRoute and factory registration, otherwise
+            // SchemeFactory::create(file://) returns null and RecentFileInfo
+            // ends up without a proxy.
+            if (!UrlRoute::hasScheme(Global::Scheme::kFile))
+                UrlRoute::regScheme(Global::Scheme::kFile, "/", QIcon(),
+                                    false, QStringLiteral("File"));
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
         });
 
         // Create temporary directory for testing
@@ -58,6 +87,12 @@ protected:
 
     void TearDown() override
     {
+        // Reset the singleton caches so cases stay independent.
+        if (manager) {
+            manager->pendingItems.clear();
+            manager->recentItems.clear();
+            manager->batchTimer.stop();
+        }
         // Clean up resources
         delete tempDir;
         stub.clear();
@@ -66,6 +101,42 @@ protected:
     stub_ext::StubExt stub;
     RecentManager *manager { nullptr };
     QTemporaryDir *tempDir { nullptr };
+    int menuExecCalls { 0 };
+
+    // Stub menu exec to behave like the user clicked the action at
+    // actionIndex (-1 = dismiss without choosing): emit triggered() while the
+    // action is still owned by the menu so its connected lambda runs.
+    void StubMenuExecReturnAction(int actionIndex)
+    {
+        menuExecCalls = 0;
+        stub.set_lamda(static_cast<QAction *(QMenu::*)(const QPoint &, QAction *)>(&QMenu::exec),
+                       [this, actionIndex](QMenu *self, const QPoint &, QAction *) -> QAction * {
+                           __DBG_STUB_INVOKE__
+                           ++menuExecCalls;
+                           const auto acts = self->actions();
+                           QAction *act = (actionIndex >= 0 && actionIndex < acts.size())
+                                   ? acts.at(actionIndex)
+                                   : nullptr;
+                           if (act)
+                               emit act->triggered();
+                           return act;
+                       });
+    }
+
+    // Deterministic InfoFactory::create<FileInfo> replacement that skips the
+    // InfoCache async machinery entirely (kAuto caching is thread-sensitive).
+    // Non-recent lookups (the proxy inside RecentFileInfo) return null, which
+    // is a supported state and also breaks the recursion.
+    void StubInfoFactoryCreate()
+    {
+        stub.set_lamda(static_cast<FileInfoPointer (*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
+                       [](const QUrl &url, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                           __DBG_STUB_INVOKE__
+                           if (url.scheme() != RecentHelper::scheme())
+                               return nullptr;
+                           return FileInfoPointer(new RecentFileInfo(url));
+                       });
+    }
 };
 
 /**
@@ -282,4 +353,450 @@ TEST_F(RecentManagerTest, Destructor_CleansUpProperly)
     // Verify cleanup
     auto nodes = manager->getRecentNodes();
     EXPECT_EQ(nodes.size(), 0);
+}
+
+/**
+ * @brief RecentHelper::recentUrl 应把本地路径包装为 recent scheme
+ */
+TEST_F(RecentManagerTest, RecentUrl_ConvertsLocalPathToRecentScheme)
+{
+    const QUrl url = RecentHelper::recentUrl("/tmp/a.txt");
+
+    EXPECT_EQ(url.scheme(), QStringLiteral("recent"));
+    EXPECT_EQ(url.path(), QStringLiteral("/tmp/a.txt"));
+
+    const QUrl emptyUrl = RecentHelper::recentUrl(QString());
+    EXPECT_EQ(emptyUrl.scheme(), QStringLiteral("recent"));
+    EXPECT_TRUE(emptyUrl.path().isEmpty());
+}
+
+/**
+ * @brief onItemAdded 对合法路径应加入缓存并记录 originPath
+ */
+TEST_F(RecentManagerTest, OnItemAdded_ValidPath_InsertsIntoCache)
+{
+    const QString path = tempDir->filePath("added.txt");
+    const QString href = QUrl::fromLocalFile(path).toString();
+
+    manager->onItemAdded(path, href, 1700000000);
+
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_TRUE(manager->recentItems.contains(recentUrl));
+    EXPECT_EQ(manager->getRecentOriginPaths(recentUrl), href);
+}
+
+/**
+ * @brief onItemAdded 对空路径应忽略
+ */
+TEST_F(RecentManagerTest, OnItemAdded_EmptyPath_Ignored)
+{
+    manager->onItemAdded(QString(), QString("file:///tmp/none.txt"), 1);
+
+    EXPECT_EQ(manager->recentItems.size(), 0);
+    EXPECT_EQ(manager->size(), 0);
+}
+
+/**
+ * @brief onItemAdded 重复路径只保留一条
+ */
+TEST_F(RecentManagerTest, OnItemAdded_DuplicatePath_KeepsSingleEntry)
+{
+    const QString path = tempDir->filePath("dup.txt");
+
+    manager->onItemAdded(path, QString("file:///tmp/dup.txt"), 1);
+    manager->onItemAdded(path, QString("file:///tmp/dup.txt"), 2);
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->getRecentNodes().size(), 1);
+}
+
+/**
+ * @brief onItemsRemoved 应移除已存在项并保持其他项
+ */
+TEST_F(RecentManagerTest, OnItemsRemoved_ExistingPaths_RemoveFromCache)
+{
+    const QString kept = tempDir->filePath("kept.txt");
+    const QString dropped = tempDir->filePath("dropped.txt");
+    manager->onItemAdded(kept, QString("file:///tmp/kept.txt"), 1);
+    manager->onItemAdded(dropped, QString("file:///tmp/dropped.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 2);
+
+    manager->onItemsRemoved(QStringList { dropped });
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_FALSE(manager->recentItems.contains(RecentHelper::recentUrl(dropped)));
+    EXPECT_TRUE(manager->recentItems.contains(RecentHelper::recentUrl(kept)));
+}
+
+/**
+ * @brief onItemsRemoved 对未知路径应无副作用
+ */
+TEST_F(RecentManagerTest, OnItemsRemoved_UnknownPath_NoEffect)
+{
+    const QString path = tempDir->filePath("stable.txt");
+    manager->onItemAdded(path, QString("file:///tmp/stable.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 1);
+
+    manager->onItemsRemoved(QStringList { "/tmp/never_added.txt" });
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->size(), 1);
+}
+
+/**
+ * @brief onItemChanged 应更新已存在项的最近访问时间
+ */
+TEST_F(RecentManagerTest, OnItemChanged_ExistingPath_UpdatesLastReadTime)
+{
+    const QString path = tempDir->filePath("changed.txt");
+    manager->onItemAdded(path, QString("file:///tmp/changed.txt"), 100);
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+
+    manager->onItemChanged(path, 1700001234);
+
+    const auto info = manager->recentItems.value(recentUrl).fileInfo.dynamicCast<RecentFileInfo>();
+    ASSERT_FALSE(info.isNull());
+    EXPECT_EQ(info->lastReadTime, QDateTime::fromSecsSinceEpoch(1700001234));
+    EXPECT_EQ(manager->recentItems.size(), 1);
+}
+
+/**
+ * @brief onItemChanged 对空路径和未知路径应忽略
+ */
+TEST_F(RecentManagerTest, OnItemChanged_EmptyOrUnknownPath_Ignored)
+{
+    manager->onItemAdded(tempDir->filePath("anchor.txt"), QString("file:///tmp/a.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 1);
+
+    manager->onItemChanged(QString(), 42);
+    manager->onItemChanged("/tmp/not_in_cache.txt", 42);
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->size(), 1);
+}
+
+/**
+ * @brief removeRecentFile 按存在性返回正确结果
+ */
+TEST_F(RecentManagerTest, RemoveRecentFile_PresentAndAbsentUrls)
+{
+    const QString path = tempDir->filePath("removable.txt");
+    manager->onItemAdded(path, QString("file:///tmp/removable.txt"), 1);
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+
+    EXPECT_FALSE(manager->removeRecentFile(QUrl("recent:///tmp/absent.txt")));
+    EXPECT_TRUE(manager->removeRecentFile(recentUrl));
+    EXPECT_FALSE(manager->recentItems.contains(recentUrl));
+    EXPECT_EQ(manager->size(), 0);
+}
+
+/**
+ * @brief reloadRecent 应触发一次 DBus Reload 调用
+ */
+TEST_F(RecentManagerTest, ReloadRecent_InvokesDBusReloadOnce)
+{
+    int reloadCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, [&]() {
+        __DBG_STUB_INVOKE__
+        ++reloadCalls;
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    const int before = reloadCalls;
+    manager->reloadRecent();
+
+    EXPECT_EQ(reloadCalls - before, 1);
+    EXPECT_GE(reloadCalls, 2);   // one from init(), one from reloadRecent()
+}
+
+/**
+ * @brief clearRecent 应调用 DBus PurgeItems
+ */
+TEST_F(RecentManagerTest, ClearRecent_PurgesAllItemsViaDbus)
+{
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    int purgeCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [&]() {
+        __DBG_STUB_INVOKE__
+        ++purgeCalls;
+        return QDBusPendingReply<>();
+    });
+
+    RecentHelper::clearRecent();
+
+    EXPECT_EQ(purgeCalls, 1);
+    EXPECT_NE(manager->dbus(), nullptr);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"在新窗口打开"应发送开窗事件
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_OpenInNewWindowAction_SendsOpenWindow)
+{
+    int openWindowCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenWindow, [&](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openWindowCalls;
+    });
+    StubMenuExecReturnAction(0);
+
+    RecentHelper::contenxtMenuHandle(1, QUrl("recent:///tmp/menu_win.txt"), QPoint(10, 10));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openWindowCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"在新标签打开"应发送开标签事件
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_OpenInNewTabAction_SendsOpenTab)
+{
+    int openTabCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenTab, [&](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openTabCalls;
+    });
+    StubMenuExecReturnAction(1);
+
+    RecentHelper::contenxtMenuHandle(2, QUrl("recent:///tmp/menu_tab.txt"), QPoint(0, 0));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openTabCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"清空最近记录"应调用 PurgeItems
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_ClearHistoryAction_PurgesRecent)
+{
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+
+    int purgeCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [&]() {
+        __DBG_STUB_INVOKE__
+        ++purgeCalls;
+        return QDBusPendingReply<>();
+    });
+    StubMenuExecReturnAction(3);   // "Clear recent history"
+
+    RecentHelper::contenxtMenuHandle(3, QUrl("recent:///tmp/menu_clear.txt"), QPoint(5, 5));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(purgeCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 未选中任何菜单项时不应产生副作用
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_NoSelection_TakesNoAction)
+{
+    int openWindowCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenWindow, [&](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openWindowCalls;
+    });
+    StubMenuExecReturnAction(-1);   // simulate no action triggered
+
+    RecentHelper::contenxtMenuHandle(4, QUrl("recent:///tmp/menu_none.txt"), QPoint(1, 1));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openWindowCalls, 0);
+}
+
+/**
+ * @brief openFileLocation 普通用户走桌面服务展示文件
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_DesktopUser_ShowsFileItem)
+{
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *) {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(SysInfoUtils, isRootUser), []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    bool shown = false;
+    stub.set_lamda(static_cast<bool (*)(const QUrl &, const QString &)>(&DDesktopServices::showFileItem),
+                   [&](const QUrl &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       shown = true;
+                       return true;
+                   });
+
+    EXPECT_TRUE(RecentHelper::openFileLocation(QUrl("recent:///tmp/show_me.txt")));
+    EXPECT_TRUE(shown);
+}
+
+/**
+ * @brief openFileLocation root 用户走 dde-file-manager 进程
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_RootUser_StartsFileManagerProcess)
+{
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *) {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(SysInfoUtils, isRootUser), []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    typedef bool (*StartDetachedFn)(const QString &, const QStringList &,
+                                    const QString &, qint64 *);
+    bool detached = false;
+    stub.set_lamda(static_cast<StartDetachedFn>(&QProcess::startDetached),
+                   [&](const QString &program, const QStringList &,
+                       const QString &, qint64 *) {
+                       __DBG_STUB_INVOKE__
+                       detached = program == QStringLiteral("dde-file-manager");
+                       return true;
+                   });
+
+    EXPECT_TRUE(RecentHelper::openFileLocation(QUrl("recent:///tmp/root_case.txt")));
+    EXPECT_TRUE(detached);
+}
+
+/**
+ * @brief openFileLocation 列表版本逐个转发
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_UrlList_ForwardsEachUrl)
+{
+    int singleCalls = 0;
+    stub.set_lamda(static_cast<bool (*)(const QUrl &)>(&RecentHelper::openFileLocation),
+                   [&](const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       ++singleCalls;
+                       return true;
+                   });
+
+    QList<QUrl> urls { QUrl("recent:///tmp/one.txt"), QUrl("recent:///tmp/two.txt"),
+                       QUrl("recent:///tmp/three.txt") };
+    RecentHelper::openFileLocation(urls);
+
+    EXPECT_EQ(singleCalls, 3);
+}
+
+/**
+ * @brief propetyExtensionFunc 应产出包含源路径的扩展字段
+ */
+TEST_F(RecentManagerTest, PropetyExtensionFunc_ReturnsSourcePathField)
+{
+    const QString filePath = tempDir->filePath("src.txt");
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const ExpandFieldMap map = RecentHelper::propetyExtensionFunc(RecentHelper::recentUrl(filePath));
+
+    ASSERT_TRUE(map.contains("kFieldInsert"));
+    const BasicExpand &expand = map.value("kFieldInsert");
+    ASSERT_TRUE(expand.contains("kFileModifiedTime"));
+    EXPECT_EQ(expand.value("kFileModifiedTime").second, filePath);
+    EXPECT_FALSE(expand.value("kFileModifiedTime").first.isEmpty());
+}
+
+/**
+ * @brief processPendingItems 按批次(50条)消费队列并停止定时器
+ */
+TEST_F(RecentManagerTest, ProcessPendingItems_ConsumesQueueInBatches)
+{
+    StubInfoFactoryCreate();
+    for (int i = 0; i < 52; ++i) {
+        RecentManager::PendingItem item;
+        item.path = tempDir->filePath(QString("batch_%1.txt").arg(i));
+        item.href = QString("file:///tmp/batch_%1.txt").arg(i);
+        item.modified = i;
+        manager->pendingItems.enqueue(item);
+    }
+
+    manager->processPendingItems();
+
+    EXPECT_EQ(manager->recentItems.size(), 50);
+    EXPECT_EQ(manager->pendingItems.size(), 2);
+
+    manager->processPendingItems();
+
+    EXPECT_EQ(manager->recentItems.size(), 52);
+    EXPECT_TRUE(manager->pendingItems.isEmpty());
+    EXPECT_FALSE(manager->batchTimer.isActive());   // drained -> timer stopped
+}
+
+/**
+ * @brief ReloadFinished DBus 信号触发批量加载，ItemAdded 信号触发缓存新增
+ */
+TEST_F(RecentManagerTest, ReloadFinishedSignal_QueuesAndDrainsRecentItems)
+{
+    StubInfoFactoryCreate();
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    // Empty reply: resetRecentNodes still runs, starts the batch timer and the
+    // empty queue drains on the first tick.
+    int itemsInfoCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::GetItemsInfo,
+                   [&](RecentManagerDBusInterface *) -> QDBusPendingReply<QVariantList> {
+                       __DBG_STUB_INVOKE__
+                       ++itemsInfoCalls;
+                       return QDBusPendingReply<QVariantList>();
+                   });
+
+    // Non-zero timestamp triggers resetRecentNodes() which starts the timer.
+    QMetaObject::invokeMethod(manager->dbus(), "ReloadFinished",
+                              Qt::DirectConnection, Q_ARG(qlonglong, 1700000000));
+    EXPECT_EQ(itemsInfoCalls, 1);
+    EXPECT_TRUE(manager->pendingItems.isEmpty());
+    EXPECT_TRUE(manager->batchTimer.isActive());
+
+    // Let the 10ms batch tick drain the (empty) queue and stop the timer.
+    QTest::qWait(50);
+    EXPECT_FALSE(manager->batchTimer.isActive());
+
+    // Zero timestamp must not reload again.
+    QMetaObject::invokeMethod(manager->dbus(), "ReloadFinished",
+                              Qt::DirectConnection, Q_ARG(qlonglong, 0));
+    EXPECT_EQ(itemsInfoCalls, 1);
+
+    // After the once-flag connections are wired, the item signals drive the slots.
+    const QString extraPath = tempDir->filePath("dbus_extra.txt");
+    QMetaObject::invokeMethod(manager->dbus(), "ItemAdded",
+                              Q_ARG(QString, extraPath),
+                              Q_ARG(QString, "file:///tmp/dbus_extra.txt"),
+                              Q_ARG(qlonglong, 42));
+    EXPECT_EQ(manager->recentItems.size(), 1);
+
+    QMetaObject::invokeMethod(manager->dbus(), "ItemsRemoved",
+                              Q_ARG(QStringList, QStringList { extraPath }));
+    EXPECT_EQ(manager->recentItems.size(), 0);
 }

--- a/autotests/plugins/dfmplugin-workspace/events/test_workspaceeventflow.cpp
+++ b/autotests/plugins/dfmplugin-workspace/events/test_workspaceeventflow.cpp
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "stubext.h"
+
+#include "events/workspaceeventreceiver.h"
+#include "utils/workspacehelper.h"
+#include "views/fileview.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QVariant>
+#include <QMap>
+#include <QDir>
+#include <QVariantList>
+#include <QVariantMap>
+
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_workspace;
+
+namespace {
+constexpr char kSpace[] { "dfmplugin_workspace" };
+
+// All topics the receiver connects to must be registered on the framework's
+// event converter, otherwise connect/push resolve to an invalid event type.
+void registerWorkspaceTopics()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+    registered = true;
+
+    auto *event = dpfEvent;
+    const char *slotTopics[] = {
+        "slot_RegisterFileView",
+        "slot_RegisterMenuScene",
+        "slot_FindMenuScene",
+        "slot_RegisterCustomTopWidget",
+        "slot_ShowViewHint",
+        "slot_RegisterGroupStrategy",
+        "slot_RegisteredGroupStrategies",
+        "slot_GetCustomTopWidgetVisible",
+        "slot_ShowCustomTopWidget",
+        "slot_CheckSchemeViewIsFileView",
+        "slot_RefreshDir",
+        "slot_RegisterFocusFileViewDisabled",
+        "slot_View_SetCustomViewProperty",
+        "slot_View_GetVisualGeometry",
+        "slot_View_GetViewItemRect",
+        "slot_View_GetCurrentViewMode",
+        "slot_View_GetDefaultViewMode",
+        "slot_View_GetSelectedUrls",
+        "slot_View_SelectFiles",
+        "slot_View_SelectAll",
+        "slot_View_ReverseSelect",
+        "slot_View_SetSelectionMode",
+        "slot_View_SetEnabledSelectionModes",
+        "slot_View_SetDragEnabled",
+        "slot_View_SetDragDropMode",
+        "slot_View_SetReadOnly",
+        "slot_View_SetFilter",
+        "slot_View_GetFilter",
+        "slot_View_ClosePersistentEditor",
+        "slot_View_SetAlwaysOpenInCurrentWindow",
+        "slot_Model_SetCustomFilterData",
+        "slot_Model_SetCustomFilterCallback",
+        "slot_Model_RegisterRoutePrehandle",
+        "slot_Model_FileUpdate",
+        "slot_Model_SetNameFilter",
+        "slot_Model_GetNameFilter",
+        "slot_Model_CurrentSortRole",
+        "slot_Model_ColumnDisplayName",
+        "slot_Model_ColumnRoles",
+        "slot_Model_SetSort",
+        "slot_Model_CurrentGroupStrategy",
+        "slot_Model_SetGroup",
+        "slot_Model_RegisterDataCache",
+        "slot_View_AboutToChangeViewWidth",
+        "slot_View_GetColumnWidth",
+        "slot_Model_RegisterLoadStrategy",
+        "slot_Model_GetCurrentBusy",
+    };
+    for (const char *topic : slotTopics)
+        event->registerEventType(EventStratege::kSlot, kSpace, topic);
+
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Created");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Removed");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Changed");
+    event->registerEventType(EventStratege::kSignal, kSpace, "signal_View_HeaderViewSectionChanged");
+}
+}   // namespace
+
+class WorkspaceEventFlowTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        registerWorkspaceTopics();
+        WorkspaceEventReceiver::instance()->initConnection();
+        channel = dpfSlotChannel;
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    EventChannelManager *channel = nullptr;
+};
+
+// --- registration slots ---
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterFileView_CheckSchemeReturnsTrue)
+{
+    QVariant voidRet = channel->push(kSpace, "slot_RegisterFileView", QString("flowfile"));
+    EXPECT_FALSE(voidRet.isValid());
+
+    QVariant ret = channel->push(kSpace, "slot_CheckSchemeViewIsFileView", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterMenuScene_FindMenuSceneReturnsScene)
+{
+    channel->push(kSpace, "slot_RegisterMenuScene", QString("flowfile"), QString("FlowScene"));
+
+    QVariant ret = channel->push(kSpace, "slot_FindMenuScene", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toString(), QString("FlowScene"));
+    EXPECT_EQ(channel->push(kSpace, "slot_FindMenuScene", QString("unregistered")).toString(), QString(""));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterFocusFileViewDisabled_DoesNotCrash)
+{
+    QVariant ret = channel->push(kSpace, "slot_RegisterFocusFileViewDisabled", QString("flowfile"));
+    EXPECT_FALSE(ret.isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterCustomTopWidget_GetVisibleReturnsFalse)
+{
+    QVariantMap dataMap;
+    dataMap.insert("scheme", "flowscheme");
+    channel->push(kSpace, "slot_RegisterCustomTopWidget", dataMap);
+
+    QVariant ret = channel->push(kSpace, "slot_GetCustomTopWidgetVisible", quint64(1), QString("flowscheme"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_FALSE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ShowViewHint_NoWorkspace_ReturnsNull)
+{
+    QVariantMap content;
+    QVariant ret = channel->push(kSpace, "slot_ShowViewHint", quint64(1), content);
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.value<QObject *>() == nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisteredGroupStrategies_ReturnsVariantList)
+{
+    QVariant ret = channel->push(kSpace, "slot_RegisteredGroupStrategies", QString());
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.canConvert<QVariantList>());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterGroupStrategy_EmptyNameIsRejected)
+{
+    QVariantMap dataMap;   // no name: handler rejects and returns nothing
+    QVariant ret = channel->push(kSpace, "slot_RegisterGroupStrategy", dataMap);
+    EXPECT_FALSE(ret.isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterGroupStrategy_WithFactoryAndName_Registers)
+{
+    StrategyFactory factory = [](QObject *) -> DFMBASE_NAMESPACE::AbstractGroupStrategy * { return nullptr; };
+    QVariantMap dataMap;
+    dataMap.insert(PropertyKey::kGroupStrategyName, QString("FlowTimeStrategy"));
+    dataMap.insert(PropertyKey::kGroupStrategyDisplayName, QString("Flow time"));
+    dataMap.insert(PropertyKey::kGroupStrategyFactory, QVariant::fromValue(factory));
+
+    QVariant ret = channel->push(kSpace, "slot_RegisterGroupStrategy", dataMap);
+    EXPECT_FALSE(ret.isValid());
+
+    QVariantList registered = channel->push(kSpace, "slot_RegisteredGroupStrategies", QString("flowfile"))
+                                      .value<QVariantList>();
+    bool found = false;
+    for (const QVariant &entry : registered)
+        found = found || entry.toMap().value("name").toString() == QString("FlowTimeStrategy");
+    EXPECT_TRUE(found);
+    EXPECT_GE(registered.size(), 1);
+}
+
+// --- view getter slots (no window registered) ---
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetters_UnknownWindow_ReturnDefaults)
+{
+    EXPECT_EQ(channel->push(kSpace, "slot_View_GetCurrentViewMode", quint64(42)).value<ViewMode>(),
+              ViewMode::kNoneMode);
+    EXPECT_EQ(channel->push(kSpace, "slot_View_GetVisualGeometry", quint64(42)).toRectF(),
+              QRectF(0, 0, 0, 0));
+    EXPECT_TRUE(channel->push(kSpace, "slot_View_GetSelectedUrls", quint64(42)).value<QList<QUrl>>().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetViewItemRect_UnknownWindow_ReturnsEmptyRect)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetViewItemRect", quint64(42),
+                                 QUrl::fromLocalFile("/tmp/flow/a.txt"),
+                                 QVariant::fromValue(ItemRoles::kItemIconRole));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toRectF(), QRectF(0, 0, 0, 0));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelGetters_UnknownWindow_ReturnDefaults)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_GetCurrentBusy", quint64(42)).toBool());
+    EXPECT_EQ(channel->push(kSpace, "slot_Model_CurrentSortRole", quint64(42)).value<ItemRoles>(),
+              ItemRoles::kItemUnknowRole);
+    EXPECT_TRUE(channel->push(kSpace, "slot_Model_ColumnRoles", quint64(42)).value<QList<ItemRoles>>().isEmpty());
+    EXPECT_EQ(channel->push(kSpace, "slot_Model_CurrentGroupStrategy", quint64(42)).toString(), QString(""));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetFilter_UnknownWindow_ReturnsNoFilter)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetFilter", quint64(42));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toInt(), static_cast<int>(QDir::NoFilter));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelGetNameFilter_UnknownWindow_ReturnsEmpty)
+{
+    QVariant ret = channel->push(kSpace, "slot_Model_GetNameFilter", quint64(42));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toStringList().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelColumnDisplayName_UnknownWindow_ReturnsEmpty)
+{
+    QVariant ret = channel->push(kSpace, "slot_Model_ColumnDisplayName", quint64(42),
+                                 QVariant::fromValue(ItemRoles::kItemFileDisplayNameRole));
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toString().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetColumnWidth_UnknownWindow_ReturnsZero)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetColumnWidth", quint64(42),
+                                 QVariant::fromValue(ItemRoles::kItemFileSizeRole));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toInt(), 0);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetDefaultViewMode_FallsBackToValidMode)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetDefaultViewMode", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    ViewMode mode = ret.value<ViewMode>();
+    EXPECT_GE(static_cast<int>(mode), static_cast<int>(ViewMode::kIconMode));
+    EXPECT_LE(static_cast<int>(mode), static_cast<int>(ViewMode::kAllViewMode));
+}
+
+// --- setter slots on unknown windows (must not crash, return nothing) ---
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewSetters_UnknownWindow_ReturnVoid)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow/a.txt") };
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SelectFiles", quint64(42), urls).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SelectAll", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_ReverseSelect", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetAlwaysOpenInCurrentWindow", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_ClosePersistentEditor", quint64(42)).isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewModeSetters_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetSelectionMode", quint64(42),
+                               QVariant::fromValue(QAbstractItemView::SingleSelection)).isValid());
+    QList<int> modes = { int(QAbstractItemView::ExtendedSelection) };
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetEnabledSelectionModes", quint64(42), modes).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetDragEnabled", quint64(42), true).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetDragDropMode", quint64(42),
+                               QVariant::fromValue(QAbstractItemView::DragDrop)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetReadOnly", quint64(42), true).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelSetters_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetSort", quint64(42),
+                               QVariant::fromValue(ItemRoles::kItemFileSizeRole)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetGroup", quint64(42), QString("TimeModified")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetCustomFilterData", quint64(42),
+                               QUrl::fromLocalFile("/tmp/flow"), QVariant("kw")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetCustomFilterCallback", quint64(42),
+                               QUrl::fromLocalFile("/tmp/flow"), QVariant()).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_RegisterDataCache", QString("flowfile")).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelFileUpdate_AndFilterSetters_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_FileUpdate", QUrl::fromLocalFile("/tmp/flow/a.txt")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetFilter", quint64(42),
+                               QVariant::fromValue(int(QDir::Files))).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetNameFilter", quint64(42), QStringList() << "*.txt").isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_RegisterLoadStrategy", QString("flowfile"),
+                               QVariant::fromValue(DirectoryLoadStrategy::kCreateNew)).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewAboutToChangeViewWidth_AndCustomProperty_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_AboutToChangeViewWidth", quint64(42), 30).isValid());
+
+    QVariantMap properties;
+    properties.insert("allowChangeListHeight", true);
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetCustomViewProperty", QString("flowfile"), properties).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ShowCustomTopWidget_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_ShowCustomTopWidget", quint64(42), QString("flowscheme"), true).isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterRoutePrehandle_ReturnsRegistrationResult)
+{
+    // QVariant cannot carry the std::function, handler receives an empty one
+    QVariant ret = channel->push(kSpace, "slot_Model_RegisterRoutePrehandle", QString("flowfile"), QVariant());
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RefreshDir_EmptyWorkspaces_ReturnVoid)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow") };
+    EXPECT_FALSE(channel->push(kSpace, "slot_RefreshDir", urls).isValid());
+}
+
+// --- signal dispatch through EventDispatcherManager ---
+
+TEST_F(WorkspaceEventFlowTest, Publish_TrashStateChanged_InvokesHelperSignal)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_TabSignals_InvokedWithoutCrash)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Created", quint64(1), QString("tab-1")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Removed", quint64(1), QString("tab-1"), QString("tab-2")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Changed", quint64(1), QString("tab-2")));
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_GlobalEventTypes_InvokedWithoutCrash)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow/a.txt") };
+    QMap<QUrl, QUrl> renamed;
+    renamed.insert(QUrl::fromLocalFile("/tmp/flow/a.txt"), QUrl::fromLocalFile("/tmp/flow/b.txt"));
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kSwitchViewMode, quint64(1), static_cast<int>(ViewMode::kListMode)));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCopyResult, urls, urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, urls, false, QString("err")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, urls, false, QString("err")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1), renamed, false, QString("err")));
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_HeaderViewSectionChanged_InvokesFileViewSlot)
+{
+    FileView view(QUrl::fromLocalFile("/tmp/flow"));
+    view.setViewMode(Global::ViewMode::kListMode);
+
+    EXPECT_NO_FATAL_FAILURE(view.onHeaderSectionMoved(0, 0, 1));   // publishes the signal
+    EXPECT_TRUE(dpfSignalDispatcher->publish(kSpace, "signal_View_HeaderViewSectionChanged", view.rootUrl()));
+    EXPECT_EQ(view.currentViewMode(), Global::ViewMode::kListMode);
+}
+
+TEST_F(WorkspaceEventFlowTest, Unsubscribe_TrashAndTabSignals_RemoveHandlers)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged",
+                                                 WorkspaceHelper::instance(), &WorkspaceHelper::trashStateChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Created",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabCreated));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Removed",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabRemoved));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Changed",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabChanged));
+
+    // handlers removed, but publish still dispatches without crashing
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Created", quint64(9), QString("tab-9")));
+}

--- a/autotests/plugins/dfmplugin-workspace/test_fileviewsorter.cpp
+++ b/autotests/plugins/dfmplugin-workspace/test_fileviewsorter.cpp
@@ -3,13 +3,50 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <gtest/gtest.h>
-#include <QUrl>
-#include <QList>
+
+#include "stubext.h"
 
 #include "utils/fileviewsorter.h"
+#include "models/fileitemdata.h"
+
+#include <dfm-base/interfaces/sortfileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <QUrl>
+#include <QList>
+#include <QHash>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QFileInfo>
+
+#include <functional>
 
 using namespace dfmplugin_workspace;
 using namespace dfmbase::Global;
+using namespace dfmbase;
+
+namespace {
+FileItemDataPointer makeSortItem(const QUrl &url, bool isDir, qint64 size, qint64 lastModified)
+{
+    auto *info = new SortFileInfo();
+    info->setUrl(url);
+    info->setDir(isDir);
+    info->setFile(!isDir);
+    info->setSize(size);
+    info->setLastModifiedTime(lastModified);
+    return FileItemDataPointer(new FileItemData(SortInfoPointer(info), nullptr));
+}
+
+QList<QUrl> toUrls(const char *const *names, int count)
+{
+    QList<QUrl> urls;
+    for (int i = 0; i < count; ++i)
+        urls << QUrl::fromLocalFile(QString("/ut-sorter/%1").arg(names[i]));
+    return urls;
+}
+}   // namespace
 
 class FileViewSorterTest : public testing::Test
 {
@@ -148,4 +185,388 @@ TEST_F(FileViewSorterTest, Reverse_SizeRole_NoCrash)
 
     QList<QUrl> urls = {QUrl("file:///a"), QUrl("file:///b"), QUrl("file:///c")};
     EXPECT_NO_FATAL_FAILURE(sorter->reverse(urls));
+}
+
+// --- sort (mixed / separated) ---
+
+TEST_F(FileViewSorterTest, Sort_MixedFileNameAscending_OrdersByName)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    sorter->setContext(ctx);
+
+    const char *names[] = { "c.txt", "a.txt", "b.txt" };
+    QList<QUrl> result = sorter->sort(toUrls(names, 3));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).fileName(), QString("a.txt"));
+    EXPECT_EQ(result.at(2).fileName(), QString("c.txt"));
+}
+
+TEST_F(FileViewSorterTest, Sort_MixedFileNameDescending_ReversesOrder)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::DescendingOrder;
+    sorter->setContext(ctx);
+
+    const char *names[] = { "c.txt", "a.txt", "b.txt" };
+    QList<QUrl> result = sorter->sort(toUrls(names, 3));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).fileName(), QString("c.txt"));
+    EXPECT_EQ(result.at(2).fileName(), QString("a.txt"));
+}
+
+TEST_F(FileViewSorterTest, Sort_SeparatedMode_DirectoriesBeforeFiles)
+{
+    QHash<QString, FileItemDataPointer> items;
+    auto add = [&items](const QString &name, bool dir) {
+        QUrl url = QUrl::fromLocalFile("/ut-sorter/" + name);
+        items.insert(name, makeSortItem(url, dir, 10, 1000));
+        return url;
+    };
+    QUrl dirZ = add("zdir", true);
+    QUrl dirA = add("adir", true);
+    QUrl fileB = add("bfile", false);
+    QUrl fileA = add("afile", false);
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = false;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ dirZ, dirA, fileB, fileA });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirA);
+    EXPECT_EQ(result.at(1), dirZ);
+    EXPECT_EQ(result.at(2), fileA);
+    EXPECT_EQ(result.at(3), fileB);
+}
+
+TEST_F(FileViewSorterTest, Sort_SizeRoleAscending_DirectoryFirstThenBySize)
+{
+    QUrl dirUrl = QUrl::fromLocalFile("/ut-sorter/dirA");
+    QUrl f100 = QUrl::fromLocalFile("/ut-sorter/f100.bin");
+    QUrl f500 = QUrl::fromLocalFile("/ut-sorter/f500.bin");
+    QUrl f050 = QUrl::fromLocalFile("/ut-sorter/f050.bin");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("dirA", makeSortItem(dirUrl, true, 0, 0));
+    items.insert("f100.bin", makeSortItem(f100, false, 100, 0));
+    items.insert("f500.bin", makeSortItem(f500, false, 500, 0));
+    items.insert("f050.bin", makeSortItem(f050, false, 50, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::Size;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ f500, dirUrl, f100, f050 });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirUrl);   // directory always prefixed first on ascending
+    EXPECT_EQ(result.at(1), f050);
+    EXPECT_EQ(result.at(3), f500);
+}
+
+TEST_F(FileViewSorterTest, Sort_LastModifiedRole_OrdersByTimeWithFallback)
+{
+    QUrl early = QUrl::fromLocalFile("/ut-sorter/early.txt");
+    QUrl late = QUrl::fromLocalFile("/ut-sorter/late.txt");
+    QUrl noTime = QUrl::fromLocalFile("/ut-sorter/notime.txt");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("early.txt", makeSortItem(early, false, 1, 1000));
+    items.insert("late.txt", makeSortItem(late, false, 1, 2000000000));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::LastModified;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ late, noTime, early });
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0), noTime);   // fallback default time "0000/00/00" sorts first
+    EXPECT_EQ(result.at(1), early);
+    EXPECT_EQ(result.at(2), late);
+}
+
+TEST_F(FileViewSorterTest, Sort_TimeRolesWithoutCallback_UseDefaultTime)
+{
+    const FileViewSorter::SortRole roles[] = {
+        FileViewSorter::SortRole::LastCreated,
+        FileViewSorter::SortRole::LastRead,
+        FileViewSorter::SortRole::DeletionDate
+    };
+    for (auto role : roles) {
+        FileViewSorter::SortContext ctx;
+        ctx.isMixDirAndFile = true;
+        ctx.role = role;
+        sorter->setContext(ctx);
+
+        const char *names[] = { "x.txt", "a.txt" };
+        QList<QUrl> result = sorter->sort(toUrls(names, 2));
+        ASSERT_EQ(result.size(), 2) << "role=" << int(role);
+        // all keys share the same fallback time, secondary key is the file name
+        EXPECT_EQ(result.at(0).fileName(), QString("a.txt")) << "role=" << int(role);
+    }
+}
+
+TEST_F(FileViewSorterTest, Sort_FilePathRole_UsesLocalPathAsKey)
+{
+    QUrl urlCa = QUrl::fromLocalFile("/ut-sorter/c/a");
+    QUrl urlAb = QUrl::fromLocalFile("/ut-sorter/a/b");
+    QUrl urlBc = QUrl::fromLocalFile("/ut-sorter/b/c");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("a", makeSortItem(urlAb, false, 1, 0));
+    items.insert("b", makeSortItem(urlBc, false, 1, 0));
+    items.insert("c", makeSortItem(urlCa, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FilePath;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QString(QFileInfo(url.path()).fileName()));
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlCa, urlAb, urlBc });
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).path(), QString("/ut-sorter/a/b"));
+    EXPECT_EQ(result.at(2).path(), QString("/ut-sorter/c/a"));
+}
+
+TEST_F(FileViewSorterTest, Sort_OriginalPathRoleWithoutInfo_FallsBackToUrlPath)
+{
+    QUrl urlY = QUrl::fromLocalFile("/ut-sorter/y");
+    QUrl urlZ = QUrl::fromLocalFile("/ut-sorter/z");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("y", makeSortItem(urlY, false, 1, 0));
+    items.insert("z", makeSortItem(urlZ, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::OriginalPath;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QString(QFileInfo(url.path()).fileName()));
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlZ, urlY });
+
+    ASSERT_EQ(result.size(), 2);
+    // no trash originalUrl data: both keys are empty, input order is preserved
+    EXPECT_EQ(result.at(0), urlZ);
+    EXPECT_EQ(result.at(1), urlY);
+}
+
+TEST_F(FileViewSorterTest, Sort_MimeTypeRoleNoInfo_RanksUnknownGroupBytName)
+{
+    QUrl urlB = QUrl::fromLocalFile("/ut-sorter/b.doc");
+    QUrl urlA = QUrl::fromLocalFile("/ut-sorter/a.doc");
+    QUrl urlC = QUrl::fromLocalFile("/ut-sorter/c.doc");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("b.doc", makeSortItem(urlB, false, 1, 0));
+    items.insert("a.doc", makeSortItem(urlA, false, 1, 0));
+    items.insert("c.doc", makeSortItem(urlC, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::MimeType;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlC, urlA });
+
+    ASSERT_EQ(result.size(), 3);
+    // no FileInfo and no SortInfo dates: all unknown mime, tie broken by name
+    EXPECT_EQ(result.at(0), urlA);
+    EXPECT_EQ(result.at(2), urlC);
+}
+
+TEST_F(FileViewSorterTest, Sort_MimeTypeRoleRealFiles_UsesAccurateMimeName)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString txtPath = dir.filePath("note.txt");
+    QString pngPath = dir.filePath("pic.png");
+    QFile txtFile(txtPath);
+    QFile pngFile(pngPath);
+    ASSERT_TRUE(txtFile.open(QIODevice::WriteOnly));
+    ASSERT_TRUE(pngFile.open(QIODevice::WriteOnly));
+    txtFile.close();
+    pngFile.close();
+
+    QUrl txtUrl = QUrl::fromLocalFile(txtPath);
+    QUrl pngUrl = QUrl::fromLocalFile(pngPath);
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("note.txt", makeSortItem(txtUrl, false, 1, 1000));
+    items.insert("pic.png", makeSortItem(pngUrl, false, 1, 1000));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::MimeType;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.fileName()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ pngUrl, txtUrl });
+
+    ASSERT_EQ(result.size(), 2);
+    // image group rank (2) sorts after text group rank (1)
+    EXPECT_EQ(result.at(0), txtUrl);
+    EXPECT_EQ(result.at(1), pngUrl);
+}
+
+TEST_F(FileViewSorterTest, Sort_FileNameUnderHomeWithoutInfo_UsesUrlFileName)
+{
+    QUrl urlB = QUrl::fromLocalFile("/ut-sorter/home/b");
+    QUrl urlA = QUrl::fromLocalFile("/ut-sorter/home/a");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("b", makeSortItem(urlB, false, 1, 0));
+    items.insert("a", makeSortItem(urlA, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.isUnderHomeDir = true;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlA });
+
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result.at(0), urlA);
+    EXPECT_EQ(result.at(1), urlB);
+}
+
+TEST_F(FileViewSorterTest, Sort_LastModifiedFromFileInfo_UsesFileStatTime)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString pathA = dir.filePath("older.txt");
+    QFile fileA(pathA);
+    ASSERT_TRUE(fileA.open(QIODevice::WriteOnly));
+    fileA.write("hello");
+    fileA.close();
+    QString pathB = dir.filePath("newer.txt");
+    QFile fileB(pathB);
+    ASSERT_TRUE(fileB.open(QIODevice::WriteOnly));
+    fileB.write("world!!");
+    fileB.close();
+
+    QUrl urlA = QUrl::fromLocalFile(pathA);
+    QUrl urlB = QUrl::fromLocalFile(pathB);
+    QHash<QString, FileItemDataPointer> items;
+    // no SortInfo: the sorter must fall back to FileInfo stat times
+    items.insert("older.txt", FileItemDataPointer(new FileItemData(urlA, InfoFactory::create<FileInfo>(urlA))));
+    items.insert("newer.txt", FileItemDataPointer(new FileItemData(urlB, InfoFactory::create<FileInfo>(urlB))));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::LastModified;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.fileName()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlA });
+
+    ASSERT_EQ(result.size(), 2);
+    // both created moments ago; the key is deterministic "time_filename"
+    EXPECT_TRUE(result.contains(urlA));
+    EXPECT_TRUE(result.contains(urlB));
+}
+
+// --- findInsertPosition ---
+
+TEST_F(FileViewSorterTest, FindInsertPosition_MiddleOfSortedList_ReturnsOne)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    sorter->setContext(ctx);
+
+    QList<QUrl> sorted = toUrls(nullptr, 0);
+    sorted << QUrl::fromLocalFile("/ut-sorter/a.txt")
+           << QUrl::fromLocalFile("/ut-sorter/c.txt");
+    int pos = sorter->findInsertPosition(QUrl::fromLocalFile("/ut-sorter/b.txt"), sorted);
+
+    EXPECT_EQ(pos, 1);
+    EXPECT_EQ(sorter->findInsertPosition(QUrl::fromLocalFile("/d.txt"), {}), 0);
+}
+
+TEST_F(FileViewSorterTest, FindInsertPosition_DescendingOrder_FindsTail)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::DescendingOrder;
+    sorter->setContext(ctx);
+
+    QList<QUrl> sorted;
+    sorted << QUrl::fromLocalFile("/ut-sorter/c.txt")
+           << QUrl::fromLocalFile("/ut-sorter/a.txt");
+    int pos = sorter->findInsertPosition(QUrl::fromLocalFile("/ut-sorter/b.txt"), sorted);
+
+    EXPECT_EQ(pos, 1);
+    EXPECT_EQ(sorted.size(), 2);
+}
+
+// --- reverse grouped ---
+
+TEST_F(FileViewSorterTest, Reverse_SeparatedMode_ReversesInsideGroups)
+{
+    QUrl dirA = QUrl::fromLocalFile("/ut-sorter/adir");
+    QUrl dirB = QUrl::fromLocalFile("/ut-sorter/bdir");
+    QUrl fileA = QUrl::fromLocalFile("/ut-sorter/afile");
+    QUrl fileB = QUrl::fromLocalFile("/ut-sorter/bfile");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("adir", makeSortItem(dirA, true, 0, 0));
+    items.insert("bdir", makeSortItem(dirB, true, 0, 0));
+    items.insert("afile", makeSortItem(fileA, false, 0, 0));
+    items.insert("bfile", makeSortItem(fileB, false, 0, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = false;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->reverse({ dirA, dirB, fileA, fileB });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirB);
+    EXPECT_EQ(result.at(1), dirA);
+    EXPECT_EQ(result.at(2), fileB);
+    EXPECT_EQ(result.at(3), fileA);
 }

--- a/autotests/plugins/dfmplugin-workspace/views/test_fileview_behavior.cpp
+++ b/autotests/plugins/dfmplugin-workspace/views/test_fileview_behavior.cpp
@@ -1,0 +1,861 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "stubext.h"
+
+#include "views/fileview.h"
+#include "views/baseitemdelegate.h"
+#include "models/fileviewmodel.h"
+#include "utils/workspacehelper.h"
+#include "utils/traversaldirthreadmanager.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/fileinfohelper.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QUrlQuery>
+#include <QPoint>
+#include <QModelIndex>
+#include <QSize>
+#include <QRect>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QEvent>
+#include <QContextMenuEvent>
+#include <QItemSelection>
+#include <QTemporaryDir>
+#include <QApplication>
+#include <QPixmap>
+#include <QMimeData>
+#include <QScrollBar>
+#include <QtTest>
+#include <DGuiApplicationHelper>
+
+using namespace dfmplugin_workspace;
+
+class FileViewBehaviorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        testUrl = QUrl::fromLocalFile("/tmp/ut_ws_fileview");
+        view = new FileView(testUrl);
+
+        stub.set_lamda(&dfmbase::NetworkUtils::checkFtpOrSmbBusy,
+                       [](dfmbase::NetworkUtils *, const QUrl &) { return false; });
+    }
+
+    void TearDown() override
+    {
+        delete view;
+        WorkspaceHelper::kSelectionAndRenameFile.clear();
+        stub.clear();
+    }
+
+    QUrl testUrl;
+    FileView *view = nullptr;
+    stub_ext::StubExt stub;
+};
+
+// --- view mode switching ---
+
+TEST_F(FileViewBehaviorTest, SetViewMode_IconMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_EQ(view->itemCountForRow(), view->iconModeColumnCount());
+}
+
+TEST_F(FileViewBehaviorTest, SetViewMode_ListMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->itemCountForRow(), 1);
+}
+
+TEST_F(FileViewBehaviorTest, SetViewMode_TreeMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kTreeMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kTreeMode);
+    EXPECT_EQ(view->itemCountForRow(), 1);
+}
+
+TEST_F(FileViewBehaviorTest, ViewModeChanged_DifferentMode_SwitchesAndPersists)
+{
+    ASSERT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+
+    // switching back to the current mode is a no-op
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, ViewModeChanged_UnsupportedMode_DoesNotSwitch)
+{
+    ASSERT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kNoneMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnDefaultViewModeChanged_UnsupportedScheme_KeepsMode)
+{
+    view->onDefaultViewModeChanged(static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    // scheme is not registered for tree/list support check, mode stays unchanged
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NE(view->model(), nullptr);
+}
+
+// --- selection related ---
+
+TEST_F(FileViewBehaviorTest, SelectedIndexCount_NoSelection_ReturnsZero)
+{
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_TRUE(view->selectedIndexes().isEmpty());
+}
+
+TEST_F(FileViewBehaviorTest, SelectFiles_EmptyList_ReturnsFalse)
+{
+    EXPECT_FALSE(view->selectFiles({}));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SelectFiles_UrlOutsideRoot_ReturnsFalse)
+{
+    QList<QUrl> files = { QUrl::fromLocalFile("/elsewhere/file.txt") };
+    EXPECT_FALSE(view->selectFiles(files));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SetEnabledSelectionModes_ExcludingCurrent_ResetsMode)
+{
+    ASSERT_EQ(view->selectionMode(), QAbstractItemView::ExtendedSelection);
+    view->setEnabledSelectionModes({ QAbstractItemView::SingleSelection });
+    EXPECT_EQ(view->selectionMode(), QAbstractItemView::SingleSelection);
+
+    // restore a list that contains the current mode: no reset needed
+    view->setEnabledSelectionModes({ QAbstractItemView::SingleSelection,
+                                     QAbstractItemView::ExtendedSelection });
+    EXPECT_EQ(view->selectionMode(), QAbstractItemView::SingleSelection);
+}
+
+TEST_F(FileViewBehaviorTest, ReverseSelect_NoSelection_KeepsEmptySelection)
+{
+    EXPECT_NO_FATAL_FAILURE(view->reverseSelect());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, CurrentPressIndex_NoPress_ReturnsInvalidIndex)
+{
+    EXPECT_FALSE(view->currentPressIndex().isValid());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SelectedTreeViewUrlList_NoSelection_ReturnsEmptyLists)
+{
+    QList<QUrl> selected;
+    QList<QUrl> treeSelected;
+    view->selectedTreeViewUrlList(selected, treeSelected);
+    EXPECT_TRUE(selected.isEmpty());
+    EXPECT_TRUE(treeSelected.isEmpty());
+
+    EXPECT_EQ(view->selectedTreeViewUrlList().size(), 0);
+}
+
+// --- model interaction ---
+
+TEST_F(FileViewBehaviorTest, DataChanged_InvalidIndexes_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->dataChanged(QModelIndex(), QModelIndex()));
+    EXPECT_EQ(view->currentIndex(), QModelIndex());
+}
+
+TEST_F(FileViewBehaviorTest, StopWork_AnyUrl_MarksModelIdle)
+{
+    view->stopWork(QUrl::fromLocalFile("/tmp/other"));
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+TEST_F(FileViewBehaviorTest, Refresh_NotBusy_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->refresh());
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+}
+
+TEST_F(FileViewBehaviorTest, SetRootUrl_WithStubbedTraversal_ReturnsTrue)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+
+    bool result = false;
+    EXPECT_NO_FATAL_FAILURE({ result = view->setRootUrl(rootUrl); });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(view->rootUrl(), rootUrl);
+}
+
+TEST_F(FileViewBehaviorTest, SetRootUrl_UrlWithSelectQuery_ParsesSelectedUrl)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+    QUrl withQuery = rootUrl;
+    QUrlQuery query;
+    query.addQueryItem("selectUrl", dir.path() + "/picked.txt");
+    withQuery.setQuery(query);
+
+    bool result = false;
+    EXPECT_NO_FATAL_FAILURE({ result = view->setRootUrl(withQuery); });
+    EXPECT_TRUE(result);
+    // the selectUrl query item is consumed by parseSelectedUrl
+    EXPECT_FALSE(QUrlQuery(view->rootUrl()).hasQueryItem("selectUrl"));
+}
+
+// --- click / open handling ---
+
+TEST_F(FileViewBehaviorTest, OnClicked_InvalidIndex_DoesNotOpenAnything)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onClicked(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, OnDoubleClicked_InvalidIndex_DoesNotOpenAnything)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onDoubleClicked(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, OnSelectAndEdit_UntrackedWindow_IsIgnored)
+{
+    WorkspaceHelper::kSelectionAndRenameFile.clear();
+    QUrl target = testUrl.toString() + "/new_file.txt";
+    EXPECT_NO_FATAL_FAILURE(view->onSelectAndEdit(target));
+    EXPECT_TRUE(WorkspaceHelper::kSelectionAndRenameFile.isEmpty());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnSelectAndEdit_TrackedUrlWithInvalidIndex_EarlyReturns)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    ASSERT_TRUE(view->setRootUrl(QUrl::fromLocalFile(dir.path())));
+
+    WorkspaceHelper::kSelectionAndRenameFile.clear();
+    QUrl target = QUrl::fromLocalFile(dir.path() + "/new_file.txt");
+    quint64 winId = WorkspaceHelper::instance()->windowId(view);
+    WorkspaceHelper::kSelectionAndRenameFile.insert(winId, { view->rootUrl(), target });
+
+    EXPECT_NO_FATAL_FAILURE(view->onSelectAndEdit(target));
+    // index lookup fails (empty model): the tracking entry is consumed before that
+    EXPECT_TRUE(WorkspaceHelper::kSelectionAndRenameFile.isEmpty());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, Edit_InvalidIndex_ReturnsFalse)
+{
+    EXPECT_FALSE(view->edit(QModelIndex(), QAbstractItemView::AllEditTriggers, nullptr));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, KeyboardSearchViaEvent_PlainLetter_NoCrash)
+{
+    QKeyEvent letter(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier, "a");
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &letter));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, KeyPressArrowKeys_NavigateEmptyModel_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QKeyEvent down(QEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&down));
+    QKeyEvent up(QEvent::KeyPress, Qt::Key_Up, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&up));
+    QKeyEvent left(QEvent::KeyPress, Qt::Key_Left, Qt::AltModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&left));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+// --- header view slots ---
+
+TEST_F(FileViewBehaviorTest, HeaderSlots_InListMode_DoNotCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewMousePressed());
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewMouseReleased());
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderSectionResized(0, 100, 120));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderSectionMoved(0, 0, 1));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderHiddenChanged(QString("Name"), true));
+    EXPECT_NO_FATAL_FAILURE(view->onSortIndicatorChanged(0, Qt::DescendingOrder));
+    EXPECT_NO_FATAL_FAILURE(view->onSectionHandleDoubleClicked(0));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnSortIndicatorChanged_BusyModel_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    auto roleBefore = view->model()->sortRole();
+    // model is idle by default, so call goes through; assert state stays consistent
+    EXPECT_NO_FATAL_FAILURE(view->onSortIndicatorChanged(0, Qt::AscendingOrder));
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->model()->sortRole(), roleBefore);
+}
+
+TEST_F(FileViewBehaviorTest, OnHeaderViewSectionChanged_SameUrlInListMode_RefreshesHeader)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewSectionChanged(view->rootUrl()));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewSectionChanged(QUrl::fromLocalFile("/tmp/other")));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, SetSort_NewRole_ModelStaysConsistent)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->setSort(dfmbase::Global::ItemRoles::kItemFileSizeRole, Qt::DescendingOrder);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->model()->sortOrder(), view->model()->sortOrder());   // reachable without crash
+}
+
+TEST_F(FileViewBehaviorTest, SetGroup_WithStrategy_NoCrash)
+{
+    view->setGroup(QString("TimeModified"), Qt::AscendingOrder);
+    EXPECT_NO_FATAL_FAILURE(view->groupingState());
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+// --- attribute / state slots ---
+
+TEST_F(FileViewBehaviorTest, OnScalingValueChanged_PersistsIconSizeLevel)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onScalingValueChanged(3));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnIconSizeChanged_NewLevel_UpdatesDelegateLevel)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    view->onIconSizeChanged(2);
+    EXPECT_EQ(view->itemDelegate()->iconSizeLevel(), 2);
+}
+
+TEST_F(FileViewBehaviorTest, OnIconSizeChanged_SameLevel_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    int levelBefore = view->itemDelegate()->iconSizeLevel();
+    view->onIconSizeChanged(levelBefore);
+    EXPECT_EQ(view->itemDelegate()->iconSizeLevel(), levelBefore);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemWidthLevelChanged_ListDelegate_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->onItemWidthLevelChanged(3);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemWidthLevelChanged_IconDelegate_UpdatesWidthLevel)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onItemWidthLevelChanged(2));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemHeightLevelChanged_NoSelection_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onItemHeightLevelChanged(1));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnShowFileSuffixChanged_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onShowFileSuffixChanged(true));
+    EXPECT_NO_FATAL_FAILURE(view->onShowFileSuffixChanged(false));
+}
+
+TEST_F(FileViewBehaviorTest, OnWidgetUpdate_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onWidgetUpdate());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnRenameProcessStarted_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onRenameProcessStarted());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnAboutToSwitchListView_EmptyList_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onAboutToSwitchListView({}));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnAppAttributeChanged_FileViewStateGroup_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("FileViewState", "any", QVariant(1)));
+
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("FileViewState", "any", QVariant(1)));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnAppAttributeChanged_OtherGroup_IsIgnored)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("OtherGroup", "key", QVariant()));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, TrashStateChanged_WithModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->trashStateChanged());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnRowCountChanged_EmptyModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(QMetaObject::invokeMethod(view, "onRowCountChanged"));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+// --- private slots via meta system ---
+
+TEST_F(FileViewBehaviorTest, PrivateSlots_LoadAndSaveViewState_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "loadViewState", Q_ARG(QUrl, testUrl)));
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "saveViewModeState"));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnModelStateChanged_IdlePath_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onModelStateChanged"));
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_SetIconSizeBySizeIndex_UpdatesSlider)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "setIconSizeBySizeIndex", Q_ARG(int, 1)));
+    EXPECT_NO_FATAL_FAILURE(view->onIconSizeChanged(1));
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_UpdateHorizontalOffset_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "updateHorizontalOffset"));
+    EXPECT_EQ(view->horizontalOffset(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_UpdateOneView_InvalidIndex_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "updateOneView", Q_ARG(QModelIndex, QModelIndex())));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnSelectionChanged_EmptySelection_NoCrash)
+{
+    QItemSelection empty;
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onSelectionChanged",
+                                          Q_ARG(QItemSelection, empty),
+                                          Q_ARG(QItemSelection, empty)));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupExpansionToggled_InvalidKey_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupExpansionToggled", Q_ARG(QString, QString(""))));
+    EXPECT_EQ(view->model()->groupingStrategy(), QString(""));
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupTruncationToggled_InvalidKey_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupTruncationToggled", Q_ARG(QString, QString(""))));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupHeaderClicked_InvalidIndex_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupHeaderClicked", Q_ARG(QModelIndex, QModelIndex())));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+// --- geometry helpers ---
+
+TEST_F(FileViewBehaviorTest, IndexAtForSelection_ListMode_ClampsXCoordinate)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QModelIndex index = view->indexAtForSelection(QPoint(-500, 4));
+    EXPECT_FALSE(index.isValid());
+    EXPECT_EQ(view->indexAtForSelection(QPoint(10, 4)), index);
+}
+
+TEST_F(FileViewBehaviorTest, IndexAtForSelection_IconMode_EmptyModelInvalidIndex)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_FALSE(view->indexAtForSelection(QPoint(10, 10)).isValid());
+    EXPECT_EQ(view->itemCountForRow(), view->iconModeColumnCount());
+}
+
+TEST_F(FileViewBehaviorTest, IsClickInTopPadding_InvalidIndex_ReturnsFalse)
+{
+    EXPECT_FALSE(view->isClickInTopPadding(QPoint(5, 5), QModelIndex()));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, IndexInRect_InvalidIndex_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->indexInRect(QRect(0, 0, 20, 20), QModelIndex()));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, CalcVisualRect_NoItems_ReturnsDeterministicRect)
+{
+    QRect rect = view->calcVisualRect(400, 3);
+    EXPECT_FALSE(rect.isValid());   // empty model: item size hint is null
+    EXPECT_EQ(rect, view->calcVisualRect(400, 3));
+}
+
+TEST_F(FileViewBehaviorTest, IconModeColumnCount_DefaultWidth_PositiveCount)
+{
+    int count = view->iconModeColumnCount(80);
+    EXPECT_GE(count, 0);
+    EXPECT_EQ(view->iconModeColumnCount(), count);
+}
+
+TEST_F(FileViewBehaviorTest, StickyHeaderHelpers_NoGroups_ReturnDefaults)
+{
+    EXPECT_EQ(view->stickyHeaderHeight(), 0);
+    EXPECT_FALSE(view->isPosInStickyHeader(QPoint(10, 10)));
+    EXPECT_FALSE(view->findStickyGroupIndex(30).isValid());
+    EXPECT_EQ(view->computeStickyY(30), 0);
+    EXPECT_EQ(view->groupHeaderContentTop(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, AboutToChangeWidth_ListMode_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->aboutToChangeWidth(50));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+// --- filters and open-mode ---
+
+TEST_F(FileViewBehaviorTest, SetFilterData_UrlMismatch_DoesNotApplyFilter)
+{
+    view->setFilterData(QUrl::fromLocalFile("/tmp/other"), QVariant("keyword"));
+    EXPECT_NE(view->model(), nullptr);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+TEST_F(FileViewBehaviorTest, SetFilterData_MatchingVisibleUrl_AppliesFilter)
+{
+    view->show();
+    view->setFilterData(view->rootUrl(), QVariant("keyword"));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, SetFilterCallback_MatchingVisibleUrl_AppliesCallback)
+{
+    FileViewFilterCallback callback = [](dfmbase::SortFileInfo *, QVariant) { return true; };
+    view->show();
+    EXPECT_NO_FATAL_FAILURE(view->setFilterCallback(view->rootUrl(), callback));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, SetAlwaysOpenInCurrentWindow_ChangesDirOpenMode)
+{
+    view->setAlwaysOpenInCurrentWindow(true);
+    EXPECT_EQ(view->currentDirOpenMode(), DirOpenMode::kAwaysInCurrentWindow);
+
+    view->setAlwaysOpenInCurrentWindow(false);
+    EXPECT_NE(view->currentDirOpenMode(), DirOpenMode::kAwaysInCurrentWindow);
+}
+
+// --- events sent through QApplication ---
+
+TEST_F(FileViewBehaviorTest, LeaveEventViaSendEvent_NoCrash)
+{
+    QEvent leaveEvent(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &leaveEvent));
+    EXPECT_FALSE(view->isPosInStickyHeader(QPoint(10, 10)));
+}
+
+TEST_F(FileViewBehaviorTest, MouseDoubleClickEventViaSendEvent_EmptyArea_NoCrash)
+{
+    QMouseEvent dblClick(QEvent::MouseButtonDblClick, QPointF(10, 10), QPointF(10, 10),
+                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &dblClick));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ContextMenuEventViaSendEvent_EmptyArea_NoBlockingMenu)
+{
+    QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, QPoint(10, 10), QPoint(10, 10));
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &menuEvent));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PaintEventViaRepaint_Offscreen_NoCrash)
+{
+    view->resize(400, 300);
+    view->show();
+    EXPECT_NO_FATAL_FAILURE(view->repaint());
+    EXPECT_TRUE(view->isVisible());
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, ScrollTo_InvalidIndex_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->scrollTo(QModelIndex(), QAbstractItemView::PositionAtTop));
+    EXPECT_EQ(view->verticalOffset(), 0);
+}
+
+// --- protected event handlers invoked directly ---
+
+TEST_F(FileViewBehaviorTest, MousePressMoveRelease_OnEmptyArea_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(5, 5), QPointF(5, 5),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mousePressEvent(&press));
+
+    QMouseEvent move(QEvent::MouseMove, QPointF(40, 40), QPointF(40, 40),
+                     Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseMoveEvent(&move));
+
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(40, 40), QPointF(40, 40),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseReleaseEvent(&release));
+
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, MouseDoubleClick_OnEmptyArea_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QMouseEvent dblClick(QEvent::MouseButtonDblClick, QPointF(10, 10), QPointF(10, 10),
+                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseDoubleClickEvent(&dblClick));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ContextMenu_OnEmptyArea_NoBlockingMenu)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, QPoint(10, 10), QPoint(10, 10));
+    EXPECT_NO_FATAL_FAILURE(view->contextMenuEvent(&menuEvent));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PaintEvent_ViaWidgetRender_Completes)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->resize(300, 200);
+    view->show();
+    QPixmap pixmap(300, 200);
+    EXPECT_NO_FATAL_FAILURE(view->render(&pixmap));
+    EXPECT_FALSE(pixmap.isNull());
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, WheelEvent_CtrlModifier_IncreasesAndDecreasesIcon)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    stub.set_lamda(&dfmbase::WindowUtils::keyCtrlIsPressed, []() { return true; });
+
+    int levelBefore = view->itemDelegate()->iconSizeLevel();
+    QWheelEvent up(QPointF(10, 10), QPointF(10, 10), QPoint(0, 120), QPoint(0, 120),
+                   Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase, false);
+    EXPECT_NO_FATAL_FAILURE(view->wheelEvent(&up));
+    EXPECT_GE(view->itemDelegate()->iconSizeLevel(), levelBefore);
+
+    QWheelEvent down(QPointF(10, 10), QPointF(10, 10), QPoint(0, -120), QPoint(0, -120),
+                     Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase, false);
+    EXPECT_NO_FATAL_FAILURE(view->wheelEvent(&down));
+    EXPECT_LE(view->itemDelegate()->iconSizeLevel(), view->itemDelegate()->maximumIconSizeLevel());
+}
+
+TEST_F(FileViewBehaviorTest, SetSelection_EmptyModel_ClearsSelectionSafely)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->setSelection(QRect(0, 0, 50, 50),
+                                               QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, RowsAboutToBeRemoved_EmptyModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->rowsAboutToBeRemoved(QModelIndex(), 0, 0));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, StartDrag_NoSelection_ReturnsWithoutDrag)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QMimeData mimeData;
+    EXPECT_NO_FATAL_FAILURE(view->startDrag(Qt::CopyAction));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+// --- private helpers invoked through direct access ---
+
+TEST_F(FileViewBehaviorTest, OpenIndex_InvalidIndex_WarnsAndReturns)
+{
+    EXPECT_NO_FATAL_FAILURE(view->openIndex(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ExpandOrCollapseItem_NoTreeArrow_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->expandOrCollapseItem(QModelIndex(), QPoint(5, 5)));
+    EXPECT_FALSE(view->groupExpandOrCollapseItem(QModelIndex(), QPoint(5, 5), true));
+}
+
+TEST_F(FileViewBehaviorTest, GroupExpandOrCollapseItem_ImmediateToggle_ReturnsTrue)
+{
+    EXPECT_TRUE(view->groupExpandOrCollapseItem(QModelIndex(), QPoint(), false));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, TruncateButtonHelpers_NoGroups_AreNoOps)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_TRUE(view->truncateButtonGroupKeyAt(QPoint(10, 10)).isEmpty());
+    EXPECT_NO_FATAL_FAILURE(view->updateTruncateButtonHover(QPoint(10, 10)));
+    EXPECT_NO_FATAL_FAILURE(view->clearTruncateButtonHover());
+    EXPECT_TRUE(view->itemDelegate()->hoveredTruncateGroupKey().isEmpty());
+}
+
+TEST_F(FileViewBehaviorTest, StickyHeaderPaintAndScroll_InvalidIndex_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->paintStickyHeaderOverlay(QModelIndex(), 0, 20));
+    EXPECT_NO_FATAL_FAILURE(view->scrollStickyHeaderToTop(QModelIndex()));
+    EXPECT_GT(view->stickyHeaderHeight(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, ItemRect_ListMode_ReturnsRectsForRoles)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_ws_fileview/none.txt");
+    EXPECT_TRUE(view->itemRect(url, dfmbase::Global::ItemRoles::kItemBackgroundRole).isNull());
+    EXPECT_NO_FATAL_FAILURE(view->itemRect(url, dfmbase::Global::ItemRoles::kItemIconRole));
+}
+
+TEST_F(FileViewBehaviorTest, RectIndexHelpers_EmptyModel_ReturnSentinelRanges)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_TRUE(view->rectContainsIndexes(QRect(0, 0, 100, 100)).isEmpty());
+    EXPECT_TRUE(view->calcRectContiansIndexes(4, QRect(0, 0, 100, 100)).isEmpty());
+
+    auto ranges = view->calcGroupRectContiansIndexes(QRect(0, 0, 100, 100));
+    ASSERT_EQ(ranges.size(), 1);
+    EXPECT_EQ(ranges.first(), qMakePair(-1, -1));   // sentinel range when nothing intersects
+}
+
+TEST_F(FileViewBehaviorTest, IsClickInGroupHeaderSpacing_InvalidIndex_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->isClickInGroupHeaderSpacing(QPoint(5, 5), QModelIndex()));
+    EXPECT_FALSE(view->isClickInGroupHeaderSpacing(QPoint(5, 5), view->model()->index(0, 0)));
+}
+
+TEST_F(FileViewBehaviorTest, RowCount_ListModeEmptyModel_ReturnsZero)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->rowCount(), 0);
+    EXPECT_EQ(view->count(), 0);
+}
+
+// --- timer / signal lambdas wired in initializeConnect / initializeScrollBarWatcher ---
+
+TEST_F(FileViewBehaviorTest, ScrollBarSignals_DriveWatcherLambdas_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    auto *vbar = view->verticalScrollBar();
+
+    EXPECT_NO_FATAL_FAILURE(emit vbar->sliderPressed());
+    EXPECT_NO_FATAL_FAILURE(emit vbar->valueChanged(5));
+    QTest::qWait(80);   // let the 50ms scrollBarValueChangedTimer fire
+    EXPECT_NO_FATAL_FAILURE(emit vbar->sliderReleased());
+    EXPECT_FALSE(view->isVerticalScrollBarSliderDragging());
+}
+
+TEST_F(FileViewBehaviorTest, ModelHighlightKeywordsSignal_UpdatesDelegates)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QStringList keywords { "foo", "bar" };
+    EXPECT_NO_FATAL_FAILURE(emit view->model()->highlightKeywordsChanged(keywords));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, ModelGroupingStateChanged_AfterSetGroup_RunsQueuedLambda)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    view->setGroup(QString("TimeModified"), Qt::AscendingOrder);
+    QTest::qWait(30);   // groupingStateChanged connection is queued
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, PreSelectionTimer_AfterSetRootUrlWithSelectUrl_SelectsNothing)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+    QUrl withQuery = rootUrl;
+    QUrlQuery query;
+    query.addQueryItem("selectUrl", dir.path() + "/picked.txt");
+    withQuery.setQuery(query);
+
+    ASSERT_TRUE(view->setRootUrl(withQuery));
+    QTest::qWait(200);   // preSelectTimer is a 100ms single shot
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, FileInfoHelperSmbSignal_NonSmbRoot_IsIgnored)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QUrl smbLike = QUrl::fromLocalFile("/tmp/ut_ws_fileview/share");
+    EXPECT_NO_FATAL_FAILURE(emit dfmbase::FileInfoHelper::instance().smbSeverMayModifyPassword(smbLike));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, MoveCursor_InvalidRootIndex_ReturnsInvalidIndex)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->moveCursor(QAbstractItemView::MoveDown, Qt::NoModifier).isValid());
+    EXPECT_FALSE(view->moveCursor(QAbstractItemView::MoveNext, Qt::NoModifier).isValid());
+}
+
+TEST_F(FileViewBehaviorTest, SizeModeChangedSignal_InIconMode_AdjustsSpacing)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(emit Dtk::Gui::DGuiApplicationHelper::instance()->sizeModeChanged(
+            Dtk::Gui::DGuiApplicationHelper::SizeMode::CompactMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}


### PR DESCRIPTION
## Summary
- Add real event-dispatch tests for ddplugin-canvas, dfmplugin-workspace, dfmplugin-fileoperations and dfmplugin-recent (real subscription + typed `publish`/`push`, stubbed heavy deps)
- Add FileView behavior tests (94 cases) and extend FileViewSorter coverage (+15) for dfmplugin-workspace
- Extend recent plugin tests: RecentManager (21 cases), real followEvents/bindEvents flow (5 cases), plus ghost-stub fixes

## Verification
- ut-ddplugin-canvas: 771/771 passed
- ut-dfmplugin-workspace: 1464 cases, 0 failures (12 pre-existing GTEST_SKIP untouched)
- ut-dfmplugin-fileoperations: 835/835 passed
- ut-dfmplugin-recent: 132/132 passed

## Coverage impact
- eventhelper.h instantiations for these 4 plugins: fully covered
- canvasview.cpp 67/67 (100%), fileview.cpp 66->144/184, fileviewsorter.cpp fully covered, recentmanager.cpp 29/30

Base: c13ee5bb