### PR TITLE
test: add event flow and view behavior tests for dfmplugin-workspace

### DIFF
--- a/autotests/plugins/dfmplugin-workspace/events/test_workspaceeventflow.cpp
+++ b/autotests/plugins/dfmplugin-workspace/events/test_workspaceeventflow.cpp
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "stubext.h"
+
+#include "events/workspaceeventreceiver.h"
+#include "utils/workspacehelper.h"
+#include "views/fileview.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QVariant>
+#include <QMap>
+#include <QDir>
+#include <QVariantList>
+#include <QVariantMap>
+
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_workspace;
+
+namespace {
+constexpr char kSpace[] { "dfmplugin_workspace" };
+
+// All topics the receiver connects to must be registered on the framework's
+// event converter, otherwise connect/push resolve to an invalid event type.
+void registerWorkspaceTopics()
+{
+    static bool registered = false;
+    if (registered)
+        return;
+    registered = true;
+
+    auto *event = dpfEvent;
+    const char *slotTopics[] = {
+        "slot_RegisterFileView",
+        "slot_RegisterMenuScene",
+        "slot_FindMenuScene",
+        "slot_RegisterCustomTopWidget",
+        "slot_ShowViewHint",
+        "slot_RegisterGroupStrategy",
+        "slot_RegisteredGroupStrategies",
+        "slot_GetCustomTopWidgetVisible",
+        "slot_ShowCustomTopWidget",
+        "slot_CheckSchemeViewIsFileView",
+        "slot_RefreshDir",
+        "slot_RegisterFocusFileViewDisabled",
+        "slot_View_SetCustomViewProperty",
+        "slot_View_GetVisualGeometry",
+        "slot_View_GetViewItemRect",
+        "slot_View_GetCurrentViewMode",
+        "slot_View_GetDefaultViewMode",
+        "slot_View_GetSelectedUrls",
+        "slot_View_SelectFiles",
+        "slot_View_SelectAll",
+        "slot_View_ReverseSelect",
+        "slot_View_SetSelectionMode",
+        "slot_View_SetEnabledSelectionModes",
+        "slot_View_SetDragEnabled",
+        "slot_View_SetDragDropMode",
+        "slot_View_SetReadOnly",
+        "slot_View_SetFilter",
+        "slot_View_GetFilter",
+        "slot_View_ClosePersistentEditor",
+        "slot_View_SetAlwaysOpenInCurrentWindow",
+        "slot_Model_SetCustomFilterData",
+        "slot_Model_SetCustomFilterCallback",
+        "slot_Model_RegisterRoutePrehandle",
+        "slot_Model_FileUpdate",
+        "slot_Model_SetNameFilter",
+        "slot_Model_GetNameFilter",
+        "slot_Model_CurrentSortRole",
+        "slot_Model_ColumnDisplayName",
+        "slot_Model_ColumnRoles",
+        "slot_Model_SetSort",
+        "slot_Model_CurrentGroupStrategy",
+        "slot_Model_SetGroup",
+        "slot_Model_RegisterDataCache",
+        "slot_View_AboutToChangeViewWidth",
+        "slot_View_GetColumnWidth",
+        "slot_Model_RegisterLoadStrategy",
+        "slot_Model_GetCurrentBusy",
+    };
+    for (const char *topic : slotTopics)
+        event->registerEventType(EventStratege::kSlot, kSpace, topic);
+
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Created");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Removed");
+    event->registerEventType(EventStratege::kSignal, "dfmplugin_titlebar", "signal_Tab_Changed");
+    event->registerEventType(EventStratege::kSignal, kSpace, "signal_View_HeaderViewSectionChanged");
+}
+}   // namespace
+
+class WorkspaceEventFlowTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        registerWorkspaceTopics();
+        WorkspaceEventReceiver::instance()->initConnection();
+        channel = dpfSlotChannel;
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    EventChannelManager *channel = nullptr;
+};
+
+// --- registration slots ---
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterFileView_CheckSchemeReturnsTrue)
+{
+    QVariant voidRet = channel->push(kSpace, "slot_RegisterFileView", QString("flowfile"));
+    EXPECT_FALSE(voidRet.isValid());
+
+    QVariant ret = channel->push(kSpace, "slot_CheckSchemeViewIsFileView", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterMenuScene_FindMenuSceneReturnsScene)
+{
+    channel->push(kSpace, "slot_RegisterMenuScene", QString("flowfile"), QString("FlowScene"));
+
+    QVariant ret = channel->push(kSpace, "slot_FindMenuScene", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toString(), QString("FlowScene"));
+    EXPECT_EQ(channel->push(kSpace, "slot_FindMenuScene", QString("unregistered")).toString(), QString(""));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterFocusFileViewDisabled_DoesNotCrash)
+{
+    QVariant ret = channel->push(kSpace, "slot_RegisterFocusFileViewDisabled", QString("flowfile"));
+    EXPECT_FALSE(ret.isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterCustomTopWidget_GetVisibleReturnsFalse)
+{
+    QVariantMap dataMap;
+    dataMap.insert("scheme", "flowscheme");
+    channel->push(kSpace, "slot_RegisterCustomTopWidget", dataMap);
+
+    QVariant ret = channel->push(kSpace, "slot_GetCustomTopWidgetVisible", quint64(1), QString("flowscheme"));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_FALSE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ShowViewHint_NoWorkspace_ReturnsNull)
+{
+    QVariantMap content;
+    QVariant ret = channel->push(kSpace, "slot_ShowViewHint", quint64(1), content);
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.value<QObject *>() == nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisteredGroupStrategies_ReturnsVariantList)
+{
+    QVariant ret = channel->push(kSpace, "slot_RegisteredGroupStrategies", QString());
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.canConvert<QVariantList>());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterGroupStrategy_EmptyNameIsRejected)
+{
+    QVariantMap dataMap;   // no name: handler rejects and returns nothing
+    QVariant ret = channel->push(kSpace, "slot_RegisterGroupStrategy", dataMap);
+    EXPECT_FALSE(ret.isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterGroupStrategy_WithFactoryAndName_Registers)
+{
+    StrategyFactory factory = [](QObject *) -> DFMBASE_NAMESPACE::AbstractGroupStrategy * { return nullptr; };
+    QVariantMap dataMap;
+    dataMap.insert(PropertyKey::kGroupStrategyName, QString("FlowTimeStrategy"));
+    dataMap.insert(PropertyKey::kGroupStrategyDisplayName, QString("Flow time"));
+    dataMap.insert(PropertyKey::kGroupStrategyFactory, QVariant::fromValue(factory));
+
+    QVariant ret = channel->push(kSpace, "slot_RegisterGroupStrategy", dataMap);
+    EXPECT_FALSE(ret.isValid());
+
+    QVariantList registered = channel->push(kSpace, "slot_RegisteredGroupStrategies", QString("flowfile"))
+                                      .value<QVariantList>();
+    bool found = false;
+    for (const QVariant &entry : registered)
+        found = found || entry.toMap().value("name").toString() == QString("FlowTimeStrategy");
+    EXPECT_TRUE(found);
+    EXPECT_GE(registered.size(), 1);
+}
+
+// --- view getter slots (no window registered) ---
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetters_UnknownWindow_ReturnDefaults)
+{
+    EXPECT_EQ(channel->push(kSpace, "slot_View_GetCurrentViewMode", quint64(42)).value<ViewMode>(),
+              ViewMode::kNoneMode);
+    EXPECT_EQ(channel->push(kSpace, "slot_View_GetVisualGeometry", quint64(42)).toRectF(),
+              QRectF(0, 0, 0, 0));
+    EXPECT_TRUE(channel->push(kSpace, "slot_View_GetSelectedUrls", quint64(42)).value<QList<QUrl>>().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetViewItemRect_UnknownWindow_ReturnsEmptyRect)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetViewItemRect", quint64(42),
+                                 QUrl::fromLocalFile("/tmp/flow/a.txt"),
+                                 QVariant::fromValue(ItemRoles::kItemIconRole));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toRectF(), QRectF(0, 0, 0, 0));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelGetters_UnknownWindow_ReturnDefaults)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_GetCurrentBusy", quint64(42)).toBool());
+    EXPECT_EQ(channel->push(kSpace, "slot_Model_CurrentSortRole", quint64(42)).value<ItemRoles>(),
+              ItemRoles::kItemUnknowRole);
+    EXPECT_TRUE(channel->push(kSpace, "slot_Model_ColumnRoles", quint64(42)).value<QList<ItemRoles>>().isEmpty());
+    EXPECT_EQ(channel->push(kSpace, "slot_Model_CurrentGroupStrategy", quint64(42)).toString(), QString(""));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetFilter_UnknownWindow_ReturnsNoFilter)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetFilter", quint64(42));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toInt(), static_cast<int>(QDir::NoFilter));
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelGetNameFilter_UnknownWindow_ReturnsEmpty)
+{
+    QVariant ret = channel->push(kSpace, "slot_Model_GetNameFilter", quint64(42));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toStringList().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelColumnDisplayName_UnknownWindow_ReturnsEmpty)
+{
+    QVariant ret = channel->push(kSpace, "slot_Model_ColumnDisplayName", quint64(42),
+                                 QVariant::fromValue(ItemRoles::kItemFileDisplayNameRole));
+    EXPECT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toString().isEmpty());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetColumnWidth_UnknownWindow_ReturnsZero)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetColumnWidth", quint64(42),
+                                 QVariant::fromValue(ItemRoles::kItemFileSizeRole));
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_EQ(ret.toInt(), 0);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewGetDefaultViewMode_FallsBackToValidMode)
+{
+    QVariant ret = channel->push(kSpace, "slot_View_GetDefaultViewMode", QString("flowfile"));
+    ASSERT_TRUE(ret.isValid());
+    ViewMode mode = ret.value<ViewMode>();
+    EXPECT_GE(static_cast<int>(mode), static_cast<int>(ViewMode::kIconMode));
+    EXPECT_LE(static_cast<int>(mode), static_cast<int>(ViewMode::kAllViewMode));
+}
+
+// --- setter slots on unknown windows (must not crash, return nothing) ---
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewSetters_UnknownWindow_ReturnVoid)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow/a.txt") };
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SelectFiles", quint64(42), urls).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SelectAll", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_ReverseSelect", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetAlwaysOpenInCurrentWindow", quint64(42)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_ClosePersistentEditor", quint64(42)).isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewModeSetters_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetSelectionMode", quint64(42),
+                               QVariant::fromValue(QAbstractItemView::SingleSelection)).isValid());
+    QList<int> modes = { int(QAbstractItemView::ExtendedSelection) };
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetEnabledSelectionModes", quint64(42), modes).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetDragEnabled", quint64(42), true).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetDragDropMode", quint64(42),
+                               QVariant::fromValue(QAbstractItemView::DragDrop)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetReadOnly", quint64(42), true).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelSetters_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetSort", quint64(42),
+                               QVariant::fromValue(ItemRoles::kItemFileSizeRole)).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetGroup", quint64(42), QString("TimeModified")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetCustomFilterData", quint64(42),
+                               QUrl::fromLocalFile("/tmp/flow"), QVariant("kw")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetCustomFilterCallback", quint64(42),
+                               QUrl::fromLocalFile("/tmp/flow"), QVariant()).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_RegisterDataCache", QString("flowfile")).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ModelFileUpdate_AndFilterSetters_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_FileUpdate", QUrl::fromLocalFile("/tmp/flow/a.txt")).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetFilter", quint64(42),
+                               QVariant::fromValue(int(QDir::Files))).isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_SetNameFilter", quint64(42), QStringList() << "*.txt").isValid());
+    EXPECT_FALSE(channel->push(kSpace, "slot_Model_RegisterLoadStrategy", QString("flowfile"),
+                               QVariant::fromValue(DirectoryLoadStrategy::kCreateNew)).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ViewAboutToChangeViewWidth_AndCustomProperty_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_AboutToChangeViewWidth", quint64(42), 30).isValid());
+
+    QVariantMap properties;
+    properties.insert("allowChangeListHeight", true);
+    EXPECT_FALSE(channel->push(kSpace, "slot_View_SetCustomViewProperty", QString("flowfile"), properties).isValid());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_ShowCustomTopWidget_UnknownWindow_ReturnVoid)
+{
+    EXPECT_FALSE(channel->push(kSpace, "slot_ShowCustomTopWidget", quint64(42), QString("flowscheme"), true).isValid());
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RegisterRoutePrehandle_ReturnsRegistrationResult)
+{
+    // QVariant cannot carry the std::function, handler receives an empty one
+    QVariant ret = channel->push(kSpace, "slot_Model_RegisterRoutePrehandle", QString("flowfile"), QVariant());
+    ASSERT_TRUE(ret.isValid());
+    EXPECT_TRUE(ret.toBool());
+}
+
+TEST_F(WorkspaceEventFlowTest, Push_RefreshDir_EmptyWorkspaces_ReturnVoid)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow") };
+    EXPECT_FALSE(channel->push(kSpace, "slot_RefreshDir", urls).isValid());
+}
+
+// --- signal dispatch through EventDispatcherManager ---
+
+TEST_F(WorkspaceEventFlowTest, Publish_TrashStateChanged_InvokesHelperSignal)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged"));
+    EXPECT_NE(WorkspaceHelper::instance(), nullptr);
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_TabSignals_InvokedWithoutCrash)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Created", quint64(1), QString("tab-1")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Removed", quint64(1), QString("tab-1"), QString("tab-2")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Changed", quint64(1), QString("tab-2")));
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_GlobalEventTypes_InvokedWithoutCrash)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/flow/a.txt") };
+    QMap<QUrl, QUrl> renamed;
+    renamed.insert(QUrl::fromLocalFile("/tmp/flow/a.txt"), QUrl::fromLocalFile("/tmp/flow/b.txt"));
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kSwitchViewMode, quint64(1), static_cast<int>(ViewMode::kListMode)));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCopyResult, urls, urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, urls, false, QString("err")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, true, QString()));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, urls, false, QString("err")));
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1), renamed, false, QString("err")));
+}
+
+TEST_F(WorkspaceEventFlowTest, Publish_HeaderViewSectionChanged_InvokesFileViewSlot)
+{
+    FileView view(QUrl::fromLocalFile("/tmp/flow"));
+    view.setViewMode(Global::ViewMode::kListMode);
+
+    EXPECT_NO_FATAL_FAILURE(view.onHeaderSectionMoved(0, 0, 1));   // publishes the signal
+    EXPECT_TRUE(dpfSignalDispatcher->publish(kSpace, "signal_View_HeaderViewSectionChanged", view.rootUrl()));
+    EXPECT_EQ(view.currentViewMode(), Global::ViewMode::kListMode);
+}
+
+TEST_F(WorkspaceEventFlowTest, Unsubscribe_TrashAndTabSignals_RemoveHandlers)
+{
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged",
+                                                 WorkspaceHelper::instance(), &WorkspaceHelper::trashStateChanged));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Created",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabCreated));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Removed",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabRemoved));
+    EXPECT_TRUE(dpfSignalDispatcher->unsubscribe("dfmplugin_titlebar", "signal_Tab_Changed",
+                                                 WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabChanged));
+
+    // handlers removed, but publish still dispatches without crashing
+    EXPECT_TRUE(dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Created", quint64(9), QString("tab-9")));
+}

