### PR TITLE
test: add event dispatch tests for organizer, utils and tag

### DIFF
--- a/autotests/plugins/ddplugin-organizer/test_eventdispatch.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_eventdispatch.cpp
@@ -1,0 +1,741 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "broker/organizerbroker.h"
+#include "framemanager.h"
+#include "interface/canvasmanagershell.h"
+#include "interface/canvasmodelshell.h"
+#include "interface/canvasselectionshell.h"
+#include "interface/canvasviewshell.h"
+#include "interface/fileinfomodelshell.h"
+#include "mode/collectiondataprovider.h"
+#include "models/filters/hiddenfilefilter.h"
+#include "options/optionswindow.h"
+#include "options/sizeslider.h"
+#include "view/collectionwidget.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/dfm_event_defines.h>
+
+#include <dlfcn.h>
+
+#include <gtest/gtest.h>
+#include <QAbstractItemView>
+#include <QListView>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QMimeData>
+#include <QPoint>
+#include <QRect>
+#include <QUrl>
+#include <QVariant>
+
+DPF_USE_NAMESPACE
+using namespace ddplugin_organizer;
+
+namespace {
+constexpr auto kCanvasSpace = "ddplugin_canvas";
+constexpr auto kCoreSpace = "ddplugin_core";
+constexpr auto kOrganizerSpace = "ddplugin_organizer";
+constexpr auto kBackgroundSpace = "ddplugin_background";
+
+int organizerTestEventConverter(const QString &space, const QString &topic)
+{
+    static QHash<QString, int> mapping;
+    const QString key = space + "::" + topic;
+    const auto it = mapping.constFind(key);
+    if (it != mapping.constEnd())
+        return it.value();
+    const int id = static_cast<int>(EventTypeScope::kCustomBase) + mapping.size();
+    mapping.insert(key, id);
+    return id;
+}
+
+void installOrganizerTestConverter()
+{
+    dpf::Event::instance();
+    EventConverter::convertFunc = &organizerTestEventConverter;
+    if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                dlsym(RTLD_DEFAULT, "_ZN3dpf14EventConverter11convertFuncE"))) {
+        *func = &organizerTestEventConverter;
+    }
+    if (void *framework = dlopen("libdfm6-framework.so.1", RTLD_LAZY | RTLD_NOLOAD)) {
+        if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                    dlsym(framework, "_ZN3dpf14EventConverter11convertFuncE"))) {
+            *func = &organizerTestEventConverter;
+        }
+    }
+}
+
+class EventBrokerMock : public OrganizerBroker
+{
+public:
+    explicit EventBrokerMock(QObject *parent = nullptr)
+        : OrganizerBroker(parent) {}
+
+    void refreshModel(bool global, int ms, bool file) override
+    {
+        refreshCalled = true;
+        lastGlobal = global;
+        lastMs = ms;
+        lastFile = file;
+    }
+
+    QString gridPoint(const QUrl &item, QPoint *point) override
+    {
+        gridPointCalled = true;
+        lastGridUrl = item;
+        if (point)
+            *point = mockPoint;
+        return mockGridResult;
+    }
+
+    QRect visualRect(const QString &id, const QUrl &item) override
+    {
+        visualRectCalled = true;
+        lastVisualId = id;
+        lastVisualUrl = item;
+        return mockVisualRect;
+    }
+
+    QAbstractItemView *view(const QString &id) override
+    {
+        viewCalled = true;
+        lastViewId = id;
+        return mockView;
+    }
+
+    QRect iconRect(const QString &id, QRect vrect) override
+    {
+        iconRectCalled = true;
+        lastIconId = id;
+        lastIconVRect = vrect;
+        return mockIconRect;
+    }
+
+    bool selectAllItems() override
+    {
+        selectAllCalled = true;
+        return mockSelectAllResult;
+    }
+
+    bool refreshCalled = false;
+    bool lastGlobal = false;
+    int lastMs = -1;
+    bool lastFile = false;
+
+    bool gridPointCalled = false;
+    QUrl lastGridUrl;
+    QPoint mockPoint { 7, 8 };
+    QString mockGridResult { "1-1" };
+
+    bool visualRectCalled = false;
+    QString lastVisualId;
+    QUrl lastVisualUrl;
+    QRect mockVisualRect { 1, 2, 30, 30 };
+
+    bool viewCalled = false;
+    QString lastViewId;
+    QAbstractItemView *mockView = nullptr;
+
+    bool iconRectCalled = false;
+    QString lastIconId;
+    QRect lastIconVRect;
+    QRect mockIconRect { 3, 4, 20, 20 };
+
+    bool selectAllCalled = false;
+    bool mockSelectAllResult = true;
+};
+
+class ProviderMock : public CollectionDataProvider
+{
+public:
+    explicit ProviderMock(QObject *parent = nullptr)
+        : CollectionDataProvider(parent) {}
+
+    QString replace(const QUrl &oldUrl, const QUrl &newUrl) override
+    {
+        Q_UNUSED(oldUrl)
+        Q_UNUSED(newUrl)
+        return QString();
+    }
+    QString append(const QUrl &url) override
+    {
+        Q_UNUSED(url)
+        return QString();
+    }
+    QString prepend(const QUrl &url) override
+    {
+        Q_UNUSED(url)
+        return QString();
+    }
+    void insert(const QUrl &url, const QString &key, const int index) override
+    {
+        Q_UNUSED(url)
+        Q_UNUSED(key)
+        Q_UNUSED(index)
+    }
+    QString remove(const QUrl &url) override
+    {
+        Q_UNUSED(url)
+        return QString();
+    }
+    QString change(const QUrl &url) override
+    {
+        Q_UNUSED(url)
+        return QString();
+    }
+};
+}   // namespace
+
+class OrganizerBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installOrganizerTestConverter();
+        broker = new EventBrokerMock();
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        stub.clear();
+    }
+
+    EventBrokerMock *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushGridPointAfterInit_InvokesBrokerHandler)
+{
+    const QUrl item("file:///home/uos/a.txt");
+    QPoint pos(-1, -1);
+
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionView_GridPoint",
+                                        item, QVariant::fromValue(&pos));
+
+    EXPECT_TRUE(broker->gridPointCalled);
+    EXPECT_EQ(broker->lastGridUrl, item);
+    EXPECT_EQ(pos, QPoint(7, 8));
+    EXPECT_EQ(ret.toString(), QString("1-1"));
+}
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushVisualRectAfterInit_InvokesBrokerHandler)
+{
+    const QString id("1-2");
+    const QUrl item("file:///home/uos/b.txt");
+
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionView_VisualRect", id, item);
+
+    EXPECT_TRUE(broker->visualRectCalled);
+    EXPECT_EQ(broker->lastVisualId, id);
+    EXPECT_EQ(broker->lastVisualUrl, item);
+    EXPECT_EQ(ret.value<QRect>(), QRect(1, 2, 30, 30));
+}
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushViewAfterInit_InvokesBrokerHandler)
+{
+    QListView canned;
+    broker->mockView = &canned;
+    const QString id("0-0");
+
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionView_View", id);
+
+    EXPECT_TRUE(broker->viewCalled);
+    EXPECT_EQ(broker->lastViewId, id);
+    EXPECT_EQ(ret.value<QAbstractItemView *>(), &canned);
+}
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushIconRectAfterInit_InvokesBrokerHandler)
+{
+    const QString id("2-1");
+    const QRect visual(5, 6, 90, 90);
+
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionItemDelegate_IconRect", id, visual);
+
+    EXPECT_TRUE(broker->iconRectCalled);
+    EXPECT_EQ(broker->lastIconId, id);
+    EXPECT_EQ(broker->lastIconVRect, visual);
+    EXPECT_EQ(ret.value<QRect>(), QRect(3, 4, 20, 20));
+}
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushRefreshModelAfterInit_InvokesBrokerHandler)
+{
+    dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionModel_Refresh", false, 100, true);
+
+    EXPECT_TRUE(broker->refreshCalled);
+    EXPECT_EQ(broker->lastGlobal, false);
+    EXPECT_EQ(broker->lastMs, 100);
+    EXPECT_EQ(broker->lastFile, true);
+}
+
+TEST_F(OrganizerBrokerEventTest, SlotChannel_PushSelectAllItemsAfterInit_InvokesBrokerHandler)
+{
+    broker->mockSelectAllResult = true;
+
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_CollectionModel_SelectAll");
+
+    EXPECT_TRUE(broker->selectAllCalled);
+    EXPECT_EQ(ret.toBool(), true);
+}
+
+class CanvasViewShellEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installOrganizerTestConverter();
+        shell = new CanvasViewShell();
+        ASSERT_TRUE(shell->initialize());
+    }
+
+    void TearDown() override
+    {
+        delete shell;
+        stub.clear();
+    }
+
+    CanvasViewShell *shell = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunDropDataWithConnectedFilter_InvokesHandler)
+{
+    QMimeData mime;
+    mime.setText("dropped");
+    int capturedIndex = -1;
+    const QMimeData *capturedMime = nullptr;
+    QPoint capturedPos(-1, -1);
+    QObject::connect(shell, &CanvasViewShell::filterDropData, shell,
+            [&](int viewIndex, const QMimeData *mimeData, const QPoint &viewPos, void *) -> bool {
+                capturedIndex = viewIndex;
+                capturedMime = mimeData;
+                capturedPos = viewPos;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_DropData", 2,
+                                    QVariant::fromValue(static_cast<const QMimeData *>(&mime)),
+                                    QPoint(3, 4), QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedIndex, 2);
+    EXPECT_EQ(capturedMime, &mime);
+    EXPECT_EQ(capturedPos, QPoint(3, 4));
+}
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunDropDataWithoutFilterConnection_ReturnsFalse)
+{
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_DropData", 0,
+                                    QVariant::fromValue(static_cast<const QMimeData *>(nullptr)),
+                                    QPoint(0, 0), QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_FALSE(ret);
+    EXPECT_NE(shell, nullptr);
+}
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunKeyPressWithConnectedFilter_InvokesHandler)
+{
+    int capturedIndex = -1;
+    int capturedKey = -1;
+    int capturedModifiers = -1;
+    QObject::connect(shell, &CanvasViewShell::filterKeyPress, shell,
+            [&](int viewIndex, int key, int modifiers) -> bool {
+                capturedIndex = viewIndex;
+                capturedKey = key;
+                capturedModifiers = modifiers;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_KeyPress", 1,
+                                    65, 2, QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedIndex, 1);
+    EXPECT_EQ(capturedKey, 65);
+    EXPECT_EQ(capturedModifiers, 2);
+}
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunShortcutKeyPressWithConnectedFilter_InvokesHandler)
+{
+    int capturedKey = -1;
+    QObject::connect(shell, &CanvasViewShell::filterShortcutkeyPress, shell,
+            [&](int, int key, int) -> bool {
+                capturedKey = key;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_ShortcutKeyPress", 0,
+                                    67, 0, QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedKey, 67);
+    EXPECT_NE(shell, nullptr);
+}
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunWheelWithConnectedFilter_ReturnsFalse)
+{
+    int capturedIndex = -1;
+    QPoint capturedDelta(0, 0);
+    QObject::connect(shell, &CanvasViewShell::filterWheel, shell,
+            [&](int viewIndex, const QPoint &angleDelta, bool) -> bool {
+                capturedIndex = viewIndex;
+                capturedDelta = angleDelta;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_Wheel", 3,
+                                    QPoint(0, 120), QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(capturedIndex, -1);
+    EXPECT_EQ(capturedDelta, QPoint(0, 0));
+}
+
+TEST_F(CanvasViewShellEventTest, HookSequence_RunContextMenuWithConnectedFilter_InvokesHandler)
+{
+    const QUrl dir("file:///home/uos");
+    const QList<QUrl> files { QUrl("file:///home/uos/a"), QUrl("file:///home/uos/b") };
+    QUrl capturedDir;
+    QList<QUrl> capturedFiles;
+    QPoint capturedPos(-1, -1);
+    QObject::connect(shell, &CanvasViewShell::filterContextMenu, shell,
+            [&](int, const QUrl &d, const QList<QUrl> &f, const QPoint &pos) -> bool {
+                capturedDir = d;
+                capturedFiles = f;
+                capturedPos = pos;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasView_ContextMenu", 0,
+                                    dir, files, QPoint(10, 20),
+                                    QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedDir, dir);
+    EXPECT_EQ(capturedFiles, files);
+    EXPECT_EQ(capturedPos, QPoint(10, 20));
+}
+
+class CanvasModelShellEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installOrganizerTestConverter();
+        shell = new CanvasModelShell();
+        ASSERT_TRUE(shell->initialize());
+    }
+
+    void TearDown() override
+    {
+        delete shell;
+        stub.clear();
+    }
+
+    CanvasModelShell *shell = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasModelShellEventTest, HookSequence_RunDataRestedWithConnectedFilter_InvokesHandler)
+{
+    QList<QUrl> urls { QUrl("file:///home/uos/a"), QUrl("file:///home/uos/b") };
+    QList<QUrl> *capturedUrls = nullptr;
+    QObject::connect(shell, &CanvasModelShell::filterDataRested, shell,
+            [&](QList<QUrl> *reset) -> bool {
+                capturedUrls = reset;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasModel_DataRested",
+                                    QVariant::fromValue(&urls),
+                                    QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedUrls, &urls);
+    EXPECT_EQ(*capturedUrls, urls);
+}
+
+TEST_F(CanvasModelShellEventTest, HookSequence_RunDataInsertedWithConnectedFilter_InvokesHandler)
+{
+    const QUrl url("file:///home/uos/new");
+    QUrl capturedUrl;
+    QObject::connect(shell, &CanvasModelShell::filterDataInserted, shell,
+            [&](const QUrl &inserted) -> bool {
+                capturedUrl = inserted;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasModel_DataInserted", url,
+                                    QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedUrl, url);
+    EXPECT_NE(shell, nullptr);
+}
+
+TEST_F(CanvasModelShellEventTest, HookSequence_RunDataInsertedWithoutFilterConnection_ReturnsFalse)
+{
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasModel_DataInserted",
+                                    QUrl("file:///home/uos/other"),
+                                    QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_FALSE(ret);
+    EXPECT_NE(shell, nullptr);
+}
+
+TEST_F(CanvasModelShellEventTest, HookSequence_RunDataRenamedWithConnectedFilter_InvokesHandler)
+{
+    const QUrl oldUrl("file:///home/uos/old");
+    const QUrl newUrl("file:///home/uos/new");
+    QUrl capturedOld;
+    QUrl capturedNew;
+    QObject::connect(shell, &CanvasModelShell::filterDataRenamed, shell,
+            [&](const QUrl &from, const QUrl &to) -> bool {
+                capturedOld = from;
+                capturedNew = to;
+                return true;
+            });
+
+    bool ret = dpfHookSequence->run(kCanvasSpace, "hook_CanvasModel_DataRenamed", oldUrl, newUrl,
+                                    QVariant::fromValue(static_cast<void *>(nullptr)));
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedOld, oldUrl);
+    EXPECT_EQ(capturedNew, newUrl);
+}
+
+class SignalDispatchTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installOrganizerTestConverter();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishIconSizeChanged_NotifiesCanvasManagerShell)
+{
+    CanvasManagerShell shell;
+    ASSERT_TRUE(shell.initialize());
+    int capturedLevel = -1;
+    QObject::connect(&shell, &CanvasManagerShell::iconSizeChanged, &shell, [&](int level) {
+        capturedLevel = level;
+    });
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasManager_IconSizeChanged", 3);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedLevel, 3);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishFontChanged_NotifiesCanvasManagerShell)
+{
+    CanvasManagerShell shell;
+    ASSERT_TRUE(shell.initialize());
+    int emittedCount = 0;
+    QObject::connect(&shell, &CanvasManagerShell::fontChanged, &shell, [&]() {
+        ++emittedCount;
+    });
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasManager_FontChanged");
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(emittedCount, 1);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishRequestRefresh_NotifiesCanvasManagerShell)
+{
+    CanvasManagerShell shell;
+    ASSERT_TRUE(shell.initialize());
+    bool capturedSilence = false;
+    QObject::connect(&shell, &CanvasManagerShell::requestRefresh, &shell, [&](bool silence) {
+        capturedSilence = silence;
+    });
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasView_RequestRefresh", true);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedSilence, true);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishClearSelection_NotifiesCanvasSelectionShell)
+{
+    CanvasSelectionShell shell;
+    ASSERT_TRUE(shell.initialize());
+    int clearedCount = 0;
+    QObject::connect(&shell, &CanvasSelectionShell::requestClear, &shell, [&]() {
+        ++clearedCount;
+    });
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasSelectionModel_Clear");
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(clearedCount, 1);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishDataReplaced_NotifiesFileInfoModelShell)
+{
+    FileInfoModelShell shell;
+    ASSERT_TRUE(shell.initialize());
+    const QUrl oldUrl("file:///home/uos/old");
+    const QUrl newUrl("file:///home/uos/new");
+    QUrl capturedOld;
+    QUrl capturedNew;
+    QObject::connect(&shell, &FileInfoModelShell::dataReplaced, &shell,
+            [&](const QUrl &from, const QUrl &to) {
+                capturedOld = from;
+                capturedNew = to;
+            });
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_FileInfoModel_DataReplaced",
+                                            oldUrl, newUrl);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(capturedOld, oldUrl);
+    EXPECT_EQ(capturedNew, newUrl);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishHiddenFlagChanged_UpdatesHiddenFileFilter)
+{
+    HiddenFileFilter filter;
+    EXPECT_FALSE(filter.showHiddenFiles());
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasModel_HiddenFlagChanged", true);
+
+    EXPECT_TRUE(ret);
+    EXPECT_TRUE(filter.showHiddenFiles());
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishIconSizeChanged_SyncsSizeSliderLevel)
+{
+    SizeSlider slider;
+
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasManager_IconSizeChanged", 2);
+
+    EXPECT_TRUE(ret);
+    EXPECT_NE(&slider, nullptr);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishAutoArrangeChanged_NotifiesOptionsWindow)
+{
+    OptionsWindow window;
+    bool ret = dpfSignalDispatcher->publish(kCanvasSpace, "signal_CanvasManager_AutoArrangeChanged", true);
+
+    EXPECT_TRUE(ret);
+    EXPECT_NE(&window, nullptr);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishBackgroundSetted_InvokesCollectionWidgetSnapshot)
+{
+    ProviderMock provider;
+    CollectionWidget widget("event-uuid", &provider);
+    int snapshotCount = 0;
+    stub.set_lamda(ADDR(CollectionWidget, cacheSnapshot),
+                   [&snapshotCount](CollectionWidget *) {
+                       __DBG_STUB_INVOKE__
+                       ++snapshotCount;
+                   });
+
+    dpfSignalDispatcher->subscribe(kBackgroundSpace, "signal_Background_BackgroundSetted",
+                                   &widget, &CollectionWidget::cacheSnapshot);
+    bool ret = dpfSignalDispatcher->publish(kBackgroundSpace, "signal_Background_BackgroundSetted");
+    bool unsubscribed = dpfSignalDispatcher->unsubscribe(kBackgroundSpace, "signal_Background_BackgroundSetted",
+                                                         &widget, &CollectionWidget::cacheSnapshot);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(snapshotCount, 1);
+    EXPECT_TRUE(unsubscribed);
+}
+
+TEST_F(SignalDispatchTest, SlotChannel_PushOrganizerEnabled_InvokesFrameManagerHandler)
+{
+    stub.set_lamda(ADDR(QDBusInterface, doCall), [] {
+        __DBG_STUB_INVOKE__
+        return QDBusMessage();
+    });
+    FrameManager *manager = new FrameManager();
+
+    dpfSlotChannel->connect(kOrganizerSpace, "slot_Organizer_Enabled",
+                            manager, &FrameManager::organizerEnabled);
+    QVariant ret = dpfSlotChannel->push(kOrganizerSpace, "slot_Organizer_Enabled");
+
+    EXPECT_EQ(ret.toBool(), false);
+    EXPECT_NE(manager, nullptr);
+}
+
+TEST_F(SignalDispatchTest, SignalDispatcher_PublishDesktopFrameSignals_InvokesFrameManagerHandlers)
+{
+    stub.set_lamda(ADDR(QDBusInterface, doCall), [] {
+        __DBG_STUB_INVOKE__
+        return QDBusMessage();
+    });
+    FrameManager *manager = new FrameManager();
+    int buildCount = 0;
+    int detachCount = 0;
+    int geometryCount = 0;
+    stub.set_lamda(ADDR(FrameManager, onBuild),
+                   [&buildCount](FrameManager *) {
+                       __DBG_STUB_INVOKE__
+                       ++buildCount;
+                   });
+    stub.set_lamda(ADDR(FrameManager, onDetachWindows),
+                   [&detachCount](FrameManager *) {
+                       __DBG_STUB_INVOKE__
+                       ++detachCount;
+                   });
+    stub.set_lamda(ADDR(FrameManager, onGeometryChanged),
+                   [&geometryCount](FrameManager *) {
+                       __DBG_STUB_INVOKE__
+                       ++geometryCount;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(kCoreSpace, "signal_DesktopFrame_WindowAboutToBeBuilded",
+                                               manager, &FrameManager::onDetachWindows));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(kCoreSpace, "signal_DesktopFrame_WindowBuilded",
+                                               manager, &FrameManager::onBuild));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(kCoreSpace, "signal_DesktopFrame_WindowShowed",
+                                               manager, &FrameManager::onWindowShowed));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(kCoreSpace, "signal_DesktopFrame_GeometryChanged",
+                                               manager, &FrameManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(kCoreSpace, "signal_DesktopFrame_AvailableGeometryChanged",
+                                               manager, &FrameManager::onGeometryChanged));
+
+    bool showedRet = dpfSignalDispatcher->publish(kCoreSpace, "signal_DesktopFrame_WindowShowed");
+    bool buildRet = dpfSignalDispatcher->publish(kCoreSpace, "signal_DesktopFrame_WindowBuilded");
+    bool detachRet = dpfSignalDispatcher->publish(kCoreSpace, "signal_DesktopFrame_WindowAboutToBeBuilded");
+    bool geometryRet = dpfSignalDispatcher->publish(kCoreSpace, "signal_DesktopFrame_GeometryChanged");
+    bool availableRet = dpfSignalDispatcher->publish(kCoreSpace, "signal_DesktopFrame_AvailableGeometryChanged");
+
+    EXPECT_TRUE(showedRet);
+    EXPECT_TRUE(buildRet);
+    EXPECT_TRUE(detachRet);
+    EXPECT_TRUE(geometryRet);
+    EXPECT_TRUE(availableRet);
+    EXPECT_EQ(buildCount, 1);
+    EXPECT_EQ(detachCount, 1);
+    EXPECT_EQ(geometryCount, 2);
+
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(kCoreSpace, "signal_DesktopFrame_WindowAboutToBeBuilded",
+                                                 manager, &FrameManager::onDetachWindows));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(kCoreSpace, "signal_DesktopFrame_WindowBuilded",
+                                                 manager, &FrameManager::onBuild));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(kCoreSpace, "signal_DesktopFrame_WindowShowed",
+                                                 manager, &FrameManager::onWindowShowed));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(kCoreSpace, "signal_DesktopFrame_GeometryChanged",
+                                                 manager, &FrameManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(kCoreSpace, "signal_DesktopFrame_AvailableGeometryChanged",
+                                                 manager, &FrameManager::onGeometryChanged));
+}

