### PR TITLE
test: add event dispatch unit tests for ddplugin-canvas

### DIFF
--- a/autotests/plugins/ddplugin-canvas/test_canvasview_events.cpp
+++ b/autotests/plugins/ddplugin-canvas/test_canvasview_events.cpp
@@ -1,0 +1,862 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "canvas_test_common.h"
+
+#include "plugins/desktop/ddplugin-canvas/view/canvasview.h"
+#include "plugins/desktop/ddplugin-canvas/view/canvasview_p.h"
+#include "plugins/desktop/ddplugin-canvas/view/viewhookinterface.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/viewsettingutil.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/viewpainter.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/dodgeoper.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/keyselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/clickselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/boxselector.h"
+#include "plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasproxymodel.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.h"
+#include "plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h"
+
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/base/application/application.h>
+
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QStandardItemModel>
+#include <QItemSelectionModel>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QWheelEvent>
+#include <QFocusEvent>
+#include <QPaintEvent>
+#include <QContextMenuEvent>
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDragLeaveEvent>
+#include <QDropEvent>
+#include <QMimeData>
+
+using namespace ddplugin_canvas;
+DFMBASE_USE_NAMESPACE
+
+namespace {
+class TestProxyModel : public CanvasProxyModel
+{
+public:
+    Qt::ItemFlags flags(const QModelIndex &) const override
+    {
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    }
+
+    QVariant data(const QModelIndex &, int) const override
+    {
+        return dataResult;
+    }
+
+    QVariant dataResult = QVariant(QString("apple"));
+};
+
+class DummyViewHook : public ViewHookInterface
+{
+public:
+    bool keyPress(int, int, int, void * = nullptr) const override { keyPressCount++; return keyPressResult; }
+    bool mousePress(int, int, const QPoint &, void * = nullptr) const override { mousePressCount++; return mousePressResult; }
+    bool wheel(int, const QPoint &, void * = nullptr) const override { wheelCount++; return wheelResult; }
+    bool startDrag(int, int, void * = nullptr) const override { startDragCount++; return startDragResult; }
+
+    mutable int keyPressCount = 0;
+    mutable int mousePressCount = 0;
+    mutable int wheelCount = 0;
+    mutable int startDragCount = 0;
+    bool keyPressResult = false;
+    bool mousePressResult = false;
+    bool wheelResult = false;
+    bool startDragResult = false;
+};
+}   // namespace
+
+class CanvasViewEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(VADDR(QWidget, show), [](QWidget *) { __DBG_STUB_INVOKE__; });
+        stub.set_lamda(VADDR(QWidget, setVisible), [](QWidget *, bool) { __DBG_STUB_INVOKE__; });
+        // CanvasView::reset calls model()->rootIndex() through the proxy cast.
+        stub.set_lamda(VADDR(CanvasView, reset), [](CanvasView *) { __DBG_STUB_INVOKE__; });
+
+        view = new CanvasView(nullptr);
+        // Valid grid metrics so real CanvasViewPrivate::gridAt never divides by zero.
+        view->d->canvasInfo = CanvasViewPrivate::CanvasInfo(2, 2, 100, 100);
+
+        proxyModel = new CanvasProxyModel();
+        // CanvasView::selectionModel() qobject_casts to CanvasSelectionModel, so a
+        // plain QItemSelectionModel would surface as null inside the view. Qt also
+        // requires the selection model to work on the same model as the view.
+        mockSelectionModel = new CanvasSelectionModel(proxyModel, proxyModel);
+        view->setModel(proxyModel);
+        view->setSelectionModel(mockSelectionModel);
+        // Plain model only used to fabricate QModelIndex values in tests.
+        mockModel = new QStandardItemModel();
+
+        stub.set_lamda(ADDR(CanvasView, model),
+                       [this](const CanvasView *) -> CanvasProxyModel * {
+                           return proxyModel;
+                       });
+        view->setItemDelegate(new CanvasItemDelegate(view));
+
+        hook = new DummyViewHook();
+        view->setViewHook(hook);
+    }
+
+    void TearDown() override
+    {
+        view->setViewHook(nullptr);
+        delete view;
+        delete proxyModel;
+        delete hook;
+        delete mockModel;   // deletes mockSelectionModel as its child
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    CanvasView *view = nullptr;
+    QStandardItemModel *mockModel = nullptr;
+    CanvasSelectionModel *mockSelectionModel = nullptr;
+    CanvasProxyModel *proxyModel = nullptr;
+    DummyViewHook *hook = nullptr;
+};
+
+TEST_F(CanvasViewEventTest, ViewHook_SetAndGet_ReturnsSameInterface)
+{
+    // Arrange
+    DummyViewHook otherHook;
+
+    // Act
+    view->setViewHook(&otherHook);
+
+    // Assert
+    EXPECT_EQ(view->viewHook(), &otherHook);
+    view->setViewHook(hook);
+    EXPECT_EQ(view->viewHook(), hook);
+    EXPECT_NE(view->viewHook(), &otherHook);
+}
+
+TEST_F(CanvasViewEventTest, SetSelection_RectAndFlags_SelectionRemainsEmpty)
+{
+    // Arrange
+    QStandardItem *item = new QStandardItem("a");
+    mockModel->appendRow(item);
+    EXPECT_TRUE(view->selectionModel()->selectedIndexes().isEmpty());
+
+    // Act: CanvasView::setSelection is intentionally a no-op.
+    view->setSelection(QRect(0, 0, 100, 100), QItemSelectionModel::ClearAndSelect);
+
+    // Assert
+    EXPECT_TRUE(view->selectionModel()->selectedIndexes().isEmpty());
+    EXPECT_EQ(view->selectionModel()->selectedIndexes().size(), 0);
+}
+
+TEST_F(CanvasViewEventTest, VisualRegionForSelection_EmptySelection_ReturnsEmptyRegion)
+{
+    // Arrange
+    QItemSelection emptySelection;
+
+    // Act
+    QRegion region = view->visualRegionForSelection(emptySelection);
+
+    // Assert
+    EXPECT_TRUE(region.isEmpty());
+    EXPECT_TRUE(region.boundingRect().isNull());
+}
+
+TEST_F(CanvasViewEventTest, KeyboardSearch_ValidSearch_ForwardedToSelector)
+{
+    // Arrange
+    QString captured;
+    stub.set_lamda(ADDR(KeySelector, keyboardSearch),
+                   [&captured](KeySelector *, const QString &search) {
+                       captured = search;
+                   });
+
+    // Act
+    view->keyboardSearch(QString("abc"));
+
+    // Assert
+    EXPECT_EQ(captured, QString("abc"));
+}
+
+TEST_F(CanvasViewEventTest, PaintEvent_NormalState_AllPaintStagesExecuted)
+{
+    // Arrange
+    bool gridInfosDrawn = false;
+    bool moveDrawn = false;
+    bool dodgeDrawn = false;
+    bool filesPainted = false;
+    stub.set_lamda(ADDR(ViewPainter, drawGirdInfos),
+                   [&gridInfosDrawn](ViewPainter *) {
+                       gridInfosDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, drawMove),
+                   [&moveDrawn](ViewPainter *, QStyleOptionViewItem) {
+                       moveDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, drawDodge),
+                   [&dodgeDrawn](ViewPainter *, QStyleOptionViewItem) {
+                       dodgeDrawn = true;
+                   });
+    stub.set_lamda(ADDR(ViewPainter, paintFiles),
+                   [&filesPainted](ViewPainter *, QStyleOptionViewItem, QPaintEvent *) {
+                       filesPainted = true;
+                   });
+    view->d->flicker = false;
+
+    // Act
+    QPaintEvent event(QRect(0, 0, 400, 300));
+    view->paintEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(gridInfosDrawn);
+    EXPECT_TRUE(moveDrawn);
+    EXPECT_TRUE(dodgeDrawn);
+    EXPECT_TRUE(filesPainted);
+}
+
+TEST_F(CanvasViewEventTest, ContextMenuEvent_EmptyArea_ShowsEmptyAreaMenu)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, disableMenu),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(WindowUtils, isWayLand),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    bool editorReverted = false;
+    stub.set_lamda(ADDR(CanvasItemDelegate, revertAndcloseEditor),
+                   [&editorReverted](CanvasItemDelegate *) {
+                       editorReverted = true;
+                   });
+    QPoint capturedGridPos(-1, -1);
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, showEmptyAreaMenu),
+                   [&capturedGridPos](CanvasViewMenuProxy *, const Qt::ItemFlags &, const QPoint gridPos) {
+                       capturedGridPos = gridPos;
+                   });
+
+    // Act
+    QContextMenuEvent event(QContextMenuEvent::Mouse, QPoint(20, 20), QPoint(120, 120));
+    view->contextMenuEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(editorReverted);
+    EXPECT_EQ(capturedGridPos, view->d->gridAt(QPoint(20, 20)));
+}
+
+TEST_F(CanvasViewEventTest, StartDrag_DelayDragEnabled_ReturnsWithoutDrag)
+{
+    // Arrange
+    stub.set_lamda(ADDR(ViewSettingUtil, isDelayDrag),
+                   [](const ViewSettingUtil *) -> bool {
+                       return true;
+                   });
+
+    // Act
+    view->startDrag(Qt::CopyAction);
+
+    // Assert
+    EXPECT_EQ(hook->startDragCount, 0);
+}
+
+TEST_F(CanvasViewEventTest, StartDrag_ExtendHookHandlesDrag_SkipsDefaultDrag)
+{
+    // Arrange
+    stub.set_lamda(ADDR(ViewSettingUtil, isDelayDrag),
+                   [](const ViewSettingUtil *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(VADDR(QAbstractItemView, closePersistentEditor), [](QAbstractItemView *, const QModelIndex &) { __DBG_STUB_INVOKE__; });
+    hook->startDragResult = true;
+
+    // Act
+    view->startDrag(Qt::CopyAction);
+
+    // Assert
+    EXPECT_EQ(hook->startDragCount, 1);
+}
+
+TEST_F(CanvasViewEventTest, DragEvents_OperHandlesEvent_BaseBehaviourSkipped)
+{
+    // Arrange
+    bool enterHandled = false;
+    bool moveHandled = false;
+    bool leaveHandled = false;
+    stub.set_lamda(ADDR(DragDropOper, enter),
+                   [&enterHandled](DragDropOper *, QDragEnterEvent *) -> bool {
+                       enterHandled = true;
+                       return true;
+                   });
+    stub.set_lamda(ADDR(DragDropOper, move),
+                   [&moveHandled](DragDropOper *, QDragMoveEvent *) -> bool {
+                       moveHandled = true;
+                       return true;
+                   });
+    stub.set_lamda(ADDR(DragDropOper, leave),
+                   [&leaveHandled](DragDropOper *, QDragLeaveEvent *) {
+                       leaveHandled = true;
+                   });
+
+    QMimeData mimeData;
+    // Act
+    QDragEnterEvent enterEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dragEnterEvent(&enterEvent);
+    QDragMoveEvent moveEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dragMoveEvent(&moveEvent);
+    QDragLeaveEvent leaveEvent;
+    view->dragLeaveEvent(&leaveEvent);
+
+    // Assert
+    EXPECT_TRUE(enterHandled);
+    EXPECT_TRUE(moveHandled);
+    EXPECT_TRUE(leaveHandled);
+}
+
+TEST_F(CanvasViewEventTest, DropEvent_OperHandlesDrop_ActivatesWindowAndResetsState)
+{
+    // Arrange
+    QDropEvent *capturedEvent = nullptr;
+    stub.set_lamda(ADDR(DragDropOper, drop),
+                   [&capturedEvent](DragDropOper *, QDropEvent *event) -> bool {
+                       capturedEvent = event;
+                       return true;
+                   });
+    stub.set_lamda(VADDR(QWidget, activateWindow), [](QWidget *) { __DBG_STUB_INVOKE__; });
+
+    // Act
+    QMimeData mimeData;
+    QDropEvent dropEvent(QPoint(10, 10), Qt::CopyAction | Qt::MoveAction, &mimeData, Qt::LeftButton, Qt::NoModifier);
+    view->dropEvent(&dropEvent);
+
+    // Assert
+    EXPECT_EQ(capturedEvent, &dropEvent);
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+}
+
+TEST_F(CanvasViewEventTest, FocusInEvent_InputMethodEnabled_AttributeEnabled)
+{
+    // Arrange
+    view->d->imEnabled = true;
+    view->setAttribute(Qt::WA_InputMethodEnabled, false);
+    QFocusEvent event(QEvent::FocusIn);
+
+    // Act
+    view->focusInEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(view->testAttribute(Qt::WA_InputMethodEnabled));
+}
+
+TEST_F(CanvasViewEventTest, FocusOutEvent_AnyFocusOut_StopsDelayDodge)
+{
+    // Arrange
+    bool delayStopped = false;
+    bool prepareUpdated = false;
+    stub.set_lamda(ADDR(DodgeOper, stopDelayDodge),
+                   [&delayStopped](DodgeOper *) {
+                       delayStopped = true;
+                   });
+    stub.set_lamda(ADDR(DodgeOper, updatePrepareDodgeValue),
+                   [&prepareUpdated](DodgeOper *, QEvent *) {
+                       prepareUpdated = true;
+                   });
+    QFocusEvent event(QEvent::FocusOut);
+
+    // Act
+    view->focusOutEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(delayStopped);
+    EXPECT_TRUE(prepareUpdated);
+}
+
+TEST_F(CanvasViewEventTest, Edit_NoSelection_ReturnsFalse)
+{
+    // Arrange
+    mockModel->appendRow(new QStandardItem("a"));
+    EXPECT_EQ(view->selectionModel()->selectedRows().size(), 0);
+    QKeyEvent keyEvent(QEvent::MouseButtonPress, Qt::Key_F2, Qt::NoModifier);
+
+    // Act
+    bool edited = view->edit(mockModel->index(0, 0), QAbstractItemView::AllEditTriggers, &keyEvent);
+
+    // Assert
+    EXPECT_FALSE(edited);
+    EXPECT_EQ(view->selectionModel()->selectedRows().size(), 0);
+}
+
+TEST_F(CanvasViewEventTest, KeyPressEvent_HookConsumesKey_EventNotPropagated)
+{
+    // Arrange
+    hook->keyPressResult = true;
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Delete, Qt::NoModifier);
+
+    // Act
+    view->keyPressEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->keyPressCount, 1);
+}
+
+TEST_F(CanvasViewEventTest, MousePressEvent_EmptyAreaLeftButton_StartsBoxSelection)
+{
+    // Arrange
+    hook->mousePressResult = false;
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    bool touchChecked = false;
+    stub.set_lamda(ADDR(ViewSettingUtil, checkTouchDrag),
+                   [&touchChecked](ViewSettingUtil *, QMouseEvent *) {
+                       touchChecked = true;
+                   });
+    bool committed = false;
+    stub.set_lamda(ADDR(CanvasItemDelegate, commitDataAndCloseEditor),
+                   [&committed](CanvasItemDelegate *) {
+                       committed = true;
+                   });
+    bool boxBegin = false;
+    stub.set_lamda(ADDR(BoxSelector, beginSelect),
+                   [&boxBegin](BoxSelector *, const QPoint &, bool) {
+                       boxBegin = true;
+                   });
+    QModelIndex clickedIndex(0, 0, nullptr, mockModel);
+    bool clickCaptured = false;
+    stub.set_lamda(ADDR(ClickSelector, click),
+                   [&clickCaptured](ClickSelector *, const QModelIndex &) {
+                       clickCaptured = true;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    view->mousePressEvent(&event);
+
+    // Assert
+    EXPECT_TRUE(touchChecked);
+    EXPECT_TRUE(committed);
+    EXPECT_TRUE(boxBegin);
+    EXPECT_TRUE(clickCaptured);
+    EXPECT_EQ(view->state(), QAbstractItemView::DragSelectingState);
+}
+
+TEST_F(CanvasViewEventTest, MouseMoveEvent_PlainMove_StateUnchanged)
+{
+    // Arrange
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+
+    // Act
+    QMouseEvent event(QEvent::MouseMove, QPointF(50, 50), QPointF(50, 50),
+                      QPointF(150, 150), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseMoveEvent(&event);
+
+    // Assert
+    EXPECT_EQ(view->state(), QAbstractItemView::NoState);
+}
+
+TEST_F(CanvasViewEventTest, MouseReleaseEvent_LeftButtonOnEmpty_ForwardsToClickSelector)
+{
+    // Arrange
+    stub.set_lamda(VADDR(CanvasView, indexAt),
+                   [](const CanvasView *, const QPoint &) -> QModelIndex {
+                       return QModelIndex();
+                   });
+    QModelIndex released(-1, -1, nullptr, nullptr);
+    stub.set_lamda(ADDR(ClickSelector, release),
+                   [&released](ClickSelector *, const QModelIndex &index) {
+                       released = index;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    // Assert
+    EXPECT_FALSE(released.isValid());
+    EXPECT_EQ(released.model(), nullptr);
+}
+
+TEST_F(CanvasViewEventTest, MouseReleaseEvent_RightButton_SkipsClickSelector)
+{
+    // Arrange
+    bool releaseCalled = false;
+    stub.set_lamda(ADDR(ClickSelector, release),
+                   [&releaseCalled](ClickSelector *, const QModelIndex &) {
+                       releaseCalled = true;
+                   });
+
+    // Act
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10),
+                      QPointF(110, 110), Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+    view->mouseReleaseEvent(&event);
+
+    // Assert
+    EXPECT_FALSE(releaseCalled);
+}
+
+TEST_F(CanvasViewEventTest, WheelEvent_HookConsumsWheel_ChangeIconLevelSkipped)
+{
+    // Arrange
+    hook->wheelResult = true;
+    bool iconLevelChanged = false;
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, changeIconLevel),
+                   [&iconLevelChanged](CanvasViewMenuProxy *, bool) {
+                       iconLevelChanged = true;
+                   });
+
+    // Act
+    QWheelEvent event(QPointF(50, 50), QPointF(150, 150), QPoint(0, 120), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    view->wheelEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->wheelCount, 1);
+    EXPECT_FALSE(iconLevelChanged);
+}
+
+TEST_F(CanvasViewEventTest, WheelEvent_NoCtrlWheel_DoesNotChangeIconLevel)
+{
+    // Arrange
+    hook->wheelResult = false;
+    bool iconLevelChanged = false;
+    stub.set_lamda(ADDR(CanvasViewMenuProxy, changeIconLevel),
+                   [&iconLevelChanged](CanvasViewMenuProxy *, bool) {
+                       iconLevelChanged = true;
+                   });
+
+    // Act
+    QWheelEvent event(QPointF(50, 50), QPointF(150, 150), QPoint(0, 120), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    view->wheelEvent(&event);
+
+    // Assert
+    EXPECT_EQ(hook->wheelCount, 1);
+    EXPECT_FALSE(iconLevelChanged);
+}
+
+TEST_F(CanvasViewEventTest, ItemRect_UnknownItem_ReturnsInvalidRect)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileUrl),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> QUrl {
+                       return QUrl();
+                   });
+
+    // Act
+    QRect rect = view->itemRect(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_TRUE(rect.isNull());
+    EXPECT_EQ(rect, QRect());
+}
+
+TEST_F(CanvasViewEventTest, ItemRect_KnownGridItem_ReturnsGridRect)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileUrl),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> QUrl {
+                       return QUrl("file:///home/a");
+                   });
+    bool gridPosFound = false;
+    stub.set_lamda(ADDR(CanvasViewPrivate, itemGridpos),
+                   [&gridPosFound](const CanvasViewPrivate *, const QString &item, QPoint &gridPos) {
+                       gridPosFound = item == QString("file:///home/a");
+                       gridPos = QPoint(1, 1);
+                       return gridPosFound;
+                   });
+    QRect canned(7, 8, 100, 100);
+    stub.set_lamda(ADDR(CanvasViewPrivate, itemRect),
+                   [&canned](const CanvasViewPrivate *, const QPoint &) -> QRect {
+                       return canned;
+                   });
+
+    // Act
+    QRect rect = view->itemRect(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_TRUE(gridPosFound);
+    EXPECT_EQ(rect, canned);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndexByClicked_MatchingActionWithNullInfo_DoesNotOpen)
+{
+    // Arrange
+    TestProxyModel testProxy;   // flags() reports enabled so the handler reaches openIndex
+    stub.set_lamda(ADDR(CanvasView, model),
+                   [&testProxy](const CanvasView *) -> CanvasProxyModel * {
+                       return &testProxy;
+                   });
+    stub.set_lamda(ADDR(Application, instance), []() -> Application * {
+        return canvas_test::sharedApp();
+    });
+    stub.set_lamda(ADDR(Application, appAttribute),
+                   [](Application::ApplicationAttribute) -> QVariant {
+                       return QVariant(static_cast<int>(CanvasViewPrivate::ClickedAction::kClicked));
+                   });
+    stub.set_lamda(ADDR(WindowUtils, keyCtrlIsPressed),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(WindowUtils, keyShiftIsPressed),
+                   []() -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasProxyModel, fileInfo),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> FileInfoPointer {
+                       return FileInfoPointer();
+                   });
+    bool openFilesCalled = false;
+    stub.set_lamda(static_cast<void (FileOperatorProxy::*)(const CanvasView *, const QList<QUrl> &)>(&FileOperatorProxy::openFiles),
+                   [&openFilesCalled](FileOperatorProxy *, const CanvasView *, const QList<QUrl> &) {
+                       openFilesCalled = true;
+                   });
+
+    // Act
+    view->d->openIndexByClicked(CanvasViewPrivate::ClickedAction::kClicked, QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert: flags on an empty proxy model lack ItemIsEnabled, so no open happens.
+    EXPECT_FALSE(openFilesCalled);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndex_NullFileInfo_DoesNotOpenFiles)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasProxyModel, fileInfo),
+                   [](const CanvasProxyModel *, const QModelIndex &) -> FileInfoPointer {
+                       return FileInfoPointer();
+                   });
+    bool openFilesCalled = false;
+    stub.set_lamda(static_cast<void (FileOperatorProxy::*)(const CanvasView *, const QList<QUrl> &)>(&FileOperatorProxy::openFiles),
+                   [&openFilesCalled](FileOperatorProxy *, const CanvasView *, const QList<QUrl> &) {
+                       openFilesCalled = true;
+                   });
+
+    // Act
+    view->d->openIndex(QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_FALSE(openFilesCalled);
+}
+
+TEST_F(CanvasViewEventTest, OpenIndexByClicked_NonMatchingAction_SkipsOpen)
+{
+    // Arrange
+    stub.set_lamda(ADDR(Application, instance), []() -> Application * {
+        return canvas_test::sharedApp();
+    });
+    stub.set_lamda(ADDR(Application, appAttribute),
+                   [](Application::ApplicationAttribute) -> QVariant {
+                       return QVariant(static_cast<int>(CanvasViewPrivate::ClickedAction::kDoubleClicked));
+                   });
+    bool openIndexCalled = false;
+    stub.set_lamda(ADDR(CanvasViewPrivate, openIndex),
+                   [&openIndexCalled](CanvasViewPrivate *, const QModelIndex &) {
+                       openIndexCalled = true;
+                   });
+
+    // Act
+    view->d->openIndexByClicked(CanvasViewPrivate::ClickedAction::kClicked, QModelIndex(0, 0, nullptr, mockModel));
+
+    // Assert
+    EXPECT_FALSE(openIndexCalled);
+}
+
+TEST_F(CanvasViewEventTest, FindIndex_EmptyGrid_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasGrid, item),
+                   [](const CanvasGrid *, int, const QPoint &) -> QString {
+                       return QString();
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return QModelIndex();
+                   });
+
+    // Act
+    QModelIndex found = view->d->findIndex(QString("a"), true, QModelIndex(), false, false);
+
+    // Assert
+    EXPECT_FALSE(found.isValid());
+    EXPECT_EQ(found, QModelIndex());
+}
+
+TEST_F(CanvasViewEventTest, FindIndex_MatchingPinyinName_ReturnsModelIndex)
+{
+    // Arrange
+    TestProxyModel testProxy;   // data() reports a matching pinyin name
+    stub.set_lamda(ADDR(CanvasView, model),
+                   [&testProxy](const CanvasView *) -> CanvasProxyModel * {
+                       return &testProxy;
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+
+    // Act
+    QModelIndex found = view->d->findIndex(QString("app"), true, QModelIndex(), false, false);
+
+    // Assert
+    EXPECT_TRUE(found.isValid());
+    EXPECT_EQ(found, canned);
+}
+
+TEST_F(CanvasViewEventTest, LastIndex_WithOverloadItem_ReturnsOverloadModelIndex)
+{
+    // Arrange
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    QUrl capturedUrl;
+    stub.set_lamda(ADDR(CanvasGrid, overloadItems),
+                   [](const CanvasGrid *, int) -> QStringList {
+                       return { QString("file:///home/overload") };
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned, &capturedUrl](const CanvasProxyModel *, const QUrl &url, int) -> QModelIndex {
+                       capturedUrl = url;
+                       return canned;
+                   });
+
+    // Act
+    QModelIndex last = view->d->lastIndex();
+
+    // Assert
+    EXPECT_EQ(capturedUrl, QUrl("file:///home/overload"));
+    EXPECT_TRUE(last.isValid());
+    EXPECT_EQ(last, canned);
+}
+
+TEST_F(CanvasViewEventTest, LastIndex_EmptyGrid_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasGrid, overloadItems),
+                   [](const CanvasGrid *, int) -> QStringList {
+                       return QStringList();
+                   });
+    stub.set_lamda(ADDR(CanvasGrid, item),
+                   [](const CanvasGrid *, int, const QPoint &) -> QString {
+                       return QString();
+                   });
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return QModelIndex();
+                   });
+
+    // Act
+    QModelIndex last = view->d->lastIndex();
+
+    // Assert
+    EXPECT_FALSE(last.isValid());
+    EXPECT_EQ(last, QModelIndex());
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_PointInsideIconRect_ReturnsItemIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 100, 100), QRect(0, 100, 100, 40) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(50, 50));
+
+    // Assert
+    EXPECT_TRUE(at.isValid());
+    EXPECT_EQ(at, canned);
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_ExpandedItemInsideIconRect_ReturnsCurrentIndex)
+{
+    // Arrange: expanded item branch exercises indexAt's own checkRect lambda.
+    QModelIndex current(0, 0, nullptr, mockModel);
+    stub.set_lamda(VADDR(QAbstractItemView, currentIndex),
+                   [&current](const QAbstractItemView *) -> QModelIndex {
+                       return current;
+                   });
+    stub.set_lamda(VADDR(QAbstractItemView, isPersistentEditorOpen),
+                   [](const QAbstractItemView *, const QModelIndex &) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return true;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 100, 100), QRect(0, 100, 100, 40) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(50, 50));
+
+    // Assert
+    EXPECT_TRUE(at.isValid());
+    EXPECT_EQ(at, current);
+}
+
+TEST_F(CanvasViewEventTest, IndexAt_PointOutsideAllRects_ReturnsInvalidIndex)
+{
+    // Arrange
+    stub.set_lamda(ADDR(CanvasItemDelegate, mayExpand),
+                   [](const CanvasItemDelegate *, QModelIndex *) -> bool {
+                       return false;
+                   });
+    stub.set_lamda(ADDR(CanvasViewPrivate, visualItem),
+                   [](const CanvasViewPrivate *, const QPoint &) -> QString {
+                       return QString("file:///home/a");
+                   });
+    QModelIndex canned(0, 0, nullptr, mockModel);
+    stub.set_lamda(static_cast<QModelIndex (CanvasProxyModel::*)(const QUrl &, int) const>(&CanvasProxyModel::index),
+                   [&canned](const CanvasProxyModel *, const QUrl &, int) -> QModelIndex {
+                       return canned;
+                   });
+    stub.set_lamda(ADDR(CanvasView, itemPaintGeomertys),
+                   [](const CanvasView *, const QModelIndex &) -> QList<QRect> {
+                       return { QRect(0, 0, 10, 10) };
+                   });
+
+    // Act
+    QModelIndex at = view->indexAt(QPoint(500, 500));
+
+    // Assert
+    EXPECT_FALSE(at.isValid());
+    EXPECT_NE(at, canned);
+}