--- a/autotests/plugins/dfmplugin-workspace/test_fileviewsorter.cpp
+++ b/autotests/plugins/dfmplugin-workspace/test_fileviewsorter.cpp
@@ -3,13 +3,50 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <gtest/gtest.h>
-#include <QUrl>
-#include <QList>
+
+#include "stubext.h"
 
 #include "utils/fileviewsorter.h"
+#include "models/fileitemdata.h"
+
+#include <dfm-base/interfaces/sortfileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <QUrl>
+#include <QList>
+#include <QHash>
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QFileInfo>
+
+#include <functional>
 
 using namespace dfmplugin_workspace;
 using namespace dfmbase::Global;
+using namespace dfmbase;
+
+namespace {
+FileItemDataPointer makeSortItem(const QUrl &url, bool isDir, qint64 size, qint64 lastModified)
+{
+    auto *info = new SortFileInfo();
+    info->setUrl(url);
+    info->setDir(isDir);
+    info->setFile(!isDir);
+    info->setSize(size);
+    info->setLastModifiedTime(lastModified);
+    return FileItemDataPointer(new FileItemData(SortInfoPointer(info), nullptr));
+}
+
+QList<QUrl> toUrls(const char *const *names, int count)
+{
+    QList<QUrl> urls;
+    for (int i = 0; i < count; ++i)
+        urls << QUrl::fromLocalFile(QString("/ut-sorter/%1").arg(names[i]));
+    return urls;
+}
+}   // namespace
 
 class FileViewSorterTest : public testing::Test
 {
@@ -148,4 +185,388 @@ TEST_F(FileViewSorterTest, Reverse_SizeRole_NoCrash)
 
     QList<QUrl> urls = {QUrl("file:///a"), QUrl("file:///b"), QUrl("file:///c")};
     EXPECT_NO_FATAL_FAILURE(sorter->reverse(urls));
+}
+
+// --- sort (mixed / separated) ---
+
+TEST_F(FileViewSorterTest, Sort_MixedFileNameAscending_OrdersByName)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    sorter->setContext(ctx);
+
+    const char *names[] = { "c.txt", "a.txt", "b.txt" };
+    QList<QUrl> result = sorter->sort(toUrls(names, 3));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).fileName(), QString("a.txt"));
+    EXPECT_EQ(result.at(2).fileName(), QString("c.txt"));
+}
+
+TEST_F(FileViewSorterTest, Sort_MixedFileNameDescending_ReversesOrder)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::DescendingOrder;
+    sorter->setContext(ctx);
+
+    const char *names[] = { "c.txt", "a.txt", "b.txt" };
+    QList<QUrl> result = sorter->sort(toUrls(names, 3));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).fileName(), QString("c.txt"));
+    EXPECT_EQ(result.at(2).fileName(), QString("a.txt"));
+}
+
+TEST_F(FileViewSorterTest, Sort_SeparatedMode_DirectoriesBeforeFiles)
+{
+    QHash<QString, FileItemDataPointer> items;
+    auto add = [&items](const QString &name, bool dir) {
+        QUrl url = QUrl::fromLocalFile("/ut-sorter/" + name);
+        items.insert(name, makeSortItem(url, dir, 10, 1000));
+        return url;
+    };
+    QUrl dirZ = add("zdir", true);
+    QUrl dirA = add("adir", true);
+    QUrl fileB = add("bfile", false);
+    QUrl fileA = add("afile", false);
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = false;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ dirZ, dirA, fileB, fileA });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirA);
+    EXPECT_EQ(result.at(1), dirZ);
+    EXPECT_EQ(result.at(2), fileA);
+    EXPECT_EQ(result.at(3), fileB);
+}
+
+TEST_F(FileViewSorterTest, Sort_SizeRoleAscending_DirectoryFirstThenBySize)
+{
+    QUrl dirUrl = QUrl::fromLocalFile("/ut-sorter/dirA");
+    QUrl f100 = QUrl::fromLocalFile("/ut-sorter/f100.bin");
+    QUrl f500 = QUrl::fromLocalFile("/ut-sorter/f500.bin");
+    QUrl f050 = QUrl::fromLocalFile("/ut-sorter/f050.bin");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("dirA", makeSortItem(dirUrl, true, 0, 0));
+    items.insert("f100.bin", makeSortItem(f100, false, 100, 0));
+    items.insert("f500.bin", makeSortItem(f500, false, 500, 0));
+    items.insert("f050.bin", makeSortItem(f050, false, 50, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::Size;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ f500, dirUrl, f100, f050 });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirUrl);   // directory always prefixed first on ascending
+    EXPECT_EQ(result.at(1), f050);
+    EXPECT_EQ(result.at(3), f500);
+}
+
+TEST_F(FileViewSorterTest, Sort_LastModifiedRole_OrdersByTimeWithFallback)
+{
+    QUrl early = QUrl::fromLocalFile("/ut-sorter/early.txt");
+    QUrl late = QUrl::fromLocalFile("/ut-sorter/late.txt");
+    QUrl noTime = QUrl::fromLocalFile("/ut-sorter/notime.txt");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("early.txt", makeSortItem(early, false, 1, 1000));
+    items.insert("late.txt", makeSortItem(late, false, 1, 2000000000));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::LastModified;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ late, noTime, early });
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0), noTime);   // fallback default time "0000/00/00" sorts first
+    EXPECT_EQ(result.at(1), early);
+    EXPECT_EQ(result.at(2), late);
+}
+
+TEST_F(FileViewSorterTest, Sort_TimeRolesWithoutCallback_UseDefaultTime)
+{
+    const FileViewSorter::SortRole roles[] = {
+        FileViewSorter::SortRole::LastCreated,
+        FileViewSorter::SortRole::LastRead,
+        FileViewSorter::SortRole::DeletionDate
+    };
+    for (auto role : roles) {
+        FileViewSorter::SortContext ctx;
+        ctx.isMixDirAndFile = true;
+        ctx.role = role;
+        sorter->setContext(ctx);
+
+        const char *names[] = { "x.txt", "a.txt" };
+        QList<QUrl> result = sorter->sort(toUrls(names, 2));
+        ASSERT_EQ(result.size(), 2) << "role=" << int(role);
+        // all keys share the same fallback time, secondary key is the file name
+        EXPECT_EQ(result.at(0).fileName(), QString("a.txt")) << "role=" << int(role);
+    }
+}
+
+TEST_F(FileViewSorterTest, Sort_FilePathRole_UsesLocalPathAsKey)
+{
+    QUrl urlCa = QUrl::fromLocalFile("/ut-sorter/c/a");
+    QUrl urlAb = QUrl::fromLocalFile("/ut-sorter/a/b");
+    QUrl urlBc = QUrl::fromLocalFile("/ut-sorter/b/c");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("a", makeSortItem(urlAb, false, 1, 0));
+    items.insert("b", makeSortItem(urlBc, false, 1, 0));
+    items.insert("c", makeSortItem(urlCa, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FilePath;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QString(QFileInfo(url.path()).fileName()));
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlCa, urlAb, urlBc });
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result.at(0).path(), QString("/ut-sorter/a/b"));
+    EXPECT_EQ(result.at(2).path(), QString("/ut-sorter/c/a"));
+}
+
+TEST_F(FileViewSorterTest, Sort_OriginalPathRoleWithoutInfo_FallsBackToUrlPath)
+{
+    QUrl urlY = QUrl::fromLocalFile("/ut-sorter/y");
+    QUrl urlZ = QUrl::fromLocalFile("/ut-sorter/z");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("y", makeSortItem(urlY, false, 1, 0));
+    items.insert("z", makeSortItem(urlZ, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::OriginalPath;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QString(QFileInfo(url.path()).fileName()));
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlZ, urlY });
+
+    ASSERT_EQ(result.size(), 2);
+    // no trash originalUrl data: both keys are empty, input order is preserved
+    EXPECT_EQ(result.at(0), urlZ);
+    EXPECT_EQ(result.at(1), urlY);
+}
+
+TEST_F(FileViewSorterTest, Sort_MimeTypeRoleNoInfo_RanksUnknownGroupBytName)
+{
+    QUrl urlB = QUrl::fromLocalFile("/ut-sorter/b.doc");
+    QUrl urlA = QUrl::fromLocalFile("/ut-sorter/a.doc");
+    QUrl urlC = QUrl::fromLocalFile("/ut-sorter/c.doc");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("b.doc", makeSortItem(urlB, false, 1, 0));
+    items.insert("a.doc", makeSortItem(urlA, false, 1, 0));
+    items.insert("c.doc", makeSortItem(urlC, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::MimeType;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlC, urlA });
+
+    ASSERT_EQ(result.size(), 3);
+    // no FileInfo and no SortInfo dates: all unknown mime, tie broken by name
+    EXPECT_EQ(result.at(0), urlA);
+    EXPECT_EQ(result.at(2), urlC);
+}
+
+TEST_F(FileViewSorterTest, Sort_MimeTypeRoleRealFiles_UsesAccurateMimeName)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString txtPath = dir.filePath("note.txt");
+    QString pngPath = dir.filePath("pic.png");
+    QFile txtFile(txtPath);
+    QFile pngFile(pngPath);
+    ASSERT_TRUE(txtFile.open(QIODevice::WriteOnly));
+    ASSERT_TRUE(pngFile.open(QIODevice::WriteOnly));
+    txtFile.close();
+    pngFile.close();
+
+    QUrl txtUrl = QUrl::fromLocalFile(txtPath);
+    QUrl pngUrl = QUrl::fromLocalFile(pngPath);
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("note.txt", makeSortItem(txtUrl, false, 1, 1000));
+    items.insert("pic.png", makeSortItem(pngUrl, false, 1, 1000));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::MimeType;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.fileName()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ pngUrl, txtUrl });
+
+    ASSERT_EQ(result.size(), 2);
+    // image group rank (2) sorts after text group rank (1)
+    EXPECT_EQ(result.at(0), txtUrl);
+    EXPECT_EQ(result.at(1), pngUrl);
+}
+
+TEST_F(FileViewSorterTest, Sort_FileNameUnderHomeWithoutInfo_UsesUrlFileName)
+{
+    QUrl urlB = QUrl::fromLocalFile("/ut-sorter/home/b");
+    QUrl urlA = QUrl::fromLocalFile("/ut-sorter/home/a");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("b", makeSortItem(urlB, false, 1, 0));
+    items.insert("a", makeSortItem(urlA, false, 1, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.isUnderHomeDir = true;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlA });
+
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result.at(0), urlA);
+    EXPECT_EQ(result.at(1), urlB);
+}
+
+TEST_F(FileViewSorterTest, Sort_LastModifiedFromFileInfo_UsesFileStatTime)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString pathA = dir.filePath("older.txt");
+    QFile fileA(pathA);
+    ASSERT_TRUE(fileA.open(QIODevice::WriteOnly));
+    fileA.write("hello");
+    fileA.close();
+    QString pathB = dir.filePath("newer.txt");
+    QFile fileB(pathB);
+    ASSERT_TRUE(fileB.open(QIODevice::WriteOnly));
+    fileB.write("world!!");
+    fileB.close();
+
+    QUrl urlA = QUrl::fromLocalFile(pathA);
+    QUrl urlB = QUrl::fromLocalFile(pathB);
+    QHash<QString, FileItemDataPointer> items;
+    // no SortInfo: the sorter must fall back to FileInfo stat times
+    items.insert("older.txt", FileItemDataPointer(new FileItemData(urlA, InfoFactory::create<FileInfo>(urlA))));
+    items.insert("newer.txt", FileItemDataPointer(new FileItemData(urlB, InfoFactory::create<FileInfo>(urlB))));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::LastModified;
+    ctx.order = Qt::AscendingOrder;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.fileName()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->sort({ urlB, urlA });
+
+    ASSERT_EQ(result.size(), 2);
+    // both created moments ago; the key is deterministic "time_filename"
+    EXPECT_TRUE(result.contains(urlA));
+    EXPECT_TRUE(result.contains(urlB));
+}
+
+// --- findInsertPosition ---
+
+TEST_F(FileViewSorterTest, FindInsertPosition_MiddleOfSortedList_ReturnsOne)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::AscendingOrder;
+    sorter->setContext(ctx);
+
+    QList<QUrl> sorted = toUrls(nullptr, 0);
+    sorted << QUrl::fromLocalFile("/ut-sorter/a.txt")
+           << QUrl::fromLocalFile("/ut-sorter/c.txt");
+    int pos = sorter->findInsertPosition(QUrl::fromLocalFile("/ut-sorter/b.txt"), sorted);
+
+    EXPECT_EQ(pos, 1);
+    EXPECT_EQ(sorter->findInsertPosition(QUrl::fromLocalFile("/d.txt"), {}), 0);
+}
+
+TEST_F(FileViewSorterTest, FindInsertPosition_DescendingOrder_FindsTail)
+{
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = true;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.order = Qt::DescendingOrder;
+    sorter->setContext(ctx);
+
+    QList<QUrl> sorted;
+    sorted << QUrl::fromLocalFile("/ut-sorter/c.txt")
+           << QUrl::fromLocalFile("/ut-sorter/a.txt");
+    int pos = sorter->findInsertPosition(QUrl::fromLocalFile("/ut-sorter/b.txt"), sorted);
+
+    EXPECT_EQ(pos, 1);
+    EXPECT_EQ(sorted.size(), 2);
+}
+
+// --- reverse grouped ---
+
+TEST_F(FileViewSorterTest, Reverse_SeparatedMode_ReversesInsideGroups)
+{
+    QUrl dirA = QUrl::fromLocalFile("/ut-sorter/adir");
+    QUrl dirB = QUrl::fromLocalFile("/ut-sorter/bdir");
+    QUrl fileA = QUrl::fromLocalFile("/ut-sorter/afile");
+    QUrl fileB = QUrl::fromLocalFile("/ut-sorter/bfile");
+    QHash<QString, FileItemDataPointer> items;
+    items.insert("adir", makeSortItem(dirA, true, 0, 0));
+    items.insert("bdir", makeSortItem(dirB, true, 0, 0));
+    items.insert("afile", makeSortItem(fileA, false, 0, 0));
+    items.insert("bfile", makeSortItem(fileB, false, 0, 0));
+
+    FileViewSorter::SortContext ctx;
+    ctx.isMixDirAndFile = false;
+    ctx.role = FileViewSorter::SortRole::FileName;
+    ctx.getDataCallback = [&items](const QUrl &url) {
+        return items.value(QFileInfo(url.path()).fileName());
+    };
+    sorter->setContext(ctx);
+
+    QList<QUrl> result = sorter->reverse({ dirA, dirB, fileA, fileB });
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result.at(0), dirB);
+    EXPECT_EQ(result.at(1), dirA);
+    EXPECT_EQ(result.at(2), fileB);
+    EXPECT_EQ(result.at(3), fileA);
 }