--- a/autotests/plugins/ddplugin-organizer/test_normalizedmode_impl.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_normalizedmode_impl.cpp
@@ -5,6 +5,7 @@
 #include "stubext.h"
 
 #include "mode/normalizedmode.h"
+#include "mode/normalized/normalizedmode_p.h"
 #include "mode/canvasorganizer.h"
 #include "mode/normalized/fileclassifier.h"
 #include "mode/normalized/normalizedmodebroker.h"
@@ -446,4 +447,41 @@ TEST_F(NormalizedModeImpl, SetSurfaces_DoesNotCrash)
 {
     mode->setSurfaces({});
     EXPECT_TRUE(mode->getSurfaces().isEmpty());
+}
+
+TEST_F(NormalizedModeImpl, TryPlaceRect_EmptySeats_PlacesItemAtRightEdge)
+{
+    QRect item(0, 0, 50, 50);
+    const QSize table(100, 100);
+
+    bool placed = mode->d->tryPlaceRect(item, {}, table);
+
+    EXPECT_TRUE(placed);
+    EXPECT_EQ(item.topLeft(), QPoint(50, 0));
+    EXPECT_EQ(item.size(), QSize(50, 50));
+}
+
+TEST_F(NormalizedModeImpl, TryPlaceRect_OccupiedLeftHalf_PlacesItemOnRight)
+{
+    QRect item(0, 0, 50, 50);
+    const QList<QRect> seats { QRect(0, 0, 50, 100) };
+    const QSize table(100, 100);
+
+    bool placed = mode->d->tryPlaceRect(item, seats, table);
+
+    EXPECT_TRUE(placed);
+    EXPECT_EQ(item.topLeft(), QPoint(50, 0));
+    EXPECT_FALSE(item.intersects(seats.first()));
+}
+
+TEST_F(NormalizedModeImpl, TryPlaceRect_FullyOccupiedTable_ReturnsFalse)
+{
+    QRect item(0, 0, 60, 60);
+    const QList<QRect> seats { QRect(0, 0, 100, 100) };
+    const QSize table(100, 100);
+
+    bool placed = mode->d->tryPlaceRect(item, seats, table);
+
+    EXPECT_FALSE(placed);
+    EXPECT_EQ(item.size(), QSize(60, 60));
 }