--- a/autotests/plugins/ddplugin-canvas/test_eventdispatch.cpp
+++ b/autotests/plugins/ddplugin-canvas/test_eventdispatch.cpp
@@ -1,0 +1,824 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "plugins/desktop/ddplugin-canvas/broker/canvasgridbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasviewbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasmodelbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/canvasmanagerbroker.h"
+#include "plugins/desktop/ddplugin-canvas/broker/fileinfomodelbroker.h"
+#include "plugins/desktop/ddplugin-canvas/canvasmanager.h"
+#include "plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h"
+#include "plugins/desktop/ddplugin-canvas/grid/canvasgrid.h"
+#include "plugins/desktop/ddplugin-canvas/model/canvasproxymodel.h"
+#include "plugins/desktop/ddplugin-canvas/model/fileinfomodel.h"
+#include "plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/dfm_event_defines.h>
+
+#include <dlfcn.h>
+
+#include <gtest/gtest.h>
+#include <QHash>
+#include <QPoint>
+#include <QRect>
+#include <QSize>
+#include <QVariant>
+#include <QStandardItemModel>
+#include <QAbstractItemView>
+#include <QItemSelectionModel>
+
+DPF_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace ddplugin_canvas;
+
+namespace {
+// Maps "space::topic" to a stable id inside the custom event type range so
+// dpfSlotChannel / dpfSignalDispatcher resolve topics in the test process.
+int canvasTestEventConverter(const QString &space, const QString &topic)
+{
+    static QHash<QString, int> mapping;
+    const QString key = space + "::" + topic;
+    const auto it = mapping.constFind(key);
+    if (it != mapping.constEnd())
+        return it.value();
+    const int id = static_cast<int>(EventTypeScope::kCustomBase) + mapping.size();
+    mapping.insert(key, id);
+    return id;
+}
+
+void installCanvasTestConverter()
+{
+    // Construct the framework Event singleton first: its constructor registers
+    // the production converter exactly once (std::call_once) and would clobber
+    // a direct assignment made before the first dpfEvent evaluation.
+    dpf::Event::instance();
+    // C++17 inline variables get separate instances in the test executable and
+    // in libdfm6-framework.so (the two are not unified at dynamic link). Assign
+    // every reachable instance so dpfSlotChannel/dpfSignalDispatcher resolve
+    // topics no matter which TU the inline call site was instantiated in.
+    EventConverter::convertFunc = &canvasTestEventConverter;
+    if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                dlsym(RTLD_DEFAULT, "_ZN3dpf14EventConverter11convertFuncE"))) {
+        *func = &canvasTestEventConverter;
+    }
+    if (void *framework = dlopen("libdfm6-framework.so.1", RTLD_LAZY | RTLD_NOLOAD)) {
+        if (auto *func = reinterpret_cast<dpf::EventConverterFunc *>(
+                    dlsym(framework, "_ZN3dpf14EventConverter11convertFuncE"))) {
+            *func = &canvasTestEventConverter;
+        }
+    }
+}
+}   // namespace
+
+static constexpr auto kCanvasSpace = "ddplugin_canvas";
+
+class CanvasGridBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        grid = new CanvasGrid(nullptr);
+        broker = new CanvasGridBroker(grid);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete grid;
+        stub.clear();
+    }
+
+    CanvasGrid *grid = nullptr;
+    CanvasGridBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridItems_InvokesBrokerMethod)
+{
+    QStringList canned { "file:///home/a", "file:///home/b" };
+    int capturedIndex = -1;
+    stub.set_lamda(ADDR(CanvasGridBroker, items),
+                   [&canned, &capturedIndex](CanvasGridBroker *, int index) -> QStringList {
+                       __DBG_STUB_INVOKE__
+                       capturedIndex = index;
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Items", 2);
+    EXPECT_EQ(capturedIndex, 2);
+    EXPECT_EQ(ret.value<QStringList>(), canned);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridItem_InvokesBrokerMethod)
+{
+    QString canned("file:///home/a");
+    int capturedIndex = -1;
+    QPoint capturedPos(-1, -1);
+    stub.set_lamda(ADDR(CanvasGridBroker, item),
+                   [&canned, &capturedIndex, &capturedPos](CanvasGridBroker *, int index, const QPoint &pos) -> QString {
+                       capturedIndex = index;
+                       capturedPos = pos;
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Item", 1, QPoint(3, 4));
+    EXPECT_EQ(capturedIndex, 1);
+    EXPECT_EQ(capturedPos, QPoint(3, 4));
+    EXPECT_EQ(ret.toString(), canned);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridPoint_InvokesBrokerMethod)
+{
+    const QString item("file:///home/a");
+    int capturedScreen = -2;
+    stub.set_lamda(ADDR(CanvasGridBroker, point),
+                   [&capturedScreen](CanvasGridBroker *, const QString &, QPoint *pos) -> int {
+                       if (pos)
+                           *pos = QPoint(7, 8);
+                       capturedScreen = 1;
+                       return 1;
+                   });
+
+    QPoint pos;
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_Point",
+                                        item, QVariant::fromValue(&pos));
+    EXPECT_EQ(capturedScreen, 1);
+    EXPECT_EQ(pos, QPoint(7, 8));
+    EXPECT_EQ(ret.toInt(), 1);
+}
+
+TEST_F(CanvasGridBrokerEventTest, SlotChannel_PushGridTryAppendAfter_InvokesBrokerMethod)
+{
+    bool invoked = false;
+    QStringList capturedItems;
+    stub.set_lamda(ADDR(CanvasGridBroker, tryAppendAfter),
+                   [&invoked, &capturedItems](CanvasGridBroker *, const QStringList &items, int, const QPoint &) {
+                       invoked = true;
+                       capturedItems = items;
+                   });
+
+    QStringList input { "x", "y" };
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasGrid_TryAppendAfter", input, 0, QPoint(0, 0));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(capturedItems, input);
+}
+
+class CanvasViewBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+        broker = new CanvasViewBroker(manager);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    CanvasViewBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushVisualRect_InvokesBrokerMethod)
+{
+    QRect canned(1, 2, 30, 30);
+    QUrl capturedUrl;
+    stub.set_lamda(ADDR(CanvasViewBroker, visualRect),
+                   [&canned, &capturedUrl](CanvasViewBroker *, int, const QUrl &url) -> QRect {
+                       capturedUrl = url;
+                       return canned;
+                   });
+
+    QUrl url("file:///home/a.txt");
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_VisualRect", 1, url);
+    EXPECT_EQ(capturedUrl, url);
+    EXPECT_EQ(ret.value<QRect>(), canned);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushGridPosAndGridVisualRect_InvokesBrokerMethods)
+{
+    QPoint cannedPos(11, 12);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridPos),
+                   [&cannedPos](CanvasViewBroker *, int, const QPoint &) -> QPoint {
+                       return cannedPos;
+                   });
+    QRect cannedRect(5, 6, 80, 90);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridVisualRect),
+                   [&cannedRect](CanvasViewBroker *, int, const QPoint &) -> QRect {
+                       return cannedRect;
+                   });
+
+    QVariant pos = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridPos", 1, QPoint(50, 60));
+    QVariant rect = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridVisualRect", 1, QPoint(0, 1));
+    EXPECT_EQ(pos.value<QPoint>(), cannedPos);
+    EXPECT_EQ(rect.value<QRect>(), cannedRect);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushGridSize_InvokesBrokerMethod)
+{
+    QSize canned(10, 8);
+    stub.set_lamda(ADDR(CanvasViewBroker, gridSize),
+                   [&canned](CanvasViewBroker *, int) -> QSize {
+                       return canned;
+                   });
+
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_GridSize", 1);
+    EXPECT_EQ(ret.value<QSize>(), canned);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushRefreshAndUpdate_InvokesBrokerMethods)
+{
+    int refreshIdx = -1;
+    int updateIdx = -1;
+    stub.set_lamda(ADDR(CanvasViewBroker, refresh),
+                   [&refreshIdx](CanvasViewBroker *, int idx) {
+                       refreshIdx = idx;
+                   });
+    stub.set_lamda(ADDR(CanvasViewBroker, update),
+                   [&updateIdx](CanvasViewBroker *, int idx) {
+                       updateIdx = idx;
+                   });
+
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Refresh", 3);
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Update", -1);
+    EXPECT_EQ(refreshIdx, 3);
+    EXPECT_EQ(updateIdx, -1);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushSelectAndSelectedUrls_InvokesBrokerMethods)
+{
+    QList<QUrl> capturedSelect;
+    stub.set_lamda(ADDR(CanvasViewBroker, select),
+                   [&capturedSelect](CanvasViewBroker *, const QList<QUrl> &urls) {
+                       capturedSelect = urls;
+                   });
+    QList<QUrl> cannedSelected { QUrl("file:///home/s1") };
+    stub.set_lamda(ADDR(CanvasViewBroker, selectedUrls),
+                   [&cannedSelected](CanvasViewBroker *, int) -> QList<QUrl> {
+                       return cannedSelected;
+                   });
+
+    QList<QUrl> input { QUrl("file:///home/a"), QUrl("file:///home/b") };
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_Select", input);
+    QVariant ret = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasView_SelectedUrls", 0);
+    EXPECT_EQ(capturedSelect, input);
+    EXPECT_EQ(ret.value<QList<QUrl>>(), cannedSelected);
+}
+
+TEST_F(CanvasViewBrokerEventTest, SlotChannel_PushFileOperatorAndIconRect_InvokesBrokerMethods)
+{
+    QObject cannedOperator;
+    stub.set_lamda(ADDR(CanvasViewBroker, fileOperator),
+                   [&cannedOperator](CanvasViewBroker *) -> QObject * {
+                       return &cannedOperator;
+                   });
+    QRect cannedIcon(2, 3, 40, 40);
+    stub.set_lamda(ADDR(CanvasViewBroker, iconRect),
+                   [&cannedIcon](CanvasViewBroker *, int, QRect) -> QRect {
+                       return cannedIcon;
+                   });
+
+    QVariant op = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasViewPrivate_FileOperator");
+    QVariant icon = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasItemDelegate_IconRect", 1, QRect(0, 0, 100, 100));
+    EXPECT_EQ(op.value<QObject *>(), &cannedOperator);
+    EXPECT_EQ(icon.value<QRect>(), cannedIcon);
+}
+
+class CanvasModelBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        model = new CanvasProxyModel();
+        broker = new CanvasModelBroker(model);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete model;
+        stub.clear();
+    }
+
+    CanvasProxyModel *model = nullptr;
+    CanvasModelBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushUrlQueries_InvokesBrokerMethods)
+{
+    QUrl cannedRoot("file:///home");
+    stub.set_lamda(ADDR(CanvasModelBroker, rootUrl),
+                   [&cannedRoot](CanvasModelBroker *) -> QUrl {
+                       return cannedRoot;
+                   });
+    QModelIndex cannedIndex(0, 0, nullptr, model);
+    stub.set_lamda(ADDR(CanvasModelBroker, urlIndex),
+                   [&cannedIndex](CanvasModelBroker *, const QUrl &) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    stub.set_lamda(ADDR(CanvasModelBroker, index),
+                   [&cannedIndex](CanvasModelBroker *, int) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    QUrl cannedUrl("file:///home/a");
+    stub.set_lamda(ADDR(CanvasModelBroker, fileUrl),
+                   [&cannedUrl](CanvasModelBroker *, const QModelIndex &) -> QUrl {
+                       return cannedUrl;
+                   });
+    QList<QUrl> cannedFiles { QUrl("file:///home/f1") };
+    stub.set_lamda(ADDR(CanvasModelBroker, files),
+                   [&cannedFiles](CanvasModelBroker *) -> QList<QUrl> {
+                       return cannedFiles;
+                   });
+
+    QUrl input("file:///home/in");
+    QVariant root = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_RootUrl");
+    QVariant urlIndex = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_UrlIndex", input);
+    QVariant row = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Index", 0);
+    QVariant fileUrl = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_FileUrl", QVariant::fromValue(cannedIndex));
+    QVariant files = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Files");
+    EXPECT_EQ(root.value<QUrl>(), cannedRoot);
+    EXPECT_EQ(urlIndex.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(row.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(fileUrl.value<QUrl>(), cannedUrl);
+    EXPECT_EQ(files.value<QList<QUrl>>(), cannedFiles);
+}
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushFlagsAndSortSettings_InvokesBrokerMethods)
+{
+    bool cannedHidden = true;
+    stub.set_lamda(ADDR(CanvasModelBroker, showHiddenFiles),
+                   [&cannedHidden](CanvasModelBroker *) -> bool {
+                       return cannedHidden;
+                   });
+    int capturedShow = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setShowHiddenFiles),
+                   [&capturedShow](CanvasModelBroker *, bool show) {
+                       capturedShow = static_cast<int>(show);
+                   });
+    int cannedOrder = Qt::DescendingOrder;
+    stub.set_lamda(ADDR(CanvasModelBroker, sortOrder),
+                   [&cannedOrder](CanvasModelBroker *) -> int {
+                       return cannedOrder;
+                   });
+    int capturedOrder = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setSortOrder),
+                   [&capturedOrder](CanvasModelBroker *, int order) {
+                       capturedOrder = order;
+                   });
+    int cannedRole = 257;
+    stub.set_lamda(ADDR(CanvasModelBroker, sortRole),
+                   [&cannedRole](CanvasModelBroker *) -> int {
+                       return cannedRole;
+                   });
+    int capturedRole = -1;
+    int capturedRoleOrder = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, setSortRole),
+                   [&capturedRole, &capturedRoleOrder](CanvasModelBroker *, int role, int order) {
+                       capturedRole = role;
+                       capturedRoleOrder = order;
+                   });
+    int cannedRowCount = 42;
+    stub.set_lamda(ADDR(CanvasModelBroker, rowCount),
+                   [&cannedRowCount](CanvasModelBroker *) -> int {
+                       return cannedRowCount;
+                   });
+
+    QVariant hidden = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_ShowHiddenFiles");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetShowHiddenFiles", true);
+    QVariant order = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SortOrder");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetSortOrder", 1);
+    QVariant role = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SortRole");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_SetSortRole", 257, 1);
+    QVariant rows = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_RowCount");
+    EXPECT_TRUE(hidden.toBool());
+    EXPECT_EQ(capturedShow, 1);
+    EXPECT_EQ(order.toInt(), Qt::DescendingOrder);
+    EXPECT_EQ(capturedOrder, 1);
+    EXPECT_EQ(role.toInt(), 257);
+    EXPECT_EQ(capturedRole, 257);
+    EXPECT_EQ(capturedRoleOrder, 1);
+    EXPECT_EQ(rows.toInt(), 42);
+}
+
+TEST_F(CanvasModelBrokerEventTest, SlotChannel_PushDataSortRefreshFetchTake_InvokesBrokerMethods)
+{
+    QVariant cannedData("icon-name");
+    QUrl capturedDataUrl;
+    int capturedDataRole = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, data),
+                   [&cannedData, &capturedDataUrl, &capturedDataRole](CanvasModelBroker *, const QUrl &url, int role) -> QVariant {
+                       capturedDataUrl = url;
+                       capturedDataRole = role;
+                       return cannedData;
+                   });
+    bool sortInvoked = false;
+    stub.set_lamda(ADDR(CanvasModelBroker, sort),
+                   [&sortInvoked](CanvasModelBroker *) {
+                       sortInvoked = true;
+                   });
+    int capturedGlobal = -1;
+    int capturedMs = -1;
+    int capturedUpdate = -1;
+    stub.set_lamda(ADDR(CanvasModelBroker, refresh),
+                   [&capturedGlobal, &capturedMs, &capturedUpdate](CanvasModelBroker *, bool global, int ms, bool updateFile) {
+                       capturedGlobal = static_cast<int>(global);
+                       capturedMs = ms;
+                       capturedUpdate = static_cast<int>(updateFile);
+                   });
+    bool cannedFetch = true;
+    stub.set_lamda(ADDR(CanvasModelBroker, fetch),
+                   [&cannedFetch](CanvasModelBroker *, const QUrl &) -> bool {
+                       return cannedFetch;
+                   });
+    bool cannedTake = false;
+    stub.set_lamda(ADDR(CanvasModelBroker, take),
+                   [&cannedTake](CanvasModelBroker *, const QUrl &) -> bool {
+                       return cannedTake;
+                   });
+
+    QUrl input("file:///home/data.txt");
+    QVariant data = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Data", input, 257);
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Sort");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Refresh", false, 200, true);
+    QVariant fetch = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Fetch", input);
+    QVariant take = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasModel_Take", input);
+    EXPECT_EQ(capturedDataUrl, input);
+    EXPECT_EQ(capturedDataRole, 257);
+    EXPECT_EQ(data.value<QVariant>().toString(), QString("icon-name"));   // QVariant return is wrapped
+    EXPECT_TRUE(sortInvoked);
+    EXPECT_EQ(capturedGlobal, 0);
+    EXPECT_EQ(capturedMs, 200);
+    EXPECT_EQ(capturedUpdate, 1);
+    EXPECT_TRUE(fetch.toBool());
+    EXPECT_FALSE(take.toBool());
+}
+
+class CanvasManagerBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+        broker = new CanvasManagerBroker(manager);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    CanvasManagerBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasManagerBrokerEventTest, SlotChannel_PushVoidAndValueQueries_InvokesBrokerMethods)
+{
+    bool updateInvoked = false;
+    stub.set_lamda(ADDR(CanvasManagerBroker, update),
+                   [&updateInvoked](CanvasManagerBroker *) {
+                       updateInvoked = true;
+                   });
+    QStandardItemModel cannedModel;
+    stub.set_lamda(ADDR(CanvasManagerBroker, fileInfoModel),
+                   [&cannedModel](CanvasManagerBroker *) -> QAbstractItemModel * {
+                       return &cannedModel;
+                   });
+    int cannedLevel = 3;
+    stub.set_lamda(ADDR(CanvasManagerBroker, iconLevel),
+                   [&cannedLevel](CanvasManagerBroker *) -> int {
+                       return cannedLevel;
+                   });
+    int capturedLevel = -1;
+    stub.set_lamda(ADDR(CanvasManagerBroker, setIconLevel),
+                   [&capturedLevel](CanvasManagerBroker *, int lv) {
+                       capturedLevel = lv;
+                   });
+    bool cannedArrange = true;
+    stub.set_lamda(ADDR(CanvasManagerBroker, autoArrange),
+                   [&cannedArrange](CanvasManagerBroker *) -> bool {
+                       return cannedArrange;
+                   });
+    int capturedArrange = -1;
+    stub.set_lamda(ADDR(CanvasManagerBroker, setAutoArrange),
+                   [&capturedArrange](CanvasManagerBroker *, bool on) {
+                       capturedArrange = static_cast<int>(on);
+                   });
+    QUrl capturedEditUrl;
+    stub.set_lamda(ADDR(CanvasManagerBroker, edit),
+                   [&capturedEditUrl](CanvasManagerBroker *, const QUrl &url) {
+                       capturedEditUrl = url;
+                   });
+
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_Update");
+    QVariant model = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_FileInfoModel");
+    QVariant level = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_IconLevel");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SetIconLevel", 4);
+    QVariant arrange = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_AutoArrange");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SetAutoArrange", true);
+    QUrl editUrl("file:///home/edit.txt");
+    dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_Edit", editUrl);
+    EXPECT_TRUE(updateInvoked);
+    EXPECT_EQ(model.value<QAbstractItemModel *>(), &cannedModel);
+    EXPECT_EQ(level.toInt(), 3);
+    EXPECT_EQ(capturedLevel, 4);
+    EXPECT_TRUE(arrange.toBool());
+    EXPECT_EQ(capturedArrange, 1);
+    EXPECT_EQ(capturedEditUrl, editUrl);
+}
+
+TEST_F(CanvasManagerBrokerEventTest, SlotChannel_PushViewAndSelectionModel_InvokesBrokerMethods)
+{
+    QAbstractItemView *cannedView = reinterpret_cast<QAbstractItemView *>(0x10);
+    stub.set_lamda(ADDR(CanvasManagerBroker, view),
+                   [cannedView](CanvasManagerBroker *, int) -> QAbstractItemView * {
+                       return cannedView;
+                   });
+    QItemSelectionModel *cannedSelection = reinterpret_cast<QItemSelectionModel *>(0x20);
+    stub.set_lamda(ADDR(CanvasManagerBroker, selectionModel),
+                   [cannedSelection](CanvasManagerBroker *) -> QItemSelectionModel * {
+                       return cannedSelection;
+                   });
+
+    QVariant view = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_View", 1);
+    QVariant selection = dpfSlotChannel->push(kCanvasSpace, "slot_CanvasManager_SelectionModel");
+    EXPECT_EQ(view.value<QAbstractItemView *>(), cannedView);
+    EXPECT_EQ(selection.value<QItemSelectionModel *>(), cannedSelection);
+}
+
+class FileInfoModelBrokerEventTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        model = new FileInfoModel();
+        broker = new FileInfoModelBroker(model);
+        ASSERT_TRUE(broker->init());
+    }
+
+    void TearDown() override
+    {
+        delete broker;
+        delete model;
+        stub.clear();
+    }
+
+    FileInfoModel *model = nullptr;
+    FileInfoModelBroker *broker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(FileInfoModelBrokerEventTest, SlotChannel_PushUrlAndIndexQueries_InvokesBrokerMethods)
+{
+    QUrl cannedRoot("file:///home");
+    stub.set_lamda(ADDR(FileInfoModelBroker, rootUrl),
+                   [&cannedRoot](FileInfoModelBroker *) -> QUrl {
+                       return cannedRoot;
+                   });
+    QModelIndex cannedRootIndex(0, 0, nullptr, model);
+    stub.set_lamda(ADDR(FileInfoModelBroker, rootIndex),
+                   [&cannedRootIndex](FileInfoModelBroker *) -> QModelIndex {
+                       return cannedRootIndex;
+                   });
+    QModelIndex cannedIndex(1, 0, nullptr, model);
+    stub.set_lamda(ADDR(FileInfoModelBroker, urlIndex),
+                   [&cannedIndex](FileInfoModelBroker *, const QUrl &) -> QModelIndex {
+                       return cannedIndex;
+                   });
+    QUrl cannedUrl("file:///home/index-url");
+    stub.set_lamda(ADDR(FileInfoModelBroker, indexUrl),
+                   [&cannedUrl](FileInfoModelBroker *, const QModelIndex &) -> QUrl {
+                       return cannedUrl;
+                   });
+    QList<QUrl> cannedFiles { QUrl("file:///home/x") };
+    stub.set_lamda(ADDR(FileInfoModelBroker, files),
+                   [&cannedFiles](FileInfoModelBroker *) -> QList<QUrl> {
+                       return cannedFiles;
+                   });
+    int cannedState = 2;
+    stub.set_lamda(ADDR(FileInfoModelBroker, modelState),
+                   [&cannedState](FileInfoModelBroker *) -> int {
+                       return cannedState;
+                   });
+
+    QUrl input("file:///home/q");
+    QVariant root = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_RootUrl");
+    QVariant rootIndex = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_RootIndex");
+    QVariant urlIndex = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_UrlIndex", input);
+    QVariant indexUrl = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_IndexUrl", QVariant::fromValue(cannedIndex));
+    QVariant files = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_Files");
+    QVariant state = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_ModelState");
+    EXPECT_EQ(root.value<QUrl>(), cannedRoot);
+    EXPECT_EQ(rootIndex.value<QModelIndex>(), cannedRootIndex);
+    EXPECT_EQ(urlIndex.value<QModelIndex>(), cannedIndex);
+    EXPECT_EQ(indexUrl.value<QUrl>(), cannedUrl);
+    EXPECT_EQ(files.value<QList<QUrl>>(), cannedFiles);
+    EXPECT_EQ(state.toInt(), 2);
+}
+
+TEST_F(FileInfoModelBrokerEventTest, SlotChannel_PushFileInfoRefreshUpdateFile_InvokesBrokerMethods)
+{
+    FileInfoPointer cannedInfo;
+    stub.set_lamda(ADDR(FileInfoModelBroker, fileInfo),
+                   [&cannedInfo](FileInfoModelBroker *, const QModelIndex &) -> FileInfoPointer {
+                       return cannedInfo;
+                   });
+    QModelIndex capturedRefresh;
+    stub.set_lamda(ADDR(FileInfoModelBroker, refresh),
+                   [&capturedRefresh](FileInfoModelBroker *, const QModelIndex &parent) {
+                       capturedRefresh = parent;
+                   });
+    QUrl capturedUpdateUrl;
+    stub.set_lamda(ADDR(FileInfoModelBroker, updateFile),
+                   [&capturedUpdateUrl](FileInfoModelBroker *, const QUrl &url) {
+                       capturedUpdateUrl = url;
+                   });
+
+    QModelIndex input(3, 0, nullptr, model);
+    QVariant info = dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_FileInfo", QVariant::fromValue(input));
+    dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_Refresh", QVariant::fromValue(input));
+    QUrl updateUrl("file:///home/update.txt");
+    dpfSlotChannel->push(kCanvasSpace, "slot_FileInfoModel_UpdateFile", updateUrl);
+    EXPECT_EQ(info.value<FileInfoPointer>(), cannedInfo);
+    EXPECT_EQ(capturedRefresh, input);
+    EXPECT_EQ(capturedUpdateUrl, updateUrl);
+}
+
+class CanvasManagerSignalTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        installCanvasTestConverter();
+        manager = new CanvasManager();
+    }
+
+    void TearDown() override
+    {
+        // Remove the handlers registered by the tests so later suites never
+        // dispatch into stale objects.
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_GeometryChanged", manager, &CanvasManager::onGeometryChanged);
+        dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged", manager, &CanvasManager::onGeometryChanged);
+        delete manager;
+        stub.clear();
+    }
+
+    CanvasManager *manager = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishWindowAboutToBeBuilded_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onDetachWindows),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded", manager, &CanvasManager::onDetachWindows));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishWindowBuilded_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onCanvasBuild),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowBuilded"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("ddplugin_core", "signal_DesktopFrame_WindowBuilded", manager, &CanvasManager::onCanvasBuild));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishGeometryChanged_InvokesHandler)
+{
+    int invoked = 0;
+    stub.set_lamda(ADDR(CanvasManager, onGeometryChanged),
+                   [&invoked](CanvasManager *) {
+                       ++invoked;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_GeometryChanged", manager, &CanvasManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged", manager, &CanvasManager::onGeometryChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_GeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged"));
+    EXPECT_EQ(invoked, 2);
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishTrashStateChanged_InvokesHandler)
+{
+    bool invoked = false;
+    stub.set_lamda(ADDR(CanvasManager, onTrashStateChanged),
+                   [&invoked](CanvasManager *) {
+                       invoked = true;
+                   });
+
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", manager, &CanvasManager::onTrashStateChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    EXPECT_TRUE(invoked);
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", manager, &CanvasManager::onTrashStateChanged));
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_RealInitSubscriptions_AllHandlersInvokedAndRemoved)
+{
+    // Arrange: run the production init() so the subscribe sites inside
+    // canvasmanager.cpp register the real handlers, with heavy internals
+    // stubbed away.
+    int detachCount = 0;
+    int buildCount = 0;
+    int geometryCount = 0;
+    int trashCount = 0;
+    stub.set_lamda(ADDR(CanvasManager, onDetachWindows),
+                   [&detachCount](CanvasManager *) { ++detachCount; });
+    stub.set_lamda(ADDR(CanvasManager, onCanvasBuild),
+                   [&buildCount](CanvasManager *) { ++buildCount; });
+    stub.set_lamda(ADDR(CanvasManager, onGeometryChanged),
+                   [&geometryCount](CanvasManager *) { ++geometryCount; });
+    stub.set_lamda(ADDR(CanvasManager, onTrashStateChanged),
+                   [&trashCount](CanvasManager *) { ++trashCount; });
+    int recentCount = 0;
+    stub.set_lamda(ADDR(CanvasRecentProxy, handleReloadRecentFiles),
+                   [&recentCount](CanvasRecentProxy *, const QList<QUrl> &, bool, const QString &) { ++recentCount; });
+    stub.set_lamda(ADDR(CanvasManagerPrivate, initModel), [](CanvasManagerPrivate *) { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ADDR(CanvasManagerPrivate, initSetting), [](CanvasManagerPrivate *) { __DBG_STUB_INVOKE__ });
+
+    manager->init();
+
+    // Act: fire every subscribed signal through the real dispatcher.
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowAboutToBeBuilded"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_WindowBuilded"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_GeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("ddplugin_core", "signal_DesktopFrame_AvailableGeometryChanged"));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    QList<QUrl> urls { QUrl("file:///home/r") };
+    EXPECT_TRUE(dpfSignalDispatcher->publish(static_cast<int>(GlobalEventType::kMoveToTrashResult), urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(static_cast<int>(GlobalEventType::kDeleteFilesResult), urls, true, QString()));
+
+    // Assert
+    EXPECT_EQ(detachCount, 1);
+    EXPECT_EQ(buildCount, 1);
+    EXPECT_EQ(geometryCount, 2);
+    EXPECT_EQ(trashCount, 1);
+    EXPECT_EQ(recentCount, 2);
+}
+
+TEST_F(CanvasManagerSignalTest, Dispatcher_PublishJobResults_InvokesRecentProxyHandler)
+{
+    CanvasRecentProxy proxy;
+    QList<QUrl> capturedUrls;
+    bool capturedOk = false;
+    QString capturedMsg;
+    stub.set_lamda(ADDR(CanvasRecentProxy, handleReloadRecentFiles),
+                   [&capturedUrls, &capturedOk, &capturedMsg](CanvasRecentProxy *, const QList<QUrl> &urls, bool ok, const QString &errMsg) {
+                       capturedUrls = urls;
+                       capturedOk = ok;
+                       capturedMsg = errMsg;
+                   });
+
+    const int movedToTrash = static_cast<int>(GlobalEventType::kMoveToTrashResult);
+    const int deleteFiles = static_cast<int>(GlobalEventType::kDeleteFilesResult);
+    QList<QUrl> input { QUrl("file:///home/recent.txt") };
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(movedToTrash, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(movedToTrash, input, true, QString("done")));
+    EXPECT_EQ(capturedUrls, input);
+    EXPECT_TRUE(capturedOk);
+    EXPECT_EQ(capturedMsg, QString("done"));
+
+    capturedUrls.clear();
+    EXPECT_TRUE(dpfSignalDispatcher->subscribe(deleteFiles, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(deleteFiles, input, false, QString("")));
+    EXPECT_EQ(capturedUrls, input);
+    EXPECT_FALSE(capturedOk);
+
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(movedToTrash, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe(deleteFiles, &proxy, &CanvasRecentProxy::handleReloadRecentFiles));
+}


### PR DESCRIPTION
## Summary
- Add event-dispatch tests for all 5 canvas brokers (CanvasGrid/View/Model/ManagerBroker, FileInfoModelBroker) via real init() + typed push, plus CanvasManager signal subscribe/publish/unsubscribe and a real CanvasManager::init() dispatch test
- Add CanvasView event tests covering the 12 previously uncovered functions (paint/wheel/key/mouse/drag/focus/contextMenu, edit, startDrag, keyboardSearch, selection, index helpers)

## Verification
- ut-ddplugin-canvas: 771/771 passed

## Coverage impact
- canvasview.cpp: 67/67 functions (100%)
- eventhelper.h ddplugin_canvas instantiations: fully covered (remaining records are gcov duplicate-counter artifacts)

Replaces the canvas part of closed #4441. Base: c13ee5bb

## Summary by Sourcery

Increase ddplugin-canvas test coverage by validating CanvasView behavior and end-to-end broker and manager event dispatch.

Enhancements:
- Expand ddplugin-canvas unit-test coverage for CanvasView event handling, editing, input, drag-and-drop, focus, context-menu, selection, and index operations.
- Exercise canvas broker slot dispatch and CanvasManager signal subscription, publication, unsubscription, and initialization paths through the real event framework.

Tests:
- Add comprehensive event-dispatch tests for the CanvasGrid, CanvasView, CanvasModel, CanvasManager, and FileInfoModel brokers.
- Add CanvasView event and helper tests covering all previously uncovered functions and validate complete function coverage.