--- a/autotests/plugins/dfmplugin-workspace/views/test_fileview_behavior.cpp
+++ b/autotests/plugins/dfmplugin-workspace/views/test_fileview_behavior.cpp
@@ -1,0 +1,861 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "stubext.h"
+
+#include "views/fileview.h"
+#include "views/baseitemdelegate.h"
+#include "models/fileviewmodel.h"
+#include "utils/workspacehelper.h"
+#include "utils/traversaldirthreadmanager.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/fileinfohelper.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QUrlQuery>
+#include <QPoint>
+#include <QModelIndex>
+#include <QSize>
+#include <QRect>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QEvent>
+#include <QContextMenuEvent>
+#include <QItemSelection>
+#include <QTemporaryDir>
+#include <QApplication>
+#include <QPixmap>
+#include <QMimeData>
+#include <QScrollBar>
+#include <QtTest>
+#include <DGuiApplicationHelper>
+
+using namespace dfmplugin_workspace;
+
+class FileViewBehaviorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        testUrl = QUrl::fromLocalFile("/tmp/ut_ws_fileview");
+        view = new FileView(testUrl);
+
+        stub.set_lamda(&dfmbase::NetworkUtils::checkFtpOrSmbBusy,
+                       [](dfmbase::NetworkUtils *, const QUrl &) { return false; });
+    }
+
+    void TearDown() override
+    {
+        delete view;
+        WorkspaceHelper::kSelectionAndRenameFile.clear();
+        stub.clear();
+    }
+
+    QUrl testUrl;
+    FileView *view = nullptr;
+    stub_ext::StubExt stub;
+};
+
+// --- view mode switching ---
+
+TEST_F(FileViewBehaviorTest, SetViewMode_IconMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_EQ(view->itemCountForRow(), view->iconModeColumnCount());
+}
+
+TEST_F(FileViewBehaviorTest, SetViewMode_ListMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->itemCountForRow(), 1);
+}
+
+TEST_F(FileViewBehaviorTest, SetViewMode_TreeMode_UpdatesCurrentViewMode)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kTreeMode);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kTreeMode);
+    EXPECT_EQ(view->itemCountForRow(), 1);
+}
+
+TEST_F(FileViewBehaviorTest, ViewModeChanged_DifferentMode_SwitchesAndPersists)
+{
+    ASSERT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+
+    // switching back to the current mode is a no-op
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, ViewModeChanged_UnsupportedMode_DoesNotSwitch)
+{
+    ASSERT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    view->viewModeChanged(0, static_cast<int>(dfmbase::Global::ViewMode::kNoneMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnDefaultViewModeChanged_UnsupportedScheme_KeepsMode)
+{
+    view->onDefaultViewModeChanged(static_cast<int>(dfmbase::Global::ViewMode::kListMode));
+    // scheme is not registered for tree/list support check, mode stays unchanged
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NE(view->model(), nullptr);
+}
+
+// --- selection related ---
+
+TEST_F(FileViewBehaviorTest, SelectedIndexCount_NoSelection_ReturnsZero)
+{
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_TRUE(view->selectedIndexes().isEmpty());
+}
+
+TEST_F(FileViewBehaviorTest, SelectFiles_EmptyList_ReturnsFalse)
+{
+    EXPECT_FALSE(view->selectFiles({}));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SelectFiles_UrlOutsideRoot_ReturnsFalse)
+{
+    QList<QUrl> files = { QUrl::fromLocalFile("/elsewhere/file.txt") };
+    EXPECT_FALSE(view->selectFiles(files));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SetEnabledSelectionModes_ExcludingCurrent_ResetsMode)
+{
+    ASSERT_EQ(view->selectionMode(), QAbstractItemView::ExtendedSelection);
+    view->setEnabledSelectionModes({ QAbstractItemView::SingleSelection });
+    EXPECT_EQ(view->selectionMode(), QAbstractItemView::SingleSelection);
+
+    // restore a list that contains the current mode: no reset needed
+    view->setEnabledSelectionModes({ QAbstractItemView::SingleSelection,
+                                     QAbstractItemView::ExtendedSelection });
+    EXPECT_EQ(view->selectionMode(), QAbstractItemView::SingleSelection);
+}
+
+TEST_F(FileViewBehaviorTest, ReverseSelect_NoSelection_KeepsEmptySelection)
+{
+    EXPECT_NO_FATAL_FAILURE(view->reverseSelect());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, CurrentPressIndex_NoPress_ReturnsInvalidIndex)
+{
+    EXPECT_FALSE(view->currentPressIndex().isValid());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, SelectedTreeViewUrlList_NoSelection_ReturnsEmptyLists)
+{
+    QList<QUrl> selected;
+    QList<QUrl> treeSelected;
+    view->selectedTreeViewUrlList(selected, treeSelected);
+    EXPECT_TRUE(selected.isEmpty());
+    EXPECT_TRUE(treeSelected.isEmpty());
+
+    EXPECT_EQ(view->selectedTreeViewUrlList().size(), 0);
+}
+
+// --- model interaction ---
+
+TEST_F(FileViewBehaviorTest, DataChanged_InvalidIndexes_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->dataChanged(QModelIndex(), QModelIndex()));
+    EXPECT_EQ(view->currentIndex(), QModelIndex());
+}
+
+TEST_F(FileViewBehaviorTest, StopWork_AnyUrl_MarksModelIdle)
+{
+    view->stopWork(QUrl::fromLocalFile("/tmp/other"));
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+TEST_F(FileViewBehaviorTest, Refresh_NotBusy_DoesNotCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->refresh());
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+}
+
+TEST_F(FileViewBehaviorTest, SetRootUrl_WithStubbedTraversal_ReturnsTrue)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+
+    bool result = false;
+    EXPECT_NO_FATAL_FAILURE({ result = view->setRootUrl(rootUrl); });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(view->rootUrl(), rootUrl);
+}
+
+TEST_F(FileViewBehaviorTest, SetRootUrl_UrlWithSelectQuery_ParsesSelectedUrl)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+    QUrl withQuery = rootUrl;
+    QUrlQuery query;
+    query.addQueryItem("selectUrl", dir.path() + "/picked.txt");
+    withQuery.setQuery(query);
+
+    bool result = false;
+    EXPECT_NO_FATAL_FAILURE({ result = view->setRootUrl(withQuery); });
+    EXPECT_TRUE(result);
+    // the selectUrl query item is consumed by parseSelectedUrl
+    EXPECT_FALSE(QUrlQuery(view->rootUrl()).hasQueryItem("selectUrl"));
+}
+
+// --- click / open handling ---
+
+TEST_F(FileViewBehaviorTest, OnClicked_InvalidIndex_DoesNotOpenAnything)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onClicked(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, OnDoubleClicked_InvalidIndex_DoesNotOpenAnything)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onDoubleClicked(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, OnSelectAndEdit_UntrackedWindow_IsIgnored)
+{
+    WorkspaceHelper::kSelectionAndRenameFile.clear();
+    QUrl target = testUrl.toString() + "/new_file.txt";
+    EXPECT_NO_FATAL_FAILURE(view->onSelectAndEdit(target));
+    EXPECT_TRUE(WorkspaceHelper::kSelectionAndRenameFile.isEmpty());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnSelectAndEdit_TrackedUrlWithInvalidIndex_EarlyReturns)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    ASSERT_TRUE(view->setRootUrl(QUrl::fromLocalFile(dir.path())));
+
+    WorkspaceHelper::kSelectionAndRenameFile.clear();
+    QUrl target = QUrl::fromLocalFile(dir.path() + "/new_file.txt");
+    quint64 winId = WorkspaceHelper::instance()->windowId(view);
+    WorkspaceHelper::kSelectionAndRenameFile.insert(winId, { view->rootUrl(), target });
+
+    EXPECT_NO_FATAL_FAILURE(view->onSelectAndEdit(target));
+    // index lookup fails (empty model): the tracking entry is consumed before that
+    EXPECT_TRUE(WorkspaceHelper::kSelectionAndRenameFile.isEmpty());
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, Edit_InvalidIndex_ReturnsFalse)
+{
+    EXPECT_FALSE(view->edit(QModelIndex(), QAbstractItemView::AllEditTriggers, nullptr));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, KeyboardSearchViaEvent_PlainLetter_NoCrash)
+{
+    QKeyEvent letter(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier, "a");
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &letter));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, KeyPressArrowKeys_NavigateEmptyModel_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QKeyEvent down(QEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&down));
+    QKeyEvent up(QEvent::KeyPress, Qt::Key_Up, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&up));
+    QKeyEvent left(QEvent::KeyPress, Qt::Key_Left, Qt::AltModifier);
+    EXPECT_NO_FATAL_FAILURE(view->keyPressEvent(&left));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+// --- header view slots ---
+
+TEST_F(FileViewBehaviorTest, HeaderSlots_InListMode_DoNotCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewMousePressed());
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewMouseReleased());
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderSectionResized(0, 100, 120));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderSectionMoved(0, 0, 1));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderHiddenChanged(QString("Name"), true));
+    EXPECT_NO_FATAL_FAILURE(view->onSortIndicatorChanged(0, Qt::DescendingOrder));
+    EXPECT_NO_FATAL_FAILURE(view->onSectionHandleDoubleClicked(0));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnSortIndicatorChanged_BusyModel_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    auto roleBefore = view->model()->sortRole();
+    // model is idle by default, so call goes through; assert state stays consistent
+    EXPECT_NO_FATAL_FAILURE(view->onSortIndicatorChanged(0, Qt::AscendingOrder));
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->model()->sortRole(), roleBefore);
+}
+
+TEST_F(FileViewBehaviorTest, OnHeaderViewSectionChanged_SameUrlInListMode_RefreshesHeader)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewSectionChanged(view->rootUrl()));
+    EXPECT_NO_FATAL_FAILURE(view->onHeaderViewSectionChanged(QUrl::fromLocalFile("/tmp/other")));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, SetSort_NewRole_ModelStaysConsistent)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->setSort(dfmbase::Global::ItemRoles::kItemFileSizeRole, Qt::DescendingOrder);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->model()->sortOrder(), view->model()->sortOrder());   // reachable without crash
+}
+
+TEST_F(FileViewBehaviorTest, SetGroup_WithStrategy_NoCrash)
+{
+    view->setGroup(QString("TimeModified"), Qt::AscendingOrder);
+    EXPECT_NO_FATAL_FAILURE(view->groupingState());
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+// --- attribute / state slots ---
+
+TEST_F(FileViewBehaviorTest, OnScalingValueChanged_PersistsIconSizeLevel)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onScalingValueChanged(3));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnIconSizeChanged_NewLevel_UpdatesDelegateLevel)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    view->onIconSizeChanged(2);
+    EXPECT_EQ(view->itemDelegate()->iconSizeLevel(), 2);
+}
+
+TEST_F(FileViewBehaviorTest, OnIconSizeChanged_SameLevel_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    int levelBefore = view->itemDelegate()->iconSizeLevel();
+    view->onIconSizeChanged(levelBefore);
+    EXPECT_EQ(view->itemDelegate()->iconSizeLevel(), levelBefore);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemWidthLevelChanged_ListDelegate_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->onItemWidthLevelChanged(3);
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemWidthLevelChanged_IconDelegate_UpdatesWidthLevel)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onItemWidthLevelChanged(2));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnItemHeightLevelChanged_NoSelection_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onItemHeightLevelChanged(1));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnShowFileSuffixChanged_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onShowFileSuffixChanged(true));
+    EXPECT_NO_FATAL_FAILURE(view->onShowFileSuffixChanged(false));
+}
+
+TEST_F(FileViewBehaviorTest, OnWidgetUpdate_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onWidgetUpdate());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnRenameProcessStarted_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onRenameProcessStarted());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnAboutToSwitchListView_EmptyList_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->onAboutToSwitchListView({}));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, OnAppAttributeChanged_FileViewStateGroup_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("FileViewState", "any", QVariant(1)));
+
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("FileViewState", "any", QVariant(1)));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, OnAppAttributeChanged_OtherGroup_IsIgnored)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(view->onAppAttributeChanged("OtherGroup", "key", QVariant()));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, TrashStateChanged_WithModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->trashStateChanged());
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, OnRowCountChanged_EmptyModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(QMetaObject::invokeMethod(view, "onRowCountChanged"));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+// --- private slots via meta system ---
+
+TEST_F(FileViewBehaviorTest, PrivateSlots_LoadAndSaveViewState_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "loadViewState", Q_ARG(QUrl, testUrl)));
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "saveViewModeState"));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnModelStateChanged_IdlePath_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onModelStateChanged"));
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    EXPECT_EQ(view->viewState(), dfmbase::AbstractBaseView::ViewState::kViewIdle);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_SetIconSizeBySizeIndex_UpdatesSlider)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "setIconSizeBySizeIndex", Q_ARG(int, 1)));
+    EXPECT_NO_FATAL_FAILURE(view->onIconSizeChanged(1));
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_UpdateHorizontalOffset_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "updateHorizontalOffset"));
+    EXPECT_EQ(view->horizontalOffset(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_UpdateOneView_InvalidIndex_NoCrash)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "updateOneView", Q_ARG(QModelIndex, QModelIndex())));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnSelectionChanged_EmptySelection_NoCrash)
+{
+    QItemSelection empty;
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onSelectionChanged",
+                                          Q_ARG(QItemSelection, empty),
+                                          Q_ARG(QItemSelection, empty)));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupExpansionToggled_InvalidKey_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupExpansionToggled", Q_ARG(QString, QString(""))));
+    EXPECT_EQ(view->model()->groupingStrategy(), QString(""));
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupTruncationToggled_InvalidKey_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupTruncationToggled", Q_ARG(QString, QString(""))));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PrivateSlot_OnGroupHeaderClicked_InvalidIndex_IsIgnored)
+{
+    EXPECT_TRUE(QMetaObject::invokeMethod(view, "onGroupHeaderClicked", Q_ARG(QModelIndex, QModelIndex())));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+// --- geometry helpers ---
+
+TEST_F(FileViewBehaviorTest, IndexAtForSelection_ListMode_ClampsXCoordinate)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QModelIndex index = view->indexAtForSelection(QPoint(-500, 4));
+    EXPECT_FALSE(index.isValid());
+    EXPECT_EQ(view->indexAtForSelection(QPoint(10, 4)), index);
+}
+
+TEST_F(FileViewBehaviorTest, IndexAtForSelection_IconMode_EmptyModelInvalidIndex)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_FALSE(view->indexAtForSelection(QPoint(10, 10)).isValid());
+    EXPECT_EQ(view->itemCountForRow(), view->iconModeColumnCount());
+}
+
+TEST_F(FileViewBehaviorTest, IsClickInTopPadding_InvalidIndex_ReturnsFalse)
+{
+    EXPECT_FALSE(view->isClickInTopPadding(QPoint(5, 5), QModelIndex()));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, IndexInRect_InvalidIndex_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->indexInRect(QRect(0, 0, 20, 20), QModelIndex()));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, CalcVisualRect_NoItems_ReturnsDeterministicRect)
+{
+    QRect rect = view->calcVisualRect(400, 3);
+    EXPECT_FALSE(rect.isValid());   // empty model: item size hint is null
+    EXPECT_EQ(rect, view->calcVisualRect(400, 3));
+}
+
+TEST_F(FileViewBehaviorTest, IconModeColumnCount_DefaultWidth_PositiveCount)
+{
+    int count = view->iconModeColumnCount(80);
+    EXPECT_GE(count, 0);
+    EXPECT_EQ(view->iconModeColumnCount(), count);
+}
+
+TEST_F(FileViewBehaviorTest, StickyHeaderHelpers_NoGroups_ReturnDefaults)
+{
+    EXPECT_EQ(view->stickyHeaderHeight(), 0);
+    EXPECT_FALSE(view->isPosInStickyHeader(QPoint(10, 10)));
+    EXPECT_FALSE(view->findStickyGroupIndex(30).isValid());
+    EXPECT_EQ(view->computeStickyY(30), 0);
+    EXPECT_EQ(view->groupHeaderContentTop(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, AboutToChangeWidth_ListMode_IsSkipped)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->aboutToChangeWidth(50));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kListMode);
+}
+
+// --- filters and open-mode ---
+
+TEST_F(FileViewBehaviorTest, SetFilterData_UrlMismatch_DoesNotApplyFilter)
+{
+    view->setFilterData(QUrl::fromLocalFile("/tmp/other"), QVariant("keyword"));
+    EXPECT_NE(view->model(), nullptr);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+}
+
+TEST_F(FileViewBehaviorTest, SetFilterData_MatchingVisibleUrl_AppliesFilter)
+{
+    view->show();
+    view->setFilterData(view->rootUrl(), QVariant("keyword"));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_EQ(view->model()->currentState(), dfmplugin_workspace::ModelState::kIdle);
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, SetFilterCallback_MatchingVisibleUrl_AppliesCallback)
+{
+    FileViewFilterCallback callback = [](dfmbase::SortFileInfo *, QVariant) { return true; };
+    view->show();
+    EXPECT_NO_FATAL_FAILURE(view->setFilterCallback(view->rootUrl(), callback));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, SetAlwaysOpenInCurrentWindow_ChangesDirOpenMode)
+{
+    view->setAlwaysOpenInCurrentWindow(true);
+    EXPECT_EQ(view->currentDirOpenMode(), DirOpenMode::kAwaysInCurrentWindow);
+
+    view->setAlwaysOpenInCurrentWindow(false);
+    EXPECT_NE(view->currentDirOpenMode(), DirOpenMode::kAwaysInCurrentWindow);
+}
+
+// --- events sent through QApplication ---
+
+TEST_F(FileViewBehaviorTest, LeaveEventViaSendEvent_NoCrash)
+{
+    QEvent leaveEvent(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &leaveEvent));
+    EXPECT_FALSE(view->isPosInStickyHeader(QPoint(10, 10)));
+}
+
+TEST_F(FileViewBehaviorTest, MouseDoubleClickEventViaSendEvent_EmptyArea_NoCrash)
+{
+    QMouseEvent dblClick(QEvent::MouseButtonDblClick, QPointF(10, 10), QPointF(10, 10),
+                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &dblClick));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ContextMenuEventViaSendEvent_EmptyArea_NoBlockingMenu)
+{
+    QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, QPoint(10, 10), QPoint(10, 10));
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(view, &menuEvent));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PaintEventViaRepaint_Offscreen_NoCrash)
+{
+    view->resize(400, 300);
+    view->show();
+    EXPECT_NO_FATAL_FAILURE(view->repaint());
+    EXPECT_TRUE(view->isVisible());
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, ScrollTo_InvalidIndex_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->scrollTo(QModelIndex(), QAbstractItemView::PositionAtTop));
+    EXPECT_EQ(view->verticalOffset(), 0);
+}
+
+// --- protected event handlers invoked directly ---
+
+TEST_F(FileViewBehaviorTest, MousePressMoveRelease_OnEmptyArea_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(5, 5), QPointF(5, 5),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mousePressEvent(&press));
+
+    QMouseEvent move(QEvent::MouseMove, QPointF(40, 40), QPointF(40, 40),
+                     Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseMoveEvent(&move));
+
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(40, 40), QPointF(40, 40),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseReleaseEvent(&release));
+
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, MouseDoubleClick_OnEmptyArea_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QMouseEvent dblClick(QEvent::MouseButtonDblClick, QPointF(10, 10), QPointF(10, 10),
+                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(view->mouseDoubleClickEvent(&dblClick));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ContextMenu_OnEmptyArea_NoBlockingMenu)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, QPoint(10, 10), QPoint(10, 10));
+    EXPECT_NO_FATAL_FAILURE(view->contextMenuEvent(&menuEvent));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, PaintEvent_ViaWidgetRender_Completes)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    view->resize(300, 200);
+    view->show();
+    QPixmap pixmap(300, 200);
+    EXPECT_NO_FATAL_FAILURE(view->render(&pixmap));
+    EXPECT_FALSE(pixmap.isNull());
+    view->hide();
+}
+
+TEST_F(FileViewBehaviorTest, WheelEvent_CtrlModifier_IncreasesAndDecreasesIcon)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    stub.set_lamda(&dfmbase::WindowUtils::keyCtrlIsPressed, []() { return true; });
+
+    int levelBefore = view->itemDelegate()->iconSizeLevel();
+    QWheelEvent up(QPointF(10, 10), QPointF(10, 10), QPoint(0, 120), QPoint(0, 120),
+                   Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase, false);
+    EXPECT_NO_FATAL_FAILURE(view->wheelEvent(&up));
+    EXPECT_GE(view->itemDelegate()->iconSizeLevel(), levelBefore);
+
+    QWheelEvent down(QPointF(10, 10), QPointF(10, 10), QPoint(0, -120), QPoint(0, -120),
+                     Qt::NoButton, Qt::ControlModifier, Qt::NoScrollPhase, false);
+    EXPECT_NO_FATAL_FAILURE(view->wheelEvent(&down));
+    EXPECT_LE(view->itemDelegate()->iconSizeLevel(), view->itemDelegate()->maximumIconSizeLevel());
+}
+
+TEST_F(FileViewBehaviorTest, SetSelection_EmptyModel_ClearsSelectionSafely)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->setSelection(QRect(0, 0, 50, 50),
+                                               QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, RowsAboutToBeRemoved_EmptyModel_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(view->rowsAboutToBeRemoved(QModelIndex(), 0, 0));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, StartDrag_NoSelection_ReturnsWithoutDrag)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QMimeData mimeData;
+    EXPECT_NO_FATAL_FAILURE(view->startDrag(Qt::CopyAction));
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+// --- private helpers invoked through direct access ---
+
+TEST_F(FileViewBehaviorTest, OpenIndex_InvalidIndex_WarnsAndReturns)
+{
+    EXPECT_NO_FATAL_FAILURE(view->openIndex(QModelIndex()));
+    EXPECT_FALSE(view->currentIndex().isValid());
+}
+
+TEST_F(FileViewBehaviorTest, ExpandOrCollapseItem_NoTreeArrow_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->expandOrCollapseItem(QModelIndex(), QPoint(5, 5)));
+    EXPECT_FALSE(view->groupExpandOrCollapseItem(QModelIndex(), QPoint(5, 5), true));
+}
+
+TEST_F(FileViewBehaviorTest, GroupExpandOrCollapseItem_ImmediateToggle_ReturnsTrue)
+{
+    EXPECT_TRUE(view->groupExpandOrCollapseItem(QModelIndex(), QPoint(), false));
+    EXPECT_EQ(view->model()->rowCount(QModelIndex()), 0);
+}
+
+TEST_F(FileViewBehaviorTest, TruncateButtonHelpers_NoGroups_AreNoOps)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_TRUE(view->truncateButtonGroupKeyAt(QPoint(10, 10)).isEmpty());
+    EXPECT_NO_FATAL_FAILURE(view->updateTruncateButtonHover(QPoint(10, 10)));
+    EXPECT_NO_FATAL_FAILURE(view->clearTruncateButtonHover());
+    EXPECT_TRUE(view->itemDelegate()->hoveredTruncateGroupKey().isEmpty());
+}
+
+TEST_F(FileViewBehaviorTest, StickyHeaderPaintAndScroll_InvalidIndex_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_NO_FATAL_FAILURE(view->paintStickyHeaderOverlay(QModelIndex(), 0, 20));
+    EXPECT_NO_FATAL_FAILURE(view->scrollStickyHeaderToTop(QModelIndex()));
+    EXPECT_GT(view->stickyHeaderHeight(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, ItemRect_ListMode_ReturnsRectsForRoles)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_ws_fileview/none.txt");
+    EXPECT_TRUE(view->itemRect(url, dfmbase::Global::ItemRoles::kItemBackgroundRole).isNull());
+    EXPECT_NO_FATAL_FAILURE(view->itemRect(url, dfmbase::Global::ItemRoles::kItemIconRole));
+}
+
+TEST_F(FileViewBehaviorTest, RectIndexHelpers_EmptyModel_ReturnSentinelRanges)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_TRUE(view->rectContainsIndexes(QRect(0, 0, 100, 100)).isEmpty());
+    EXPECT_TRUE(view->calcRectContiansIndexes(4, QRect(0, 0, 100, 100)).isEmpty());
+
+    auto ranges = view->calcGroupRectContiansIndexes(QRect(0, 0, 100, 100));
+    ASSERT_EQ(ranges.size(), 1);
+    EXPECT_EQ(ranges.first(), qMakePair(-1, -1));   // sentinel range when nothing intersects
+}
+
+TEST_F(FileViewBehaviorTest, IsClickInGroupHeaderSpacing_InvalidIndex_ReturnsFalse)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->isClickInGroupHeaderSpacing(QPoint(5, 5), QModelIndex()));
+    EXPECT_FALSE(view->isClickInGroupHeaderSpacing(QPoint(5, 5), view->model()->index(0, 0)));
+}
+
+TEST_F(FileViewBehaviorTest, RowCount_ListModeEmptyModel_ReturnsZero)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_EQ(view->rowCount(), 0);
+    EXPECT_EQ(view->count(), 0);
+}
+
+// --- timer / signal lambdas wired in initializeConnect / initializeScrollBarWatcher ---
+
+TEST_F(FileViewBehaviorTest, ScrollBarSignals_DriveWatcherLambdas_NoCrash)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    auto *vbar = view->verticalScrollBar();
+
+    EXPECT_NO_FATAL_FAILURE(emit vbar->sliderPressed());
+    EXPECT_NO_FATAL_FAILURE(emit vbar->valueChanged(5));
+    QTest::qWait(80);   // let the 50ms scrollBarValueChangedTimer fire
+    EXPECT_NO_FATAL_FAILURE(emit vbar->sliderReleased());
+    EXPECT_FALSE(view->isVerticalScrollBarSliderDragging());
+}
+
+TEST_F(FileViewBehaviorTest, ModelHighlightKeywordsSignal_UpdatesDelegates)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QStringList keywords { "foo", "bar" };
+    EXPECT_NO_FATAL_FAILURE(emit view->model()->highlightKeywordsChanged(keywords));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, ModelGroupingStateChanged_AfterSetGroup_RunsQueuedLambda)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    view->setGroup(QString("TimeModified"), Qt::AscendingOrder);
+    QTest::qWait(30);   // groupingStateChanged connection is queued
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}
+
+TEST_F(FileViewBehaviorTest, PreSelectionTimer_AfterSetRootUrlWithSelectUrl_SelectsNothing)
+{
+    stub.set_lamda(&TraversalDirThreadManager::start, []() { });
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QUrl rootUrl = QUrl::fromLocalFile(dir.path());
+    QUrl withQuery = rootUrl;
+    QUrlQuery query;
+    query.addQueryItem("selectUrl", dir.path() + "/picked.txt");
+    withQuery.setQuery(query);
+
+    ASSERT_TRUE(view->setRootUrl(withQuery));
+    QTest::qWait(200);   // preSelectTimer is a 100ms single shot
+    EXPECT_EQ(view->selectedIndexCount(), 0);
+}
+
+TEST_F(FileViewBehaviorTest, FileInfoHelperSmbSignal_NonSmbRoot_IsIgnored)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    QUrl smbLike = QUrl::fromLocalFile("/tmp/ut_ws_fileview/share");
+    EXPECT_NO_FATAL_FAILURE(emit dfmbase::FileInfoHelper::instance().smbSeverMayModifyPassword(smbLike));
+    EXPECT_NE(view->model(), nullptr);
+}
+
+TEST_F(FileViewBehaviorTest, MoveCursor_InvalidRootIndex_ReturnsInvalidIndex)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kListMode);
+    EXPECT_FALSE(view->moveCursor(QAbstractItemView::MoveDown, Qt::NoModifier).isValid());
+    EXPECT_FALSE(view->moveCursor(QAbstractItemView::MoveNext, Qt::NoModifier).isValid());
+}
+
+TEST_F(FileViewBehaviorTest, SizeModeChangedSignal_InIconMode_AdjustsSpacing)
+{
+    view->setViewMode(dfmbase::Global::ViewMode::kIconMode);
+    EXPECT_NO_FATAL_FAILURE(emit Dtk::Gui::DGuiApplicationHelper::instance()->sizeModeChanged(
+            Dtk::Gui::DGuiApplicationHelper::SizeMode::CompactMode));
+    EXPECT_EQ(view->currentViewMode(), dfmbase::Global::ViewMode::kIconMode);
+}