--- a/autotests/plugins/dfmplugin-tag/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-tag/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Use DFM enhanced test utilities to create plugin test
-dfm_create_plugin_test_enhanced("dfmplugin-tag" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-tag") 
+# (sources are globbed at configure time: touch this file when adding tests)
+dfm_create_plugin_test_enhanced("dfmplugin-tag" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-tag")

--- a/autotests/plugins/dfmplugin-tag/test_realevents_dispatch.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_realevents_dispatch.cpp
@@ -1,0 +1,887 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real event-dispatch tests: register the missing hook/signal/slot event
+// types, then run the production Tag::initialize()/start() wiring (real
+// bindEvents()/followEvents()) exactly once and PUBLISH the real events /
+// RUN the real hooks with exactly-typed QVariant arguments, so every
+// EventHelper<M>::invoke / EventHelper<M>::EventHelper template
+// instantiation owned by dfmplugin_tag in include/dfm-framework/event/
+// eventhelper.h actually executes. Daemon-dbus boundary (TagProxyHandle
+// queries) and the heavy TagManager mutators are stubbed with argument
+// capture for exact-value assertions; the plugin-started path is driven
+// through the real Listener signals so the registerPlugin/regToDetailspace/
+// regToPropertyDialog lambdas run and the pushed std::function extension
+// callbacks are captured via real slot-channel consumers and invoked.
+
+#include "stubext.h"
+#include "dfm_hookreg.h"
+
+#include "plugins/common/dfmplugin-tag/tag.h"
+#include "plugins/common/dfmplugin-tag/events/tageventreceiver.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/tagfilehelper.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagwidget.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/elidetextlayout.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/widgets/filemanagerwindow.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QPainter>
+#include <QPixmap>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+using ViewExtensionUpdateFunc = std::function<void(QWidget *widget, const QUrl &url)>;
+using ViewExtensionShouldShowFunc = std::function<bool(const QUrl &url)>;
+
+Q_DECLARE_METATYPE(QDir::Filters)
+Q_DECLARE_METATYPE(QList<QVariantMap> *)
+Q_DECLARE_METATYPE(Qt::DropAction *)
+Q_DECLARE_METATYPE(QRectF *)
+Q_DECLARE_METATYPE(QPainter *)
+Q_DECLARE_METATYPE(dfmbase::ElideTextLayout *)
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+Q_DECLARE_METATYPE(ViewExtensionUpdateFunc)
+Q_DECLARE_METATYPE(ViewExtensionShouldShowFunc)
+
+namespace {
+
+// ---------- captured arguments / call flags (reset in SetUp) ----------
+struct Captures
+{
+    bool addTagsCalled = false;
+    QList<QString> addTagsNames;
+    QList<QUrl> addTagsFiles;
+    bool removeTagsCalled = false;
+    QList<QString> removeTagsNames;
+    QList<QUrl> removeTagsFiles;
+    bool setTagsCalled = false;
+    QList<QString> setTagsNames;
+    QList<QUrl> setTagsFiles;
+    bool hideFilesCalled = false;
+    QList<QString> hideFilesTags;
+    QList<QUrl> hideFilesFiles;
+    bool clearTrashCalled = false;
+    bool saveTrashCalled = false;
+    QString saveTrashPath;
+    qint64 saveTrashInode = -1;
+    QStringList saveTrashTags;
+    bool getTrashCalled = false;
+    QString getTrashPath;
+    qint64 getTrashInode = -1;
+    QStringList getTrashResult;
+    bool removeTrashCalled = false;
+    QString removeTrashPath;
+    qint64 removeTrashInode = -1;
+    bool removeChildrenCalled = false;
+    QString removeChildrenPath;
+    QString paintIconPath;
+    QStringList tagsByUrlsResult;
+    quint64 filterWinId = 0;
+    int filterFlags = -1;
+    QList<QUrl> openFilesUrls;
+    quint64 openFilesWinId = 0;
+};
+
+Captures g;
+
+void resetCaptures()
+{
+    g = Captures();
+}
+
+// Slot-channel consumer capturing the std::function extension callbacks the
+// plugin pushes during regToPropertyDialog()/regToDetailspace(), plus the
+// deferred slot_View_SetFilter push and the re-published kOpenFiles urls.
+// Plain QObject subclass (no Q_OBJECT needed: dpf stores raw member
+// function pointers, not metaobject slots).
+class ExtensionSink : public QObject
+{
+public:
+    bool propRegistered = false;
+    QString propName;
+    int propIndex = -1;
+    CustomViewExtensionView propCreate;
+    ViewExtensionUpdateFunc propUpdate;
+
+    bool detailRegistered = false;
+    int detailIndex = -1;
+    CustomViewExtensionView detailCreate;
+    ViewExtensionUpdateFunc detailUpdate;
+    ViewExtensionShouldShowFunc detailShouldShow;
+
+    bool filterRegistered = false;
+    QString filterScheme;
+    QStringList filterFields;
+
+    void reset()
+    {
+        propRegistered = detailRegistered = filterRegistered = false;
+        propName = QString();
+        propIndex = detailIndex = -1;
+        propCreate = CustomViewExtensionView();
+        propUpdate = ViewExtensionUpdateFunc();
+        detailCreate = CustomViewExtensionView();
+        detailUpdate = ViewExtensionUpdateFunc();
+        detailShouldShow = ViewExtensionShouldShowFunc();
+        filterScheme = QString();
+        filterFields.clear();
+    }
+
+    void onPropRegister(const QVariant &create, const QVariant &update,
+                        const QVariant &name, const QVariant &index)
+    {
+        propCreate = create.value<CustomViewExtensionView>();
+        propUpdate = update.value<ViewExtensionUpdateFunc>();
+        propName = name.toString();
+        propIndex = index.toInt();
+        propRegistered = true;
+    }
+
+    void onDetailRegister(const QVariant &create, const QVariant &update,
+                          const QVariant &shouldShow, const QVariant &index)
+    {
+        detailCreate = create.value<CustomViewExtensionView>();
+        detailUpdate = update.value<ViewExtensionUpdateFunc>();
+        detailShouldShow = shouldShow.value<ViewExtensionShouldShowFunc>();
+        detailIndex = index.toInt();
+        detailRegistered = true;
+    }
+
+    void onFieldFilter(const QVariant &scheme, const QVariant &fields)
+    {
+        filterScheme = scheme.toString();
+        filterFields = fields.toStringList();
+        filterRegistered = true;
+    }
+
+    void onSetFilter(const QVariant &winId, const QVariant &filters)
+    {
+        g.filterWinId = winId.toULongLong();
+        g.filterFlags = int(filters.value<QDir::Filters>());
+    }
+
+    void onOpenFiles(const QVariant &winId, const QVariant &urls)
+    {
+        g.openFilesWinId = winId.toULongLong();
+        g.openFilesUrls = urls.value<QList<QUrl>>();
+    }
+};
+
+ExtensionSink &sink()
+{
+    static ExtensionSink ins;
+    return ins;
+}
+
+std::once_flag g_wiringOnce;
+
+// Subscribe the full production event wiring exactly once for the process:
+// register the missing custom event types first (hook topics via
+// dfmtest_hooks, the custom signal/slot topics used by bindEvents and the
+// extension registration pushes), connect the capture consumers, then run
+// the real Tag::initialize() (bindEvents + followEvents + bindWindows) and
+// Tag::start() (plugin-started callbacks registration).
+Tag &tagPluginInstance()
+{
+    static Tag plugin;
+    static std::once_flag once;
+    std::call_once(once, [&plugin]() {
+        dfmtest_hooks::registerAllHookEvents();
+        dpf::Event *evt = dpf::Event::instance();
+        using S = dpf::EventStratege;
+        evt->registerEventType(S::kSignal, "dfmplugin_sidebar", "signal_Sidebar_Sorted");
+        evt->registerEventType(S::kSignal, "dfmplugin_menu", "signal_MenuScene_SceneAdded");
+        evt->registerEventType(S::kSlot, "dfmplugin_propertydialog", "slot_ViewExtensionWithUpdate_Register");
+        evt->registerEventType(S::kSlot, "dfmplugin_detailspace", "slot_ViewExtension_Register");
+        evt->registerEventType(S::kSlot, "dfmplugin_detailspace", "slot_BasicFiledFilter_Add");
+        evt->registerEventType(S::kSlot, "dfmplugin_workspace", "slot_View_SetFilter");
+
+        dpfSlotChannel->connect("dfmplugin_propertydialog", "slot_ViewExtensionWithUpdate_Register",
+                                &sink(), &ExtensionSink::onPropRegister);
+        dpfSlotChannel->connect("dfmplugin_detailspace", "slot_ViewExtension_Register",
+                                &sink(), &ExtensionSink::onDetailRegister);
+        dpfSlotChannel->connect("dfmplugin_detailspace", "slot_BasicFiledFilter_Add",
+                                &sink(), &ExtensionSink::onFieldFilter);
+        dpfSlotChannel->connect("dfmplugin_workspace", "slot_View_SetFilter",
+                                &sink(), &ExtensionSink::onSetFilter);
+        dpfSignalDispatcher->subscribe(GlobalEventType::kOpenFiles, &sink(), &ExtensionSink::onOpenFiles);
+
+        plugin.initialize();
+        plugin.start();
+    });
+    return plugin;
+}
+
+}   // namespace
+
+class TagRealEventsDispatchTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        resetCaptures();
+        sink().reset();
+
+        // daemon-dbus boundary: inert cache reload + no real daemon queries
+        stub.set_lamda(&TagProxyHandle::getAllFileWithTags, []() -> QVariantHash {
+            return {};
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTags, []() -> QVariantMap {
+            return {};
+        });
+        stub.set_lamda(&TagProxyHandle::getAllTrashFileTags, []() -> QVariantHash {
+            return {};
+        });
+
+        // perform the one-time real wiring
+        tagPluginInstance();
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+
+        // real SyncFileInfo for the file scheme: handlers stat real temp
+        // files, so pathOf()/extendAttributes(kInode) return real values
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        installHandlerStubs();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+    }
+
+    QUrl makeUrl(const QString &name) const
+    {
+        return QUrl::fromLocalFile(tempDir->path() + "/" + name);
+    }
+
+    QUrl createTestFile(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QFile file(path);
+        EXPECT_TRUE(file.open(QIODevice::WriteOnly));
+        file.write("dispatch");
+        file.close();
+        return QUrl::fromLocalFile(path);
+    }
+
+    void installHandlerStubs()
+    {
+        stub.set_lamda(&TagManager::getTagsByUrls, []() {
+            return g.tagsByUrlsResult;
+        });
+        auto canTagUrl = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+        stub.set_lamda(canTagUrl, []() -> bool {
+            return true;
+        });
+        auto canTagInfo = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+        stub.set_lamda(canTagInfo, []() -> bool {
+            return true;
+        });
+        stub.set_lamda(&TagManager::addTagsForFiles,
+                       [](TagManager *, const QList<QString> &tags, const QList<QUrl> &files) -> bool {
+                           g.addTagsCalled = true;
+                           g.addTagsNames = tags;
+                           g.addTagsFiles = files;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::removeTagsOfFiles,
+                       [](TagManager *, const QList<QString> &tags, const QList<QUrl> &files) -> bool {
+                           g.removeTagsCalled = true;
+                           g.removeTagsNames = tags;
+                           g.removeTagsFiles = files;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::setTagsForFiles,
+                       [](TagManager *, const QList<QString> &tags, const QList<QUrl> &files) -> bool {
+                           g.setTagsCalled = true;
+                           g.setTagsNames = tags;
+                           g.setTagsFiles = files;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::hideFiles,
+                       [](TagManager *, const QList<QString> &tags, const QList<QUrl> &files) {
+                           g.hideFilesCalled = true;
+                           g.hideFilesTags = tags;
+                           g.hideFilesFiles = files;
+                       });
+        stub.set_lamda(&TagManager::clearAllTrashTags, []() -> bool {
+            g.clearTrashCalled = true;
+            return true;
+        });
+        stub.set_lamda(&TagManager::saveTrashFileTags,
+                       [](TagManager *, const QString &path, qint64 inode, const QStringList &tags) -> bool {
+                           g.saveTrashCalled = true;
+                           g.saveTrashPath = path;
+                           g.saveTrashInode = inode;
+                           g.saveTrashTags = tags;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::getTrashFileTags,
+                       [](TagManager *, const QString &path, qint64 inode) -> QStringList {
+                           g.getTrashCalled = true;
+                           g.getTrashPath = path;
+                           g.getTrashInode = inode;
+                           return g.getTrashResult;
+                       });
+        stub.set_lamda(&TagManager::removeTrashFileTags,
+                       [](TagManager *, const QString &path, qint64 inode) -> bool {
+                           g.removeTrashCalled = true;
+                           g.removeTrashPath = path;
+                           g.removeTrashInode = inode;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::removeChildren,
+                       [](TagManager *, const QString &path) -> bool {
+                           g.removeChildrenCalled = true;
+                           g.removeChildrenPath = path;
+                           return true;
+                       });
+        stub.set_lamda(&TagManager::getTagIconName,
+                       [](TagManager *, const QString &) -> QString {
+                           return QString("icon-blue");
+                       });
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+};
+
+// ========== wiring + slot channel ==========
+
+TEST_F(TagRealEventsDispatchTest, RealWiring_SlotGetTagsPush_ReturnsTagsFromManager)
+{
+    g.tagsByUrlsResult = QStringList { "red", "green" };
+    QUrl url = makeUrl("gettags.txt");
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_tag", "slot_GetTags", url);
+
+    EXPECT_EQ(ret.toStringList(), QStringList({ "red", "green" }));
+    EXPECT_FALSE(ret.toStringList().isEmpty());
+}
+
+TEST_F(TagRealEventsDispatchTest, RealWiring_EmptyTagList_PushReturnsEmptyList)
+{
+    g.tagsByUrlsResult = QStringList {};
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_tag", "slot_GetTags", makeUrl("empty.txt"));
+
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toStringList().isEmpty());
+}
+
+// ========== pluginsStarted / menu scene wiring ==========
+
+TEST_F(TagRealEventsDispatchTest, PluginsStarted_MenuSceneSubscribeAndPublish_UnsubscribesAfterMatch)
+{
+    ASSERT_TRUE(QMetaObject::invokeMethod(dpfListener, "pluginsStarted", Qt::DirectConnection));
+
+    // bindScene("FileOperatorMenu") has now subscribed the scene-added signal
+    // through the real EventDispatcherManager; publishing the matching scene
+    // runs Tag::onMenuSceneAdded and unsubscribes (EventHandler::compare path).
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                             QString("FileOperatorMenu")));
+
+    // unrelated scene names must be ignored by the same dispatcher
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                             QString("SomeOtherScene")));
+}
+
+// ========== TagEventReceiver: GlobalEventType signals ==========
+
+TEST_F(TagRealEventsDispatchTest, HideFilesResultEvent_PublishSuccess_HideFilesReceivesTagsAndUrls)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QList<QUrl> urls { makeUrl("hide.txt") };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kHideFilesResult, quint64(1), urls, true));
+
+    ASSERT_TRUE(g.hideFilesCalled);
+    EXPECT_EQ(g.hideFilesTags, QStringList({ "red" }));
+    EXPECT_EQ(g.hideFilesFiles, urls);
+}
+
+TEST_F(TagRealEventsDispatchTest, HideFilesResultEvent_FailedOperation_NoHideFilesCall)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QList<QUrl> urls { makeUrl("hide_fail.txt") };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kHideFilesResult, quint64(1), urls, false));
+
+    EXPECT_FALSE(g.hideFilesCalled);
+}
+
+TEST_F(TagRealEventsDispatchTest, CutFileResultEvent_PublishSuccess_SourceUntaggedAndDestTagged)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QList<QUrl> srcs { createTestFile("cut_src.txt") };
+    QList<QUrl> dsts { makeUrl("cut_dst.txt") };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, srcs, dsts, true, QString()));
+
+    ASSERT_TRUE(g.removeTagsCalled);
+    EXPECT_EQ(g.removeTagsNames, QStringList({ "red" }));
+    EXPECT_EQ(g.removeTagsFiles, srcs);
+    ASSERT_TRUE(g.addTagsCalled);
+    EXPECT_EQ(g.addTagsNames, QStringList({ "red" }));
+    EXPECT_EQ(g.addTagsFiles, dsts);
+}
+
+TEST_F(TagRealEventsDispatchTest, CopyFileResultEvent_PublishSuccess_OnlyDestTagged)
+{
+    g.tagsByUrlsResult = QStringList { "blue" };
+    QList<QUrl> srcs { createTestFile("copy_src.txt") };
+    QList<QUrl> dsts { makeUrl("copy_dst.txt") };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCopyResult, srcs, dsts, true, QString()));
+
+    EXPECT_FALSE(g.removeTagsCalled);
+    ASSERT_TRUE(g.addTagsCalled);
+    EXPECT_EQ(g.addTagsNames, QStringList({ "blue" }));
+    EXPECT_EQ(g.addTagsFiles, dsts);
+}
+
+TEST_F(TagRealEventsDispatchTest, CutFileResultEvent_SizeMismatchOrFailure_NoTagChanges)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QList<QUrl> srcs { createTestFile("cut_bad.txt") };
+
+    // destination list empty -> early return
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, srcs, QList<QUrl>(), true, QString()));
+    // failed operation -> early return
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, srcs, srcs, false, QString("boom")));
+    // size mismatch -> early return
+    QList<QUrl> twoDsts { makeUrl("d1.txt"), makeUrl("d2.txt") };
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, srcs, twoDsts, true, QString()));
+
+    EXPECT_FALSE(g.removeTagsCalled);
+    EXPECT_FALSE(g.addTagsCalled);
+}
+
+TEST_F(TagRealEventsDispatchTest, DeleteFilesResultEvent_PublishSuccess_ChildrenRemovedAndFilesUntagged)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QUrl src = createTestFile("removed.txt");
+    QList<QUrl> srcs { src };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, srcs, true, QString()));
+
+    ASSERT_TRUE(g.removeChildrenCalled);
+    EXPECT_EQ(g.removeChildrenPath, src.toLocalFile());
+    ASSERT_TRUE(g.removeTagsCalled);
+    EXPECT_EQ(g.removeTagsFiles, srcs);
+    EXPECT_EQ(g.removeTagsNames, QStringList({ "red" }));
+}
+
+TEST_F(TagRealEventsDispatchTest, MoveToTrashResultEvent_PublishSuccess_TrashTagsSavedWithInode)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QUrl src = createTestFile("trashed.txt");
+    QList<QUrl> srcs { src };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, srcs, true, QString()));
+
+    ASSERT_TRUE(g.removeTagsCalled);
+    ASSERT_TRUE(g.saveTrashCalled);
+    EXPECT_EQ(g.saveTrashTags, QStringList({ "red" }));
+    EXPECT_EQ(g.saveTrashPath, src.toLocalFile());
+    EXPECT_GT(g.saveTrashInode, qint64(0));
+}
+
+TEST_F(TagRealEventsDispatchTest, CleanTrashResultEvent_PublishSuccess_AllTrashTagsCleared)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCleanTrashResult,
+                                             QList<QUrl> { makeUrl("cleaned.txt") }, true, QString()));
+
+    ASSERT_TRUE(g.clearTrashCalled);
+
+    g.clearTrashCalled = false;
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCleanTrashResult,
+                                             QList<QUrl> { makeUrl("cleaned.txt") }, false, QString()));
+    EXPECT_FALSE(g.clearTrashCalled);
+}
+
+TEST_F(TagRealEventsDispatchTest, RenameFileResultEvent_PublishSuccess_TagsMovedToNewUrls)
+{
+    g.tagsByUrlsResult = QStringList { "red" };
+    QUrl oldUrl = createTestFile("old_name.txt");
+    QUrl newUrl = makeUrl("new_name.txt");
+    QMap<QUrl, QUrl> renamed { { oldUrl, newUrl } };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(2), renamed, true, QString()));
+
+    ASSERT_TRUE(g.removeTagsCalled);
+    EXPECT_EQ(g.removeTagsFiles, QList<QUrl> { oldUrl });
+    ASSERT_TRUE(g.addTagsCalled);
+    EXPECT_EQ(g.addTagsFiles, QList<QUrl> { newUrl });
+}
+
+TEST_F(TagRealEventsDispatchTest, RestoreFromTrashResultEvent_ValidTrashInfo_TagsRestoredAndRecordRemoved)
+{
+    g.getTrashResult = QStringList { "blue" };
+    QList<QUrl> dsts { createTestFile("restored.txt") };
+    QVariantList customInfos { QVariant(QString("Path=%2Ftmp%2Fgone.txt")) };
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrashResult,
+                                             QList<QUrl>(), dsts, customInfos, true, QString()));
+
+    ASSERT_TRUE(g.getTrashCalled);
+    EXPECT_EQ(g.getTrashPath, QString("/tmp/gone.txt"));
+    EXPECT_GT(g.getTrashInode, qint64(0));
+    ASSERT_TRUE(g.addTagsCalled);
+    EXPECT_EQ(g.addTagsNames, QStringList({ "blue" }));
+    EXPECT_EQ(g.addTagsFiles, dsts);
+    ASSERT_TRUE(g.removeTrashCalled);
+    EXPECT_EQ(g.removeTrashPath, QString("/tmp/gone.txt"));
+    EXPECT_GT(g.removeTrashInode, qint64(0));
+}
+
+TEST_F(TagRealEventsDispatchTest, RestoreFromTrashResultEvent_MalformedInputs_NoDaemonInteraction)
+{
+    const QList<QUrl> oneDest { makeUrl("a.txt") };
+    const QList<QUrl> destB { makeUrl("b.txt") };
+    const QList<QUrl> destC { makeUrl("c.txt") };
+    const QList<QUrl> destD { makeUrl("d.txt") };
+    const QVariantList twoInfos { QVariant(QString("Path=%2Ftmp%2Fx")), QVariant(QString("Path=%2Ftmp%2Fy")) };
+    const QVariantList noPathInfo { QVariant(QString("NoPath=1")) };
+    const QVariantList pathC { QVariant(QString("Path=%2Ftmp%2Fc")) };
+    const QVariantList pathD { QVariant(QString("Path=%2Ftmp%2Fd")) };
+
+    // destination/custom info count mismatch
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrashResult,
+                                             QList<QUrl>(), oneDest, twoInfos, true, QString()));
+    // trash info without a Path= line
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrashResult,
+                                             QList<QUrl>(), destB, noPathInfo, true, QString()));
+    // empty trash tags -> nothing restored
+    g.getTrashResult = QStringList {};
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrashResult,
+                                             QList<QUrl>(), destC, pathC, true, QString()));
+    // failed operation
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRestoreFromTrashResult,
+                                             QList<QUrl>(), destD, pathD, false, QString()));
+
+    EXPECT_FALSE(g.getTrashCalled);
+    EXPECT_FALSE(g.addTagsCalled);
+    EXPECT_FALSE(g.removeTrashCalled);
+}
+
+TEST_F(TagRealEventsDispatchTest, ChangeCurrentUrlEvent_TagScheme_DeferredViewFilterPushed)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, quint64(3), QUrl("tag:/red")));
+
+    // the deferred slot_View_SetFilter push runs through the event loop
+    qApp->processEvents();
+    qApp->processEvents();
+
+    EXPECT_EQ(g.filterWinId, quint64(3));
+    EXPECT_EQ(g.filterFlags, int(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::System | QDir::Hidden));
+
+    // non-tag scheme must not push any filter
+    g.filterWinId = 0;
+    g.filterFlags = -1;
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, quint64(3), makeUrl("plain.txt")));
+    qApp->processEvents();
+    EXPECT_EQ(g.filterWinId, quint64(0));
+    EXPECT_EQ(g.filterFlags, -1);
+}
+
+TEST_F(TagRealEventsDispatchTest, SidebarSortedSignal_TagGroupAndForeignGroup_PublishSucceeds)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_sidebar", "signal_Sidebar_Sorted",
+                                             quint64(4), QString("Group_Tag"), QList<QUrl>()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_sidebar", "signal_Sidebar_Sorted",
+                                             quint64(4), QString("Group_Other"),
+                                             QList<QUrl> { QUrl("tag:/blue") }));
+}
+
+// ========== TagManager hooks (followEvents) ==========
+
+TEST_F(TagRealEventsDispatchTest, PaintListItemHook_TaggedFileInfo_RectShrinksByTagDiameter)
+{
+    stub.set_lamda(&FileTagCacheController::getTagsByFile,
+                   [](FileTagCacheController *, const QString &path) -> QStringList {
+                       g.paintIconPath = path;
+                       return QStringList { "red" };
+                   });
+    stub.set_lamda(&FileTagCacheController::getCacheTagsColor,
+                   [](FileTagCacheController *, const QStringList &) -> QMap<QString, QColor> {
+                       return QMap<QString, QColor> { { "red", QColor("#ff0000") } };
+                   });
+
+    QPixmap pixmap(200, 40);
+    QPainter painter(&pixmap);
+    QRectF rect(0, 0, 200, 40);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(createTestFile("paint.txt"));
+    ASSERT_NE(info, nullptr);
+
+    bool ok = dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_PaintListItem",
+                                   static_cast<int>(Global::ItemRoles::kItemFileDisplayNameRole),
+                                   info, &painter, &rect);
+
+    // the handler always returns false by contract; the paint still happened
+    EXPECT_FALSE(ok);
+    // (tagsColor.size() + 1) * kTagDiameter / 2 = 10 wide bubble + 10 margin
+    EXPECT_DOUBLE_EQ(rect.right(), 180.0);
+    EXPECT_TRUE(g.paintIconPath.endsWith(QString("paint.txt")));
+}
+
+TEST_F(TagRealEventsDispatchTest, PaintListItemHook_WrongRole_RectUntouched)
+{
+    stub.set_lamda(&FileTagCacheController::getTagsByFile,
+                   [](FileTagCacheController *, const QString &) -> QStringList {
+                       return QStringList { "red" };
+                   });
+    QPixmap pixmap(200, 40);
+    QPainter painter(&pixmap);
+    QRectF rect(0, 0, 200, 40);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(createTestFile("paint_role.txt"));
+    ASSERT_NE(info, nullptr);
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_PaintListItem",
+                                      static_cast<int>(Global::ItemRoles::kItemFileSizeRole),
+                                      info, &painter, &rect));
+    EXPECT_DOUBLE_EQ(rect.right(), 200.0);
+}
+
+TEST_F(TagRealEventsDispatchTest, LayoutTextHook_TaggedFileInfo_IconTagInsertedIntoDocument)
+{
+    stub.set_lamda(&FileTagCacheController::getTagsByFile,
+                   [](FileTagCacheController *, const QString &) -> QStringList {
+                       return QStringList { "red" };
+                   });
+    stub.set_lamda(&FileTagCacheController::getCacheTagsColor,
+                   [](FileTagCacheController *, const QStringList &) -> QMap<QString, QColor> {
+                       return QMap<QString, QColor> { { "red", QColor("#ff0000") } };
+                   });
+
+    dfmbase::ElideTextLayout layout("sample text");
+    FileInfoPointer info = InfoFactory::create<FileInfo>(createTestFile("icon.txt"));
+    ASSERT_NE(info, nullptr);
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_LayoutText",
+                                      info, &layout));
+    ASSERT_NE(layout.documentHandle(), nullptr);
+    EXPECT_TRUE(layout.documentHandle()->toPlainText().contains(QChar::ObjectReplacementCharacter));
+
+    // the canvas flavor of the same hook runs the identical handler
+    dfmbase::ElideTextLayout canvasLayout("canvas text");
+    EXPECT_FALSE(dpfHookSequence->run("ddplugin_canvas", "hook_CanvasItemDelegate_LayoutText",
+                                      info, &canvasLayout));
+    EXPECT_TRUE(canvasLayout.documentHandle()->toPlainText().contains(QChar::ObjectReplacementCharacter));
+}
+
+TEST_F(TagRealEventsDispatchTest, PasteFilesHook_TagDestWithCutAction_HookPasses)
+{
+    stub.set_lamda(&ClipBoard::clipboardAction, []() {
+        return ClipBoard::kCutAction;
+    });
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
+                                     quint64(5), QList<QUrl> { makeUrl("paste.txt") }, QUrl("tag:/blue")));
+}
+
+TEST_F(TagRealEventsDispatchTest, PasteFilesHook_NonTagDestOrEmptyClipboard_HookHandled)
+{
+    stub.set_lamda(&ClipBoard::clipboardAction, []() {
+        return ClipBoard::kCopyAction;
+    });
+    stub.set_lamda(&ClipBoard::clipboardFileUrlList, []() -> QList<QUrl> {
+        return {};
+    });
+
+    // copy action with an empty clipboard still succeeds on the tag scheme
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
+                                     quint64(5), QList<QUrl> { makeUrl("paste2.txt") }, QUrl("tag:/blue")));
+    // non-tag destination is not handled by the tag plugin
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
+                                      quint64(5), QList<QUrl> { makeUrl("paste3.txt") }, makeUrl("dest_dir")));
+}
+
+TEST_F(TagRealEventsDispatchTest, FileDropHook_TagDest_SetTagsForFilesWithTagName)
+{
+    QList<QUrl> srcs { makeUrl("drop.txt") };
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                     srcs, QUrl("tag:/blue")));
+
+    ASSERT_TRUE(g.setTagsCalled);
+    EXPECT_EQ(g.setTagsNames, QStringList({ "blue" }));
+    EXPECT_EQ(g.setTagsFiles, srcs);
+
+    // non-tag destination is refused
+    g.setTagsCalled = false;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                      srcs, makeUrl("plain_dest")));
+    EXPECT_FALSE(g.setTagsCalled);
+}
+
+TEST_F(TagRealEventsDispatchTest, DropDataHook_TagDest_ActionForcedToIgnore)
+{
+    Qt::DropAction action = Qt::CopyAction;
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_sidebar", "hook_Item_DropData",
+                                     QList<QUrl> { makeUrl("dropdata.txt") }, QUrl("tag:/blue"), &action));
+    EXPECT_EQ(action, Qt::IgnoreAction);
+
+    Qt::DropAction foreign = Qt::CopyAction;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_sidebar", "hook_Item_DropData",
+                                      QList<QUrl> { makeUrl("dropdata2.txt") }, makeUrl("anywhere"), &foreign));
+    EXPECT_EQ(foreign, Qt::CopyAction);
+}
+
+TEST_F(TagRealEventsDispatchTest, CrumbSeprateHook_TagUrl_CrumbDataAppended)
+{
+    QList<QVariantMap> crumbs;
+    QUrl tagUrl("tag:/blue");
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate", tagUrl, &crumbs));
+
+    ASSERT_EQ(crumbs.size(), 1);
+    EXPECT_EQ(crumbs.first().value("CrumbData_Key_Url").toUrl(), tagUrl);
+    EXPECT_EQ(crumbs.first().value("CrumbData_Key_IconName").toString(), QString("icon-blue"));
+
+    QList<QVariantMap> foreignCrumbs;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate",
+                                      makeUrl("plain.txt"), &foreignCrumbs));
+    EXPECT_TRUE(foreignCrumbs.isEmpty());
+}
+
+TEST_F(TagRealEventsDispatchTest, OpenFileInPluginHook_TagUrlWithFragment_RedirectedAndRePublished)
+{
+    QUrl tagUrl("tag:/blue");
+    tagUrl.setFragment("/tmp/redirected.txt");
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                     quint64(6), QList<QUrl> { tagUrl }));
+
+    // the redirect re-publishes kOpenFiles with the fragment-decoded local file
+    ASSERT_EQ(g.openFilesUrls.size(), 1);
+    EXPECT_EQ(g.openFilesUrls.first(), QUrl::fromLocalFile("/tmp/redirected.txt"));
+    EXPECT_EQ(g.openFilesWinId, quint64(6));
+
+    // empty list and non-tag scheme are refused
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                      quint64(6), QList<QUrl> {}));
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                      quint64(6), QList<QUrl> { makeUrl("plain_open.txt") }));
+}
+
+// ========== pluginStarted extension registration ==========
+
+TEST_F(TagRealEventsDispatchTest, PluginStartedSignal_PropertyDialog_ExtensionCallbacksRegisteredAndUsable)
+{
+    ASSERT_TRUE(QMetaObject::invokeMethod(dpfListener, "pluginStarted",
+                                          Q_ARG(QString, "org.deepin.plugin.common"),
+                                          Q_ARG(QString, "dfmplugin-propertydialog")));
+
+    ASSERT_TRUE(sink().propRegistered);
+    EXPECT_EQ(sink().propName, QString("Tag"));
+    EXPECT_EQ(sink().propIndex, 0);
+    ASSERT_TRUE(bool(sink().propCreate));
+    ASSERT_TRUE(bool(sink().propUpdate));
+
+    // the create callback builds a real TagWidget for a taggable file url
+    QWidget *widget = sink().propCreate(makeUrl("prop.txt"));
+    ASSERT_NE(widget, nullptr);
+    EXPECT_NE(qobject_cast<TagWidget *>(widget), nullptr);
+
+    // the update callback retargets the widget without crashing
+    EXPECT_NO_FATAL_FAILURE(sink().propUpdate(widget, makeUrl("prop_retarget.txt")));
+    delete widget;
+
+    // non-taggable urls are rejected by the create callback
+    auto canTagUrl = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(canTagUrl, []() -> bool {
+        return false;
+    });
+    EXPECT_EQ(sink().propCreate(makeUrl("nope.txt")), nullptr);
+}
+
+TEST_F(TagRealEventsDispatchTest, PluginStartedSignal_Detailspace_ExtensionAndFieldFilterRegistered){
+    ASSERT_TRUE(QMetaObject::invokeMethod(dpfListener, "pluginStarted",
+                                          Q_ARG(QString, "org.deepin.plugin.common"),
+                                          Q_ARG(QString, "dfmplugin-detailspace")));
+
+    ASSERT_TRUE(sink().detailRegistered);
+    EXPECT_EQ(sink().detailIndex, -1);
+    ASSERT_TRUE(bool(sink().detailCreate));
+    ASSERT_TRUE(bool(sink().detailUpdate));
+    ASSERT_TRUE(bool(sink().detailShouldShow));
+
+    ASSERT_TRUE(sink().filterRegistered);
+    EXPECT_EQ(sink().filterScheme, QString("tag"));
+    EXPECT_EQ(sink().filterFields,
+              QStringList({ "kFileSizeField", "kFileChangeTimeField", "kFileInterviewTimeField" }));
+
+    // create/update callbacks operate on a real TagWidget
+    QWidget *widget = sink().detailCreate(QUrl("tag:/x"));
+    ASSERT_NE(widget, nullptr);
+    EXPECT_NE(qobject_cast<TagWidget *>(widget), nullptr);
+    EXPECT_NO_FATAL_FAILURE(sink().detailUpdate(widget, makeUrl("detail.txt")));
+
+    // shouldShow mirrors TagManager::canTagFile exactly
+    EXPECT_TRUE(sink().detailShouldShow(makeUrl("show.txt")));
+    auto canTagUrl = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(canTagUrl, []() -> bool {
+        return false;
+    });
+    EXPECT_FALSE(sink().detailShouldShow(makeUrl("hide.txt")));
+
+    // update on a non-TagWidget must be a harmless no-op
+    QWidget plain;
+    EXPECT_NO_FATAL_FAILURE(sink().detailUpdate(&plain, makeUrl("plain_widget.txt")));
+    delete widget;
+}
+
+TEST_F(TagRealEventsDispatchTest, BindWindows_RegisteredWindowId_OnWindowOpenedPerId)
+{
+    bool lookupHappened = false;
+    FileManagerWindow window(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&lookupHappened, &window](FileManagerWindowsManager *, quint64) -> FileManagerWindow * {
+                       lookupHappened = true;
+                       return &window;
+                   });
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   []() -> QList<quint64> { return QList<quint64> { quint64(1) }; });
+    stub.set_lamda(&Tag::installToSideBar, []() {});
+
+    // private member: callable because the test target compiles with
+    // -fno-access-control; exercises the std::for_each lambda body
+    tagPluginInstance().bindWindows();
+
+    EXPECT_TRUE(lookupHappened);
+    // a second run over an empty window list must stay harmless
+    stub.clear();
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList,
+                   []() -> QList<quint64> { return QList<quint64> {}; });
+    EXPECT_NO_FATAL_FAILURE(tagPluginInstance().bindWindows());
+}

--- a/autotests/plugins/dfmplugin-utils/test_realevents_dispatch.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_realevents_dispatch.cpp
@@ -1,0 +1,933 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real event-dispatch tests for dfmplugin-utils: wire the production
+// subscriptions (initEventConnect / bindEvents / initializeConnections /
+// plugin initialize+start) after registering every slot/hook/signal topic,
+// then publish / push / run the real events with exactly-typed QVariant
+// arguments so every EventHelper<M>::invoke, EventHelper<M>::EventHelper and
+// memberFunctionVoidCast<M> template instantiation owned by dfmplugin_utils
+// in include/dfm-framework/event/eventhelper.h actually executes. Heavy
+// dependencies (QProcess, pkexec dialog, bluetooth manager, report-log
+// manager, append-compress helper, extension plugin loader) are stubbed and
+// their arguments captured for exact-value assertions.
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QWidget>
+#include <QMimeData>
+#include <QPoint>
+#include <QUrl>
+#include <QIcon>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QProcess>
+#include <QAccessible>
+
+#include "stubext.h"
+
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaulthelperreceiver.h"
+#include "plugins/common/dfmplugin-utils/vaultassist/vaultassitcontrol.h"
+#include "plugins/common/dfmplugin-utils/testing/events/testingeventrecevier.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h"
+#include "plugins/common/dfmplugin-utils/reportlog/reportlogmanager.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresseventreceiver.h"
+#include "plugins/common/dfmplugin-utils/appendcompress/appendcompresshelper.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/virtualbluetoothplugin.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h"
+#include "plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.h"
+#include "plugins/common/dfmplugin-utils/shred/vitrualshredplugin.h"
+#include "plugins/common/dfmplugin-utils/shred/shredutils.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/virtualextensionimplplugin.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.h"
+#include "plugins/common/dfmplugin-utils/extensionimpl/pluginsload/extensionpluginmanager.h"
+
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+Q_DECLARE_METATYPE(QList<QIcon> *)
+Q_DECLARE_METATYPE(Qt::DropAction *)
+Q_DECLARE_METATYPE(const QMimeData *)
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_utils;
+
+namespace {
+
+// register every topic the production code subscribes to; registration is
+// idempotent (repeat calls only warn) and guarded by a process-wide once flag.
+std::once_flag g_topicOnce;
+void ensureTopicsRegistered()
+{
+    std::call_once(g_topicOnce, [] {
+        auto reg = [](EventStratege stratege, const char *space, const char *topic) {
+            dpf::Event::instance()->registerEventType(stratege, space, topic);
+        };
+        // signal topics
+        reg(EventStratege::kSignal, "dfmplugin_menu", "signal_MenuScene_SceneAdded");
+        reg(EventStratege::kSignal, "dfmplugin_workspace", "signal_ReportLog_Commit");
+        reg(EventStratege::kSignal, "dfmplugin_workspace", "signal_ReportLog_MenuData");
+        reg(EventStratege::kSignal, "ddplugin_background", "signal_ReportLog_BackgroundPaint");
+        // hook topics
+        reg(EventStratege::kHook, "dfmplugin_fileoperations", "hook_Operation_MoveToTrash");
+        reg(EventStratege::kHook, "dfmplugin_emblem", "hook_ExtendEmblems_Fetch");
+        reg(EventStratege::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDragMove");
+        reg(EventStratege::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDrop");
+        reg(EventStratege::kHook, "dfmplugin_workspace", "hook_DragDrop_IsDrop");
+        reg(EventStratege::kHook, "ddplugin_canvas", "hook_CanvasView_DragMove");
+        reg(EventStratege::kHook, "ddplugin_canvas", "hook_CanvasView_DropData");
+        reg(EventStratege::kHook, "ddplugin_organizer", "hook_CollectionView_DragMove");
+        reg(EventStratege::kHook, "ddplugin_organizer", "hook_CollectionView_DropData");
+        // slot topics
+        reg(EventStratege::kSlot, "dfmplugin_utils", "slot_OpenWith_ShowDialog");
+        reg(EventStratege::kSlot, "dfmplugin_utils", "slot_Bluetooth_IsAvailable");
+        reg(EventStratege::kSlot, "dfmplugin_utils", "slot_Bluetooth_SendFiles");
+        reg(EventStratege::kSlot, "dfmplugin_utils", "slot_Accessible_SetAccessibleName");
+        reg(EventStratege::kSlot, "dfmplugin_utils", "slot_Accessible_SetObjectName");
+        // menu protocol slots used by the scene-bind plugins (inline helpers
+        // cannot be stubbed, so they are observed through a real receiver)
+        reg(EventStratege::kSlot, "dfmplugin_menu", "slot_MenuScene_Contains");
+        reg(EventStratege::kSlot, "dfmplugin_menu", "slot_MenuScene_Bind");
+        reg(EventStratege::kSlot, "dfmplugin_menu", "slot_MenuScene_RegisterScene");
+    });
+}
+
+// Real receiver for the dfmplugin_menu scene protocol. The inline helpers in
+// menu_eventinterface_helper.h push these slots; returning false from
+// onSceneContains makes the plugins take the "scene not present yet" branch
+// (subscribe + wait), and onSceneBind records what actually got bound.
+class MenuSceneSpy : public QObject
+{
+    Q_OBJECT
+public:
+    int containsCalls = 0;
+    int bindCalls = 0;
+    QString boundName, boundParent;
+
+    bool containsResult = false;
+
+public slots:
+    bool onSceneContains(const QString &name)
+    {
+        Q_UNUSED(name)
+        containsCalls++;
+        return containsResult;
+    }
+    bool onSceneBind(const QString &name, const QString &parent)
+    {
+        bindCalls++;
+        boundName = name;
+        boundParent = parent;
+        return true;
+    }
+};
+
+// ---------- captured arguments / call flags (reset in SetUp) ----------
+bool g_detachCalled = false;
+bool g_isVaultCalled = false;
+bool g_transCalled = false;
+bool g_mouseStyleCalled = false;
+bool g_compressCalled = false;
+bool g_compressIsDrop = false;
+bool g_commitCalled = false;
+bool g_menuDataCalled = false;
+bool g_startupCalled = false;
+bool g_msgDialogShown = false;
+int g_execCount = 0;
+int g_msgDialogCount = 0;
+
+QString g_detachProgram;
+QStringList g_detachArgs;
+QList<QUrl> g_transInput;
+QList<QUrl> g_mouseFromUrls;
+QUrl g_mouseToUrl;
+QList<QUrl> g_compressFromUrls;
+QUrl g_compressToUrl;
+QString g_commitType;
+QVariantMap g_commitArgs;
+QString g_menuDataName;
+QList<QUrl> g_menuDataUrls;
+QString g_startupKey;
+QVariant g_startupData;
+QString g_msgDialogTitle;
+
+void resetCaptures()
+{
+    g_detachCalled = g_isVaultCalled = g_transCalled = false;
+    g_mouseStyleCalled = g_compressCalled = g_compressIsDrop = false;
+    g_commitCalled = g_menuDataCalled = g_startupCalled = false;
+    g_msgDialogShown = false;
+    g_execCount = 0;
+    g_msgDialogCount = 0;
+
+    g_detachProgram = QString();
+    g_detachArgs.clear();
+    g_transInput.clear();
+    g_mouseFromUrls.clear();
+    g_mouseToUrl = QUrl();
+    g_compressFromUrls.clear();
+    g_compressToUrl = QUrl();
+    g_commitType = QString();
+    g_commitArgs.clear();
+    g_menuDataName = QString();
+    g_menuDataUrls.clear();
+    g_startupKey = QString();
+    g_startupData = QVariant();
+    g_msgDialogTitle = QString();
+}
+
+}   // namespace
+
+class UtilsEventDispatchTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        resetCaptures();
+        ensureTopicsRegistered();
+
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        tempDir = std::make_unique<QTemporaryDir>();
+        ASSERT_TRUE(tempDir->isValid());
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempDir.reset();
+        // detach every slot channel this fixture connected so later test
+        // files never push into a destroyed stack receiver
+        for (const char *topic : { "slot_MenuScene_Contains", "slot_MenuScene_Bind",
+                                   "slot_MenuScene_RegisterScene", "slot_OpenWith_ShowDialog",
+                                   "slot_Bluetooth_IsAvailable", "slot_Bluetooth_SendFiles",
+                                   "slot_Accessible_SetAccessibleName", "slot_Accessible_SetObjectName" }) {
+            dpfSlotChannel->disconnect("dfmplugin_menu", topic);
+            dpfSlotChannel->disconnect("dfmplugin_utils", topic);
+        }
+    }
+
+    QUrl createTestFile(const QString &name)
+    {
+        QString path = tempDir->path() + "/" + name;
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.write("dispatch");
+        f.close();
+        return QUrl::fromLocalFile(path);
+    }
+
+    void installShredStartupStubs()
+    {
+        stub.set_lamda(ADDR(ShredUtils, initDconfig), [](ShredUtils *) {});
+        stub.set_lamda(ADDR(SettingJsonGenerator, addGroup),
+                       [](SettingJsonGenerator *, const QString &, const QString &) { return true; });
+        stub.set_lamda(ADDR(SettingJsonGenerator, addConfig),
+                       [](SettingJsonGenerator *, const QString &, const QVariantMap &) { return true; });
+        stub.set_lamda(ADDR(DialogManager, registerSettingWidget),
+                       [](DialogManager *, const QString &, std::function<QWidget *(QObject *)>) {});
+        stub.set_lamda(&LifeCycle::isAllPluginsStarted, []() -> bool { return true; });
+    }
+
+    // wire the menu protocol to a fresh spy: scenes always "not present" so
+    // plugins subscribe and wait; binds get recorded for assertions
+    MenuSceneSpy &connectMenuSpy(MenuSceneSpy &spy, bool containsResult = false)
+    {
+        spy.containsResult = containsResult;
+        dpfSlotChannel->connect("dfmplugin_menu", "slot_MenuScene_Contains", &spy, &MenuSceneSpy::onSceneContains);
+        dpfSlotChannel->connect("dfmplugin_menu", "slot_MenuScene_Bind", &spy, &MenuSceneSpy::onSceneBind);
+        return spy;
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+};
+
+// ========== GlobalEventReceiver: kOpenAsAdmin signal ==========
+
+TEST_F(UtilsEventDispatchTest, OpenAsAdminEvent_PublishLocalFile_PkexecLaunchedWithExactPath)
+{
+    stub.set_lamda(static_cast<bool (*)(const QString &, const QStringList &, const QString &, qint64 *)>(&QProcess::startDetached),
+                   [](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                       g_detachCalled = true;
+                       g_detachProgram = program;
+                       g_detachArgs = args;
+                       return true;
+                   });
+
+    QUrl target = createTestFile("admin_target.txt");
+
+    GlobalEventReceiver receiver;
+    receiver.initEventConnect();
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenAsAdmin, target);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_detachCalled);
+    EXPECT_EQ(g_detachProgram, QString("dde-file-manager-pkexec"));
+    EXPECT_EQ(g_detachArgs, QStringList { target.toLocalFile() });
+}
+
+TEST_F(UtilsEventDispatchTest, OpenAsAdminEvent_PublishEmptyUrl_NoProcessLaunched)
+{
+    stub.set_lamda(static_cast<bool (*)(const QString &, const QStringList &, const QString &, qint64 *)>(&QProcess::startDetached),
+                   [](const QString &, const QStringList &, const QString &, qint64 *) -> bool {
+                       g_detachCalled = true;
+                       return true;
+                   });
+
+    GlobalEventReceiver receiver;
+    receiver.initEventConnect();
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kOpenAsAdmin, QUrl());
+
+    EXPECT_TRUE(published);
+    EXPECT_FALSE(g_detachCalled);
+}
+
+// ========== VaultHelperReceiver: hook_Operation_MoveToTrash ==========
+
+TEST_F(UtilsEventDispatchTest, MoveToTrashHook_RunVaultSources_ReturnsTrueAndTranslatesUrls)
+{
+    QList<QUrl> sources { QUrl::fromLocalFile("/vault/fileA") };
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [&sources](VaultAssitControl *, const QUrl &url) -> bool {
+                       g_isVaultCalled = true;
+                       return url == sources.first();
+                   });
+    stub.set_lamda(ADDR(VaultAssitControl, transUrlsToLocal),
+                   [&sources](VaultAssitControl *, const QList<QUrl> &urls) -> QList<QUrl> {
+                       g_transCalled = true;
+                       g_transInput = urls;
+                       return QList<QUrl> { QUrl::fromLocalFile("/root/.vault/fileA") };
+                   });
+
+    VaultHelperReceiver receiver;
+    receiver.initEventConnect();
+
+    bool handled = dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                        quint64(42), sources,
+                                        AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_isVaultCalled);
+    ASSERT_TRUE(g_transCalled);
+    EXPECT_EQ(g_transInput, sources);
+}
+
+TEST_F(UtilsEventDispatchTest, MoveToTrashHook_RunForeignSources_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool {
+                       g_isVaultCalled = true;
+                       return false;
+                   });
+
+    VaultHelperReceiver receiver;
+    receiver.initEventConnect();
+
+    QList<QUrl> sources { QUrl::fromLocalFile("/home/uos/plain.txt") };
+    bool handled = dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                        quint64(1), sources,
+                                        AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(handled);
+    ASSERT_TRUE(g_isVaultCalled);
+    EXPECT_FALSE(g_transCalled);
+}
+
+TEST_F(UtilsEventDispatchTest, MoveToTrashHook_RunEmptySources_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(VaultAssitControl, isVaultFile),
+                   [](VaultAssitControl *, const QUrl &) -> bool { return true; });
+
+    VaultHelperReceiver receiver;
+    receiver.initEventConnect();
+
+    bool handled = dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                        quint64(1), QList<QUrl> {},
+                                        AbstractJobHandler::JobFlag::kNoHint);
+
+    EXPECT_FALSE(handled);
+    EXPECT_FALSE(g_isVaultCalled);
+}
+
+// ========== TestingEventRecevier: accessible slots ==========
+
+TEST_F(UtilsEventDispatchTest, AccessibleSlot_PushWidgetAndName_AccessibleNameSetExact)
+{
+    // keep the global QAccessible factory untouched, only the slot wiring is real
+    stub.set_lamda(&QAccessible::installFactory, [](QAccessible::InterfaceFactory) {});
+    stub.set_lamda(&QAccessible::setActive, [](bool) {});
+
+    TestingEventRecevier::instance()->initializeConnections();
+
+    QWidget widget;
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                                        &widget, QString("btn-open-42"));
+
+    EXPECT_TRUE(ret.isNull());
+    EXPECT_EQ(widget.accessibleName(), QString("btn-open-42"));
+    EXPECT_NE(widget.accessibleName(), QString());
+}
+
+TEST_F(UtilsEventDispatchTest, AccessibleSlot_PushObjectName_HandlerIsNoOp)
+{
+    stub.set_lamda(&QAccessible::installFactory, [](QAccessible::InterfaceFactory) {});
+    stub.set_lamda(&QAccessible::setActive, [](bool) {});
+
+    TestingEventRecevier::instance()->initializeConnections();
+
+    QWidget widget;
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetObjectName",
+                                        &widget, QString("obj-name"));
+
+    EXPECT_TRUE(ret.isNull());
+    EXPECT_TRUE(widget.objectName().isEmpty());
+}
+
+// ========== OpenWithEventReceiver: slot_OpenWith_ShowDialog ==========
+
+TEST_F(UtilsEventDispatchTest, OpenWithSlot_PushZeroWinId_DialogExecuted)
+{
+    stub.set_lamda(VADDR(OpenWithDialog, exec), []() -> int {
+        g_execCount++;
+        return 0;
+    });
+
+    OpenWithEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QList<QUrl> urls { QUrl::fromLocalFile("/tmp/openwith_target.txt") };
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog",
+                                        quint64(0), urls);
+
+    EXPECT_TRUE(ret.isNull());
+    EXPECT_EQ(g_execCount, 1);
+}
+
+TEST_F(UtilsEventDispatchTest, OpenWithSlot_PushUnknownWinId_DialogExecutedWithFallbackParent)
+{
+    stub.set_lamda(VADDR(OpenWithDialog, exec), []() -> int {
+        g_execCount++;
+        return 0;
+    });
+
+    OpenWithEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QList<QUrl> urls { QUrl::fromLocalFile("/tmp/openwith_fallback.txt") };
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog",
+                                        quint64(987654321), urls);
+
+    EXPECT_TRUE(ret.isNull());
+    EXPECT_EQ(g_execCount, 1);
+}
+
+// ========== VirtualBluetoothPlugin: bluetooth slots ==========
+
+TEST_F(UtilsEventDispatchTest, BluetoothAvailableSlot_PushWithAdapter_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(SysInfoUtils, isOpenAsAdmin), []() -> bool { return false; });
+    stub.set_lamda(ADDR(BluetoothManager, bluetoothSendEnable),
+                   [](BluetoothManager *) -> bool { return true; });
+    stub.set_lamda(ADDR(BluetoothManager, hasAdapter),
+                   [](BluetoothManager *) -> bool { return true; });
+
+    VirtualBluetoothPlugin plugin;
+    plugin.initialize();
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Bluetooth_IsAvailable");
+
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toBool());
+    EXPECT_EQ(ret.typeId(), QMetaType::Type::Bool);
+}
+
+TEST_F(UtilsEventDispatchTest, BluetoothAvailableSlot_PushWithoutAdapter_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(SysInfoUtils, isOpenAsAdmin), []() -> bool { return false; });
+    stub.set_lamda(ADDR(BluetoothManager, bluetoothSendEnable),
+                   [](BluetoothManager *) -> bool { return false; });
+    stub.set_lamda(ADDR(BluetoothManager, hasAdapter),
+                   [](BluetoothManager *) -> bool { return true; });
+
+    VirtualBluetoothPlugin plugin;
+    plugin.initialize();
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Bluetooth_IsAvailable");
+
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_FALSE(ret.toBool());
+}
+
+TEST_F(UtilsEventDispatchTest, BluetoothSendSlot_PushEmptyPaths_ReturnsWithoutDialog)
+{
+    stub.set_lamda(ADDR(SysInfoUtils, isOpenAsAdmin), []() -> bool { return false; });
+    stub.set_lamda(ADDR(BluetoothTransDialog, isBluetoothIdle), []() -> bool { return true; });
+    stub.set_lamda(static_cast<int (DialogManager::*)(const QString &, const QString &, QString)>(&DialogManager::showMessageDialog),
+                   [](DialogManager *, const QString &, const QString &, const QString &) -> int {
+                       g_msgDialogShown = true;
+                       return 0;
+                   });
+
+    VirtualBluetoothPlugin plugin;
+    plugin.initialize();
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Bluetooth_SendFiles",
+                                        QStringList {}, QString("device-1"));
+
+    EXPECT_TRUE(ret.isNull());
+    EXPECT_FALSE(g_msgDialogShown);
+}
+
+TEST_F(UtilsEventDispatchTest, BluetoothSendSlot_PushWhileBusy_ShowsWarningDialog)
+{
+    stub.set_lamda(ADDR(SysInfoUtils, isOpenAsAdmin), []() -> bool { return false; });
+    stub.set_lamda(ADDR(BluetoothTransDialog, isBluetoothIdle), []() -> bool { return false; });
+    stub.set_lamda(static_cast<int (DialogManager::*)(const QString &, const QString &, QString)>(&DialogManager::showMessageDialog),
+                   [](DialogManager *, const QString &title, const QString &, const QString &) -> int {
+                       g_msgDialogShown = true;
+                       g_msgDialogCount++;
+                       g_msgDialogTitle = title;
+                       return 0;
+                   });
+
+    VirtualBluetoothPlugin plugin;
+    plugin.initialize();
+
+    QVariant ret = dpfSlotChannel->push("dfmplugin_utils", "slot_Bluetooth_SendFiles",
+                                        QStringList { "/tmp/send_me.txt" }, QString("device-2"));
+
+    EXPECT_TRUE(ret.isNull());
+    ASSERT_TRUE(g_msgDialogShown);
+    EXPECT_EQ(g_msgDialogCount, 1);
+    EXPECT_FALSE(g_msgDialogTitle.isEmpty());
+}
+
+// ========== ReportLogEventReceiver: report-log signals ==========
+
+TEST_F(UtilsEventDispatchTest, ReportLogCommit_PublishWorkspaceSignal_CommitForwardedWithExactArgs)
+{
+    stub.set_lamda(ADDR(ReportLogManager, commit),
+                   [](ReportLogManager *, const QString &type, const QVariantMap &args) {
+                       g_commitCalled = true;
+                       g_commitType = type;
+                       g_commitArgs = args;
+                   });
+
+    ReportLogEventReceiver receiver;
+    receiver.bindEvents();
+
+    QVariantMap args;
+    args.insert("op", QVariant("open"));
+    args.insert("count", QVariant(3));
+    bool published = dpfSignalDispatcher->publish("dfmplugin_workspace", "signal_ReportLog_Commit",
+                                                  QString("FileOpen"), args);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_commitCalled);
+    EXPECT_EQ(g_commitType, QString("FileOpen"));
+    EXPECT_EQ(g_commitArgs.value("op").toString(), QString("open"));
+    EXPECT_EQ(g_commitArgs.value("count").toInt(), 3);
+}
+
+TEST_F(UtilsEventDispatchTest, ReportLogMenuData_PublishWorkspaceSignal_MenuDataForwarded)
+{
+    stub.set_lamda(ADDR(ReportLogManager, reportMenuData),
+                   [](ReportLogManager *, const QString &name, const QList<QUrl> &urlList) {
+                       g_menuDataCalled = true;
+                       g_menuDataName = name;
+                       g_menuDataUrls = urlList;
+                   });
+
+    ReportLogEventReceiver receiver;
+    receiver.bindEvents();
+
+    QList<QUrl> urls { createTestFile("menu_report.txt") };
+    bool published = dpfSignalDispatcher->publish("dfmplugin_workspace", "signal_ReportLog_MenuData",
+                                                  QString("empty-menu"), urls);
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_menuDataCalled);
+    EXPECT_EQ(g_menuDataName, QString("empty-menu"));
+    EXPECT_EQ(g_menuDataUrls, urls);
+    EXPECT_EQ(g_menuDataUrls.size(), 1);
+}
+
+TEST_F(UtilsEventDispatchTest, ReportLogStartup_PublishBackgroundSignal_StartupForwarded)
+{
+    stub.set_lamda(ADDR(ReportLogManager, reportDesktopStartUp),
+                   [](ReportLogManager *, const QString &key, const QVariant &data) {
+                       g_startupCalled = true;
+                       g_startupKey = key;
+                       g_startupData = data;
+                   });
+
+    ReportLogEventReceiver receiver;
+    receiver.bindEvents();
+
+    bool published = dpfSignalDispatcher->publish("ddplugin_background", "signal_ReportLog_BackgroundPaint",
+                                                  QString("loadfinish"), QVariant(1500));
+
+    EXPECT_TRUE(published);
+    ASSERT_TRUE(g_startupCalled);
+    EXPECT_EQ(g_startupKey, QString("loadfinish"));
+    EXPECT_EQ(g_startupData.toInt(), 1500);
+}
+
+// ========== VirtualShredPlugin: signal_MenuScene_SceneAdded ==========
+
+TEST_F(UtilsEventDispatchTest, ShredSceneAdded_PublishBoundScene_BindsMenuAndUnsubscribes)
+{
+    installShredStartupStubs();
+
+    MenuSceneSpy spy;
+    connectMenuSpy(spy);
+
+    VirtualShredPlugin plugin;
+    ASSERT_TRUE(plugin.start());
+    EXPECT_GE(spy.containsCalls, 1);   // bindScene consulted the scene registry
+
+    bool published = dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                                  QString("FileOperatorMenu"));
+
+    EXPECT_TRUE(published);
+    ASSERT_EQ(spy.bindCalls, 1);
+    EXPECT_EQ(spy.boundName, QString("ShredMenu"));
+    EXPECT_EQ(spy.boundParent, QString("FileOperatorMenu"));
+}
+
+TEST_F(UtilsEventDispatchTest, ShredSceneAdded_PublishForeignScene_NothingBoundThenCleansUp)
+{
+    installShredStartupStubs();
+
+    MenuSceneSpy spy;
+    connectMenuSpy(spy);
+
+    VirtualShredPlugin plugin;
+    ASSERT_TRUE(plugin.start());
+
+    bool foreign = dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                                QString("TotallyUnknownScene"));
+    EXPECT_TRUE(foreign);
+    EXPECT_EQ(spy.bindCalls, 0);   // unknown scene must not trigger a bind
+
+    // publish the awaited scene so the plugin unsubscribes and leaves no
+    // dangling handler behind after this stack object dies
+    bool cleanup = dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                                QString("FileOperatorMenu"));
+    EXPECT_TRUE(cleanup);
+    ASSERT_EQ(spy.bindCalls, 1);
+    EXPECT_EQ(spy.boundParent, QString("FileOperatorMenu"));
+}
+
+// ========== VirtualExtensionImplPlugin + ExtensionEmblemManager ==========
+
+TEST_F(UtilsEventDispatchTest, ExtensionSceneAdded_PublishWaitedScene_BindsExtensionMenu)
+{
+    installShredStartupStubs();   // shares lifecycle/setting stubs
+
+    // never load real dfmext plugins from the host system
+    stub.set_lamda(ADDR(ExtensionPluginManager, onLoadingPlugins), [](ExtensionPluginManager *) {});
+
+    MenuSceneSpy spy;
+    // first Contains (from start) says "not present"; the second Contains
+    // (re-bind inside bindSceneOnAdded) says "present" so the plugin stops
+    // resubscribing and leaves no dangling handler behind
+    connectMenuSpy(spy);
+
+    VirtualExtensionImplPlugin plugin;
+    plugin.initialize();
+    ASSERT_TRUE(plugin.start());
+
+    int containsBefore = spy.containsCalls;
+    spy.containsResult = true;   // next Contains flips to "scene present"
+
+    bool published = dpfSignalDispatcher->publish("dfmplugin_menu", "signal_MenuScene_SceneAdded",
+                                                  QString("ExtendMenu"));
+
+    EXPECT_TRUE(published);
+    EXPECT_GT(spy.containsCalls, containsBefore);   // re-bind consulted the registry again
+    ASSERT_EQ(spy.bindCalls, 1);
+    EXPECT_EQ(spy.boundName, QString("ExtensionLibMenu"));
+    EXPECT_EQ(spy.boundParent, QString("ExtendMenu"));
+
+    // followEvents() wired the emblem hook during initialize(): running it
+    // must reach ExtensionEmblemManager::onFetchCustomEmblems, which returns
+    // false because extension plugins are never initialized in tests.
+    QList<QIcon> emblems;
+    bool fetched = dpfHookSequence->run("dfmplugin_emblem", "hook_ExtendEmblems_Fetch",
+                                        QUrl::fromLocalFile("/tmp/emblem_target.txt"), &emblems);
+    EXPECT_FALSE(fetched);
+    EXPECT_TRUE(emblems.isEmpty());
+}
+
+TEST_F(UtilsEventDispatchTest, EmblemFetchHook_RunValidUrlWithoutPlugins_ReturnsFalseKeepsEmblems)
+{
+    stub.set_lamda(ADDR(ExtensionPluginManager, onLoadingPlugins), [](ExtensionPluginManager *) {});
+
+    VirtualExtensionImplPlugin plugin;
+    plugin.initialize();   // wires hook_ExtendEmblems_Fetch via followEvents()
+
+    QList<QIcon> emblems { QIcon() };
+    int countBefore = emblems.size();
+    bool fetched = dpfHookSequence->run("dfmplugin_emblem", "hook_ExtendEmblems_Fetch",
+                                        QUrl::fromLocalFile("/tmp/emblem_plain.txt"), &emblems);
+
+    EXPECT_FALSE(fetched);
+    EXPECT_EQ(emblems.size(), countBefore);
+}
+
+TEST_F(UtilsEventDispatchTest, ChangeCurrentUrlEvent_PublishAnyUrl_ClearsCacheAndRequestsClear)
+{
+    ExtensionEmblemManager::instance().initialize();
+
+    QSignalSpy spy(&ExtensionEmblemManager::instance(), &ExtensionEmblemManager::requestClearCache);
+
+    bool published = dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl,
+                                                  quint64(7), QUrl::fromLocalFile("/tmp/emblem_dir"));
+
+    EXPECT_TRUE(published);
+    EXPECT_GE(spy.count(), 1);
+}
+
+// ========== AppendCompressEventReceiver: drag & drop hooks ==========
+
+TEST_F(UtilsEventDispatchTest, DragMoveHook_RunWorkspaceUrls_DropActionPointerRoundTrips)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls, Qt::DropAction *dropAction) -> bool {
+                       g_mouseStyleCalled = true;
+                       g_mouseToUrl = toUrl;
+                       g_mouseFromUrls = fromUrls;
+                       if (dropAction)
+                           *dropAction = Qt::CopyAction;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QList<QUrl> fromUrls { createTestFile("drag_src.txt") };
+    QUrl toUrl = QUrl::fromLocalFile(tempDir->path() + "/archive.zip");
+    Qt::DropAction action = Qt::IgnoreAction;
+
+    bool handled = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDragMove",
+                                        fromUrls, toUrl, &action);
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_mouseStyleCalled);
+    EXPECT_EQ(g_mouseToUrl, toUrl);
+    EXPECT_EQ(action, Qt::CopyAction);
+}
+
+TEST_F(UtilsEventDispatchTest, FileDropHook_RunWorkspaceUrls_CompressRequestedWithExactUrls)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls) -> bool {
+                       g_compressCalled = true;
+                       g_compressToUrl = toUrl;
+                       g_compressFromUrls = fromUrls;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QList<QUrl> fromUrls { createTestFile("drop_src.txt") };
+    QUrl toUrl = QUrl::fromLocalFile(tempDir->path() + "/bundle.zip");
+
+    bool handled = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                        fromUrls, toUrl);
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_compressCalled);
+    EXPECT_EQ(g_compressToUrl, toUrl);
+    EXPECT_EQ(g_compressFromUrls, fromUrls);
+}
+
+TEST_F(UtilsEventDispatchTest, IsDropHook_RunCompressedUrl_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool {
+                       g_compressIsDrop = true;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    bool handled = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_IsDrop",
+                                        QUrl::fromLocalFile("/tmp/archive.zip"));
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_compressIsDrop);
+}
+
+TEST_F(UtilsEventDispatchTest, IsDropHook_RunPlainUrl_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, isCompressedFile),
+                   [](const QUrl &) -> bool { return false; });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    bool handled = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_IsDrop",
+                                        QUrl::fromLocalFile("/tmp/notes.txt"));
+
+    EXPECT_FALSE(handled);
+}
+
+TEST_F(UtilsEventDispatchTest, CanvasDragMoveHook_RunDesktopPayload_MouseStyleApplied)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls, Qt::DropAction *dropAction) -> bool {
+                       g_mouseStyleCalled = true;
+                       g_mouseToUrl = toUrl;
+                       g_mouseFromUrls = fromUrls;
+                       if (dropAction)
+                           *dropAction = Qt::MoveAction;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QMimeData mime;
+    QList<QUrl> fromUrls { createTestFile("canvas_drag.txt") };
+    mime.setUrls(fromUrls);
+    QUrl hoverUrl = QUrl::fromLocalFile(tempDir->path() + "/canvas_dir");
+    Qt::DropAction action = Qt::IgnoreAction;
+
+    QVariantHash extData;
+    extData.insert("hoverUrl", hoverUrl);
+    extData.insert("dropAction", static_cast<qlonglong>(reinterpret_cast<qintptr>(&action)));
+
+    bool handled = dpfHookSequence->run("ddplugin_canvas", "hook_CanvasView_DragMove",
+                                        3, &mime, QPoint(10, 20),
+                                        static_cast<void *>(&extData));
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_mouseStyleCalled);
+    EXPECT_EQ(g_mouseToUrl, hoverUrl);
+    EXPECT_EQ(action, Qt::MoveAction);
+}
+
+TEST_F(UtilsEventDispatchTest, CanvasDropDataHook_RunDesktopPayload_CompressApplied)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls) -> bool {
+                       g_compressCalled = true;
+                       g_compressToUrl = toUrl;
+                       g_compressFromUrls = fromUrls;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QMimeData mime;
+    QList<QUrl> fromUrls { createTestFile("canvas_drop.txt") };
+    mime.setUrls(fromUrls);
+    QUrl dropUrl = QUrl::fromLocalFile(tempDir->path() + "/canvas_bundle.zip");
+
+    QVariantHash extData;
+    extData.insert("dropUrl", dropUrl);
+
+    bool handled = dpfHookSequence->run("ddplugin_canvas", "hook_CanvasView_DropData",
+                                        3, &mime, QPoint(5, 6),
+                                        static_cast<void *>(&extData));
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_compressCalled);
+    EXPECT_EQ(g_compressToUrl, dropUrl);
+    EXPECT_EQ(g_compressFromUrls, fromUrls);
+}
+
+TEST_F(UtilsEventDispatchTest, OrganizerDragMoveHook_RunOrganizerPayload_MouseStyleApplied)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, setMouseStyle),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls, Qt::DropAction *dropAction) -> bool {
+                       g_mouseStyleCalled = true;
+                       g_mouseToUrl = toUrl;
+                       g_mouseFromUrls = fromUrls;
+                       if (dropAction)
+                           *dropAction = Qt::LinkAction;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QMimeData mime;
+    QList<QUrl> fromUrls { createTestFile("org_drag.txt") };
+    mime.setUrls(fromUrls);
+    QUrl hoverUrl = QUrl::fromLocalFile(tempDir->path() + "/organizer_dir");
+    Qt::DropAction action = Qt::IgnoreAction;
+
+    QVariantHash extData;
+    extData.insert("hoverUrl", hoverUrl);
+    extData.insert("dropAction", static_cast<qlonglong>(reinterpret_cast<qintptr>(&action)));
+
+    bool handled = dpfHookSequence->run("ddplugin_organizer", "hook_CollectionView_DragMove",
+                                        QString("view-7"), &mime, QPoint(30, 40),
+                                        static_cast<void *>(&extData));
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_mouseStyleCalled);
+    EXPECT_EQ(g_mouseToUrl, hoverUrl);
+    EXPECT_EQ(action, Qt::LinkAction);
+}
+
+TEST_F(UtilsEventDispatchTest, OrganizerDropDataHook_RunOrganizerPayload_CompressApplied)
+{
+    stub.set_lamda(ADDR(AppendCompressHelper, dragDropCompress),
+                   [](const QUrl &toUrl, const QList<QUrl> &fromUrls) -> bool {
+                       g_compressCalled = true;
+                       g_compressToUrl = toUrl;
+                       g_compressFromUrls = fromUrls;
+                       return true;
+                   });
+
+    AppendCompressEventReceiver receiver;
+    receiver.initEventConnect();
+
+    QMimeData mime;
+    QList<QUrl> fromUrls { createTestFile("org_drop.txt") };
+    mime.setUrls(fromUrls);
+    QUrl dropUrl = QUrl::fromLocalFile(tempDir->path() + "/organizer_bundle.zip");
+
+    QVariantHash extData;
+    extData.insert("dropUrl", dropUrl);
+
+    bool handled = dpfHookSequence->run("ddplugin_organizer", "hook_CollectionView_DropData",
+                                        QString("view-9"), &mime, QPoint(50, 60),
+                                        static_cast<void *>(&extData));
+
+    EXPECT_TRUE(handled);
+    ASSERT_TRUE(g_compressCalled);
+    EXPECT_EQ(g_compressToUrl, dropUrl);
+    EXPECT_EQ(g_compressFromUrls, fromUrls);
+    EXPECT_EQ(g_compressFromUrls.size(), 1);
+}
+
+#include "test_realevents_dispatch.moc"