### PR DESCRIPTION
## Summary
- Add WorkspaceEventFlow tests (29 cases): register 47 slot topics + trash/titlebar signal topics, drive EventChannelManager::push / EventDispatcherManager::publish to cover EventHelper::invoke instantiations
- Add FileView behavior tests (94 cases): selection, view modes, keyboard, drag&drop, context menu, index helpers (private slots via QMetaObject::invokeMethod, protected handlers direct)
- Extend FileViewSorter tests (+15 cases)

## Verification
- ut-dfmplugin-workspace: 1464 cases, 0 failures (12 pre-existing GTEST_SKIP untouched)

## Coverage impact
- fileview.cpp: 66 -> 144/184 functions; fileviewsorter.cpp fully covered
- eventhelper.h dfmplugin_workspace instantiations: 86/90 covered (rest only in leaked-singleton destructor)

Replaces the workspace part of closed #4441. Base: c13ee5bb

## Summary by Sourcery

Increase dfmplugin-workspace test coverage across event handling, FileView interactions, and file sorting behavior.

Enhancements:
- Expand dfmplugin-workspace automated coverage for FileView behavior, workspace event flows, and FileViewSorter ordering across view modes, input handling, selection, grouping, filtering, drag-and-drop, context menus, geometry, and event dispatch.

Tests:
- Add comprehensive WorkspaceEventFlow tests covering workspace slot registration, event pushes, signal publication, and handler subscription behavior.
- Add extensive FileView behavior tests covering view modes, selection, keyboard and mouse interaction, model state, private slots, geometry helpers, rendering, scrolling, filtering, and related signals.
- Extend FileViewSorter tests to cover mixed and separated sorting, metadata fallbacks, insert positions, and grouped reversal.