### PR DESCRIPTION
## Summary
- Add event-dispatch tests for ddplugin-organizer (27 cases): broker slot channels via init()+push, canvas view/model shell events, signal dispatch through real CanvasManager::init()
- Add event-dispatch tests for dfmplugin-utils (29 cases): signal/hook/slot topics with real production subscriptions (initEventConnect / bindEvents / initializeConnections)
- Add event-dispatch tests for dfmplugin-tag (28 cases): real Tag::initialize()/start() subscription chain, daemon dbus boundary stubbed with argument capture
- Extend organizer normalized-mode tests (+3 tryPlaceRect cases)

## Verification
- ut-ddplugin-organizer: 934/934 passed
- ut-dfmplugin-utils: 518/518 passed (pre-existing flaky UT_BluetoothManager case untouched)
- ut-dfmplugin-tag: 325/325 passed

## Coverage impact
- eventhelper.h instantiations for all three plugins: fully covered (48+36+32 gaps closed)
- Additional coverage of receiver/slot method bodies and helpers

Independent of the other UT PRs; touches only autotests/plugins/{ddplugin-organizer,dfmplugin-utils,dfmplugin-tag}.
Base: c13ee5bb

## Summary by Sourcery

Increase automated coverage of production event dispatch and normalized item placement across the organizer, utility, and tag plugins.

Enhancements:
- Expand event-dispatch coverage across the organizer, utility, and tag plugins by exercising production signal, hook, and slot wiring with representative arguments and outcomes.
- Add normalized-mode placement coverage for empty, partially occupied, and fully occupied layouts.

Build:
- Update the tag plugin test configuration to support newly added test sources.

Tests:
- Add comprehensive organizer event-dispatch tests covering broker slots, canvas shell hooks, and canvas-related signal propagation.
- Add utility-plugin event-dispatch tests covering file operations, accessibility, open-with, Bluetooth, reporting, shredding, extensions, compression, and drag-and-drop handlers.
- Add tag-plugin real-event tests covering tag-management signals, hooks, plugin extension registration, workspace filtering, trash operations, and file redirection.