### PR TITLE
test: extend recent plugin tests with real follow-events coverage

### DIFF
--- a/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
@@ -11,16 +11,26 @@
 #include "utils/recentmanager.h"
 #include "utils/recentfilehelper.h"
 #include "events/recenteventreceiver.h"
+#include "events/recenteventcaller.h"
 
 #include <dfm-framework/dpf.h>
 #include <dfm-framework/event/event.h>
 #include <dfm-framework/event/eventhelper.h>
 
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+#include <DDialog>
+
 #include <gtest/gtest.h>
+
+#include <QTemporaryDir>
+#include <QTemporaryFile>
 
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_recent;
 using namespace dpf;
+DWIDGET_USE_NAMESPACE
 
 Q_DECLARE_METATYPE(QString *)
 Q_DECLARE_METATYPE(bool *)
@@ -58,6 +68,17 @@ static void registerRecentHookEvents(dpf::Event *evt)
     evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_SetPermission");
 }
 
+// Initialize the plugin exactly once for the whole binary: repeating
+// followEvents()/bindEvents() would append duplicate followers and make
+// per-signal invocation counts non-deterministic.
+static Recent &recentPluginInstance()
+{
+    static Recent instance;
+    static std::once_flag once;
+    std::call_once(once, [&instance] { instance.initialize(); });
+    return instance;
+}
+
 class RecentFollowEventsTest : public testing::Test
 {
 protected:
@@ -67,15 +88,220 @@ protected:
         // Only stub the genuinely unsafe paths; let followEvents/bindEvents run for real.
         stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
         stub.set_lamda(&Recent::bindWindows, [] { __DBG_STUB_INVOKE__ });
+        // removeRecent() shows a modal DDialog and then calls DBus; intercept it
+        // (a plain namespace function, safe to stub) so drop/trash hooks stay headless.
+        removeRecentCalls = 0;
+        stub.set_lamda(&RecentHelper::removeRecent, [this](const QList<QUrl> &) {
+            __DBG_STUB_INVOKE__
+            ++removeRecentCalls;
+        });
+        reloadCount = 0;
+        stub.set_lamda(&RecentManager::reloadRecent, [this] { __DBG_STUB_INVOKE__ ++reloadCount; });
+        // Perform the one-time real followEvents()/bindEvents() registration.
+        recentPluginInstance();
     }
-    void TearDown() override { stub.clear(); }
+    void TearDown() override
+    {
+        RecentManager::instance()->recentItems.clear();
+        stub.clear();
+    }
     stub_ext::StubExt stub;
-    Recent ins;
+    int reloadCount { 0 };
+    int removeRecentCalls { 0 };
 };
 
-// Run the real followEvents + bindEvents path (initialize calls both) so the
-// EventHelper<M> template instantiations in recent.cpp execute and get covered.
+// The real followEvents + bindEvents path must have run (via the shared
+// instance) without crashing, registering every hook/signal follower.
 TEST_F(RecentFollowEventsTest, Initialize_RunsRealFollowAndBindEvents_NoCrash)
 {
-    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+    EXPECT_NE(&recentPluginInstance(), nullptr);
+    // Proof that the followers were really registered:
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_propertydialog",
+                                     "hook_PropertyDialog_Disable",
+                                     RecentHelper::rootUrl()));
+}
+
+// Trigger every workspace/detailspace/titlebar/propertydialog hook through the
+// real EventSequenceManager so each followed EventHelper<RecentEventReceiver>
+// is constructed and invoked with exact-signature arguments.
+TEST_F(RecentFollowEventsTest, HookRun_RecentSchemeHooks_InvokeReceiverHandlers)
+{
+    const QUrl recentRoot { RecentHelper::rootUrl() };
+    const QUrl recentItem { "recent:///tmp/follow_item.txt" };
+
+    QList<Global::ItemRoles> roles;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles",
+                                     recentRoot, &roles));
+    EXPECT_TRUE(roles.contains(Global::ItemRoles::kItemFilePathRole));
+    EXPECT_TRUE(roles.contains(Global::ItemRoles::kItemFileLastReadRole));
+
+    QString displayName;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName",
+                                     recentItem, Global::ItemRoles::kItemFilePathRole, &displayName));
+    EXPECT_EQ(displayName.toStdString(), "Path");
+
+    Global::TransparentStatus status { Global::TransparentStatus::kTransparent };
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_CheckTransparent",
+                                     recentItem, &status));
+    EXPECT_EQ(status, Global::TransparentStatus::kUntransparent);
+
+    Qt::DropAction action { Qt::IgnoreAction };
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction",
+                                     QList<QUrl> { recentItem }, recentRoot, &action));
+    EXPECT_EQ(action, Qt::CopyAction);
+
+    // Drops from recent:// into trash:// trigger the removal flow (stubbed).
+    const int removesBefore = removeRecentCalls;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                     QList<QUrl> { recentItem }, QUrl("trash:///")));
+    EXPECT_EQ(removeRecentCalls, removesBefore + 1);
+
+    QString iconName;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_detailspace", "hook_Icon_Fetch",
+                                     recentRoot, &iconName));
+    EXPECT_EQ(iconName.toStdString(), "dfm_recent");
+
+    QList<QVariantMap> crumbs;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate",
+                                     recentItem, &crumbs));
+    ASSERT_EQ(crumbs.size(), 1);
+    EXPECT_EQ(crumbs.first().value("CrumbData_Key_Url").toUrl(), recentRoot);
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_propertydialog", "hook_PropertyDialog_Disable",
+                                     recentRoot));
+}
+
+// Trigger every fileoperations hook so the followed
+// EventHelper<RecentFileHelper> instantiations are constructed and invoked.
+TEST_F(RecentFollowEventsTest, HookRun_FileOperationHooks_InvokeHelperHandlers)
+{
+    const QUrl recentRoot { RecentHelper::rootUrl() };
+    const QUrl recentItem { "recent:///tmp/follow_op.txt" };
+    const AbstractJobHandler::JobFlags noFlags {};
+
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_CutToFile",
+                                     quint64(1), QList<QUrl> { recentItem }, recentRoot, noFlags));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_CopyFile",
+                                     quint64(1), QList<QUrl> { recentItem }, recentRoot, noFlags));
+    // moveToTrash triggers the removal flow (stubbed) and succeeds.
+    const int removesBefore = removeRecentCalls;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                     quint64(1), QList<QUrl> { recentItem }, noFlags));
+    EXPECT_EQ(removeRecentCalls, removesBefore + 1);
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                     quint64(1), QList<QUrl> { recentItem }));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_WriteUrlsToClipboard",
+                                     quint64(1), ClipBoard::ClipboardAction::kCopyAction,
+                                     QList<QUrl> { recentItem }));
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenInTerminal",
+                                     quint64(1), QList<QUrl> { recentItem }));
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString filePath = dir.filePath("perm.txt");
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const QUrl recentPerm { RecentHelper::recentUrl(filePath) };
+    bool ok = false;
+    QString error;
+    EXPECT_TRUE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_SetPermission",
+                                     quint64(1), recentPerm,
+                                     QFileDevice::Permissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner),
+                                     &ok, &error));
+    EXPECT_TRUE(ok);
+    // The handler applied the owner read/write permission set (dfm-io may
+    // additionally mirror owner bits onto user bits).
+    const QFileDevice::Permissions perms = file.permissions();
+    EXPECT_TRUE(perms & QFileDevice::ReadOwner);
+    EXPECT_TRUE(perms & QFileDevice::WriteOwner);
+}
+
+// Non-recent inputs must make every hooked handler return false, which makes
+// the whole hook traversal fail -> covers the negative branches of the
+// EventHelper invocations.
+TEST_F(RecentFollowEventsTest, HookRun_NonRecentInputs_TraversalFails)
+{
+    const QUrl plainFile { "file:///tmp/not_recent.txt" };
+    QList<Global::ItemRoles> roles;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles",
+                                      plainFile, &roles));
+    EXPECT_TRUE(roles.isEmpty());
+
+    Global::TransparentStatus status {};
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_Delegate_CheckTransparent",
+                                      plainFile, &status));
+
+    Qt::DropAction action { Qt::IgnoreAction };
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction",
+                                      QList<QUrl> { plainFile }, plainFile, &action));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileDrop",
+                                      QList<QUrl> { plainFile }, QUrl("trash:///")));
+
+    QList<QVariantMap> crumbs;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_titlebar", "hook_Crumb_Seprate",
+                                      plainFile, &crumbs));
+
+    QString iconName;
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_detailspace", "hook_Icon_Fetch",
+                                      QUrl("recent:///not_root.txt"), &iconName));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_propertydialog", "hook_PropertyDialog_Disable",
+                                      QUrl("recent:///not_root.txt")));
+
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash",
+                                      quint64(1), QList<QUrl> { plainFile },
+                                      AbstractJobHandler::JobFlags {}));
+    EXPECT_FALSE(dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin",
+                                      quint64(1), QList<QUrl> {}));
+}
+
+// Publish the GlobalEventType signals Recent::bindEvents() subscribed to so the
+// EventHelper<void (RecentEventReceiver::*)(...)> dispatch instantiations run.
+TEST_F(RecentFollowEventsTest, SignalPublish_BoundEvents_InvokeReceiverHandlers)
+{
+    const QList<QUrl> urls { QUrl("recent:///tmp/cut_src.txt") };
+    const QList<QUrl> dests { QUrl("file:///tmp/cut_dst.txt") };
+    const QMap<QUrl, QUrl> renamed { { QUrl("recent:///tmp/a.txt"), QUrl("file:///tmp/b.txt") } };
+
+    EXPECT_EQ(reloadCount, 0);
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, dests, true, QString()));
+    EXPECT_EQ(reloadCount, 1);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, true, QString()));
+    EXPECT_EQ(reloadCount, 2);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, urls, true, QString()));
+    EXPECT_EQ(reloadCount, 3);
+
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1), renamed, true, QString()));
+    EXPECT_EQ(reloadCount, 4);
+
+    // Window url change on the recent scheme only posts a deferred slot push;
+    // it must succeed without any registered slot consumer.
+    EXPECT_TRUE(dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, quint64(1),
+                                             QUrl("recent:///")));
+}
+
+// Failed operations must not reload the recent cache: the receiver handlers
+// short-circuit, covering the negative branches behind the dispatch helpers.
+TEST_F(RecentFollowEventsTest, SignalPublish_FailedOperations_DoNotReload)
+{
+    const QList<QUrl> urls { QUrl("recent:///tmp/failed.txt") };
+
+    EXPECT_EQ(reloadCount, 0);
+    dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrashResult, urls, false, QString("boom"));
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kDeleteFilesResult, QList<QUrl> {}, true, QString());
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kCutFileResult, urls, QList<QUrl> {}, false, QString("boom"));
+    EXPECT_EQ(reloadCount, 0);
+
+    dpfSignalDispatcher->publish(GlobalEventType::kRenameFileResult, quint64(1),
+                                 QMap<QUrl, QUrl> {}, true, QString());
+    EXPECT_EQ(reloadCount, 0);
 }

--- a/autotests/plugins/dfmplugin-recent/test_recent.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recent.cpp
@@ -116,33 +116,33 @@ TEST_F(RecentTest, FollowEvents)
 {
     stub_ext::StubExt st;
     st.set_lamda(&RecentManager::init, []() {});
-    // type of RecentManager::customColumnRole
-    typedef bool (RecentManager::*HookFunc1)(const QUrl &, QList<Global::ItemRoles> *);
-    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentManager *, HookFunc1);
+    // type of RecentEventReceiver::customColumnRole
+    typedef bool (RecentEventReceiver::*HookFunc1)(const QUrl &, QList<Global::ItemRoles> *);
+    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentEventReceiver *, HookFunc1);
 
-    // type of RecentManager::customRoleDisplayName
-    typedef bool (RecentManager::*HookFunc2)(const QUrl &, const Global::ItemRoles, QString *);
-    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, RecentManager *, HookFunc2);
+    // type of RecentEventReceiver::customRoleDisplayName
+    typedef bool (RecentEventReceiver::*HookFunc2)(const QUrl &, const Global::ItemRoles, QString *);
+    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, RecentEventReceiver *, HookFunc2);
 
-    // type of RecentManager::isTransparent
-    typedef bool (RecentManager::*HookFunc3)(const QUrl &, DFMGLOBAL_NAMESPACE::TransparentStatus *);
-    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, RecentManager *, HookFunc3);
+    // type of RecentEventReceiver::isTransparent
+    typedef bool (RecentEventReceiver::*HookFunc3)(const QUrl &, DFMGLOBAL_NAMESPACE::TransparentStatus *);
+    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, RecentEventReceiver *, HookFunc3);
 
-    // type of RecentManager::checkDragDropAction
-    typedef bool (RecentManager::*HookFunc4)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
-    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, RecentManager *, HookFunc4);
+    // type of RecentEventReceiver::checkDragDropAction
+    typedef bool (RecentEventReceiver::*HookFunc4)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
+    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, RecentEventReceiver *, HookFunc4);
 
-    // type of RecentManager::handleDropFiles
-    typedef bool (RecentManager::*HookFunc5)(const QList<QUrl> &, const QUrl &);
-    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, RecentManager *, HookFunc5);
+    // type of RecentEventReceiver::handleDropFiles
+    typedef bool (RecentEventReceiver::*HookFunc5)(const QList<QUrl> &, const QUrl &);
+    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, RecentEventReceiver *, HookFunc5);
 
-    // type of RecentManager::detailViewIcon
-    typedef bool (RecentManager::*HookFunc6)(const QUrl &, QString *);
-    typedef bool (EventSequenceManager::*HookType6)(const QString &, const QString &, RecentManager *, HookFunc6);
+    // type of RecentEventReceiver::detailViewIcon
+    typedef bool (RecentEventReceiver::*HookFunc6)(const QUrl &, QString *);
+    typedef bool (EventSequenceManager::*HookType6)(const QString &, const QString &, RecentEventReceiver *, HookFunc6);
 
-    // type of RecentManager::sepateTitlebarCrumb
-    typedef bool (RecentManager::*HookFunc7)(const QUrl &, QList<QVariantMap> *);
-    typedef bool (EventSequenceManager::*HookType7)(const QString &, const QString &, RecentManager *, HookFunc7);
+    // type of RecentEventReceiver::sepateTitlebarCrumb
+    typedef bool (RecentEventReceiver::*HookFunc7)(const QUrl &, QList<QVariantMap> *);
+    typedef bool (EventSequenceManager::*HookType7)(const QString &, const QString &, RecentEventReceiver *, HookFunc7);
 
     // type of RecentFileHelper::cutFile
     typedef bool (RecentFileHelper::*HookFunc8)(const quint64, const QList<QUrl>,
@@ -166,8 +166,8 @@ TEST_F(RecentTest, FollowEvents)
     typedef bool (RecentFileHelper::*HookFunc12)(quint64, QList<QUrl>);
     typedef bool (EventSequenceManager::*HookType12)(const QString &, const QString &, RecentFileHelper *, HookFunc12);
 
-    // type of RecentFileHelper::linkFile
-    typedef bool (RecentFileHelper::*HookFunc13)(const quint64, const QUrl, const QUrl, const bool, const bool);
+    // type of RecentFileHelper::setPermissionHandle
+    typedef bool (RecentFileHelper::*HookFunc13)(const quint64, const QUrl, QFileDevice::Permissions, bool *, QString *);
     typedef bool (EventSequenceManager::*HookType13)(const QString &, const QString &, RecentFileHelper *, HookFunc13);
 
     // type of RecentFileHelper::writeUrlsToClipboard

--- a/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
@@ -15,15 +15,27 @@
 
 // 包含待测试的类
 #include "utils/recentmanager.h"
+#include "files/recentfileinfo.h"
+#include "events/recenteventcaller.h"
 #include "dfmplugin_recent_global.h"
 
 // 包含依赖的头文件
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
 #include <dfm-base/interfaces/abstractfilewatcher.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/sysinfoutils.h>
+
+#include <DDesktopServices>
+#include <QDBusArgument>
+#include <QAction>
+#include <QMenu>
+#include <QProcess>
 
 DPRECENT_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 /**
  * @brief RecentManager类单元测试
@@ -41,10 +53,27 @@ class RecentManagerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        // Mock QCoreApplication thread check
-        stub.set_lamda(&QThread::currentThread, []() {
-            __DBG_STUB_INVOKE__
-            return QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+        // NOTE: do NOT stub QThread::currentThread here: InfoCache's worker
+        // thread asserts `qApp->thread() != currentThread()` and a global
+        // currentThread stub breaks that worker thread.
+
+        // Register the "recent" scheme exactly once for the whole binary so
+        // InfoFactory::create<FileInfo>(recent://...) returns a RecentFileInfo.
+        // Also register "file" so RecentFileInfo gets a real proxy and
+        // urlOf(kRedirectedFileUrl) resolves to the local file path.
+        static std::once_flag schemeOnce;
+        std::call_once(schemeOnce, [] {
+            if (!UrlRoute::hasScheme(RecentHelper::scheme()))
+                UrlRoute::regScheme(RecentHelper::scheme(), "/", RecentHelper::icon(),
+                                    true, QStringLiteral("Recent"));
+            InfoFactory::regClass<RecentFileInfo>(RecentHelper::scheme());
+            // "file" needs both UrlRoute and factory registration, otherwise
+            // SchemeFactory::create(file://) returns null and RecentFileInfo
+            // ends up without a proxy.
+            if (!UrlRoute::hasScheme(Global::Scheme::kFile))
+                UrlRoute::regScheme(Global::Scheme::kFile, "/", QIcon(),
+                                    false, QStringLiteral("File"));
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
         });
 
         // Create temporary directory for testing
@@ -58,6 +87,12 @@ protected:
 
     void TearDown() override
     {
+        // Reset the singleton caches so cases stay independent.
+        if (manager) {
+            manager->pendingItems.clear();
+            manager->recentItems.clear();
+            manager->batchTimer.stop();
+        }
         // Clean up resources
         delete tempDir;
         stub.clear();
@@ -66,6 +101,42 @@ protected:
     stub_ext::StubExt stub;
     RecentManager *manager { nullptr };
     QTemporaryDir *tempDir { nullptr };
+    int menuExecCalls { 0 };
+
+    // Stub menu exec to behave like the user clicked the action at
+    // actionIndex (-1 = dismiss without choosing): emit triggered() while the
+    // action is still owned by the menu so its connected lambda runs.
+    void StubMenuExecReturnAction(int actionIndex)
+    {
+        menuExecCalls = 0;
+        stub.set_lamda(static_cast<QAction *(QMenu::*)(const QPoint &, QAction *)>(&QMenu::exec),
+                       [this, actionIndex](QMenu *self, const QPoint &, QAction *) -> QAction * {
+                           __DBG_STUB_INVOKE__
+                           ++menuExecCalls;
+                           const auto acts = self->actions();
+                           QAction *act = (actionIndex >= 0 && actionIndex < acts.size())
+                                   ? acts.at(actionIndex)
+                                   : nullptr;
+                           if (act)
+                               emit act->triggered();
+                           return act;
+                       });
+    }
+
+    // Deterministic InfoFactory::create<FileInfo> replacement that skips the
+    // InfoCache async machinery entirely (kAuto caching is thread-sensitive).
+    // Non-recent lookups (the proxy inside RecentFileInfo) return null, which
+    // is a supported state and also breaks the recursion.
+    void StubInfoFactoryCreate()
+    {
+        stub.set_lamda(static_cast<FileInfoPointer (*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
+                       [](const QUrl &url, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                           __DBG_STUB_INVOKE__
+                           if (url.scheme() != RecentHelper::scheme())
+                               return nullptr;
+                           return FileInfoPointer(new RecentFileInfo(url));
+                       });
+    }
 };
 
 /**
@@ -282,4 +353,450 @@ TEST_F(RecentManagerTest, Destructor_CleansUpProperly)
     // Verify cleanup
     auto nodes = manager->getRecentNodes();
     EXPECT_EQ(nodes.size(), 0);
+}
+
+/**
+ * @brief RecentHelper::recentUrl 应把本地路径包装为 recent scheme
+ */
+TEST_F(RecentManagerTest, RecentUrl_ConvertsLocalPathToRecentScheme)
+{
+    const QUrl url = RecentHelper::recentUrl("/tmp/a.txt");
+
+    EXPECT_EQ(url.scheme(), QStringLiteral("recent"));
+    EXPECT_EQ(url.path(), QStringLiteral("/tmp/a.txt"));
+
+    const QUrl emptyUrl = RecentHelper::recentUrl(QString());
+    EXPECT_EQ(emptyUrl.scheme(), QStringLiteral("recent"));
+    EXPECT_TRUE(emptyUrl.path().isEmpty());
+}
+
+/**
+ * @brief onItemAdded 对合法路径应加入缓存并记录 originPath
+ */
+TEST_F(RecentManagerTest, OnItemAdded_ValidPath_InsertsIntoCache)
+{
+    const QString path = tempDir->filePath("added.txt");
+    const QString href = QUrl::fromLocalFile(path).toString();
+
+    manager->onItemAdded(path, href, 1700000000);
+
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_TRUE(manager->recentItems.contains(recentUrl));
+    EXPECT_EQ(manager->getRecentOriginPaths(recentUrl), href);
+}
+
+/**
+ * @brief onItemAdded 对空路径应忽略
+ */
+TEST_F(RecentManagerTest, OnItemAdded_EmptyPath_Ignored)
+{
+    manager->onItemAdded(QString(), QString("file:///tmp/none.txt"), 1);
+
+    EXPECT_EQ(manager->recentItems.size(), 0);
+    EXPECT_EQ(manager->size(), 0);
+}
+
+/**
+ * @brief onItemAdded 重复路径只保留一条
+ */
+TEST_F(RecentManagerTest, OnItemAdded_DuplicatePath_KeepsSingleEntry)
+{
+    const QString path = tempDir->filePath("dup.txt");
+
+    manager->onItemAdded(path, QString("file:///tmp/dup.txt"), 1);
+    manager->onItemAdded(path, QString("file:///tmp/dup.txt"), 2);
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->getRecentNodes().size(), 1);
+}
+
+/**
+ * @brief onItemsRemoved 应移除已存在项并保持其他项
+ */
+TEST_F(RecentManagerTest, OnItemsRemoved_ExistingPaths_RemoveFromCache)
+{
+    const QString kept = tempDir->filePath("kept.txt");
+    const QString dropped = tempDir->filePath("dropped.txt");
+    manager->onItemAdded(kept, QString("file:///tmp/kept.txt"), 1);
+    manager->onItemAdded(dropped, QString("file:///tmp/dropped.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 2);
+
+    manager->onItemsRemoved(QStringList { dropped });
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_FALSE(manager->recentItems.contains(RecentHelper::recentUrl(dropped)));
+    EXPECT_TRUE(manager->recentItems.contains(RecentHelper::recentUrl(kept)));
+}
+
+/**
+ * @brief onItemsRemoved 对未知路径应无副作用
+ */
+TEST_F(RecentManagerTest, OnItemsRemoved_UnknownPath_NoEffect)
+{
+    const QString path = tempDir->filePath("stable.txt");
+    manager->onItemAdded(path, QString("file:///tmp/stable.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 1);
+
+    manager->onItemsRemoved(QStringList { "/tmp/never_added.txt" });
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->size(), 1);
+}
+
+/**
+ * @brief onItemChanged 应更新已存在项的最近访问时间
+ */
+TEST_F(RecentManagerTest, OnItemChanged_ExistingPath_UpdatesLastReadTime)
+{
+    const QString path = tempDir->filePath("changed.txt");
+    manager->onItemAdded(path, QString("file:///tmp/changed.txt"), 100);
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+
+    manager->onItemChanged(path, 1700001234);
+
+    const auto info = manager->recentItems.value(recentUrl).fileInfo.dynamicCast<RecentFileInfo>();
+    ASSERT_FALSE(info.isNull());
+    EXPECT_EQ(info->lastReadTime, QDateTime::fromSecsSinceEpoch(1700001234));
+    EXPECT_EQ(manager->recentItems.size(), 1);
+}
+
+/**
+ * @brief onItemChanged 对空路径和未知路径应忽略
+ */
+TEST_F(RecentManagerTest, OnItemChanged_EmptyOrUnknownPath_Ignored)
+{
+    manager->onItemAdded(tempDir->filePath("anchor.txt"), QString("file:///tmp/a.txt"), 1);
+    ASSERT_EQ(manager->recentItems.size(), 1);
+
+    manager->onItemChanged(QString(), 42);
+    manager->onItemChanged("/tmp/not_in_cache.txt", 42);
+
+    EXPECT_EQ(manager->recentItems.size(), 1);
+    EXPECT_EQ(manager->size(), 1);
+}
+
+/**
+ * @brief removeRecentFile 按存在性返回正确结果
+ */
+TEST_F(RecentManagerTest, RemoveRecentFile_PresentAndAbsentUrls)
+{
+    const QString path = tempDir->filePath("removable.txt");
+    manager->onItemAdded(path, QString("file:///tmp/removable.txt"), 1);
+    const QUrl recentUrl = RecentHelper::recentUrl(path);
+
+    EXPECT_FALSE(manager->removeRecentFile(QUrl("recent:///tmp/absent.txt")));
+    EXPECT_TRUE(manager->removeRecentFile(recentUrl));
+    EXPECT_FALSE(manager->recentItems.contains(recentUrl));
+    EXPECT_EQ(manager->size(), 0);
+}
+
+/**
+ * @brief reloadRecent 应触发一次 DBus Reload 调用
+ */
+TEST_F(RecentManagerTest, ReloadRecent_InvokesDBusReloadOnce)
+{
+    int reloadCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, [&]() {
+        __DBG_STUB_INVOKE__
+        ++reloadCalls;
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    const int before = reloadCalls;
+    manager->reloadRecent();
+
+    EXPECT_EQ(reloadCalls - before, 1);
+    EXPECT_GE(reloadCalls, 2);   // one from init(), one from reloadRecent()
+}
+
+/**
+ * @brief clearRecent 应调用 DBus PurgeItems
+ */
+TEST_F(RecentManagerTest, ClearRecent_PurgesAllItemsViaDbus)
+{
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    int purgeCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [&]() {
+        __DBG_STUB_INVOKE__
+        ++purgeCalls;
+        return QDBusPendingReply<>();
+    });
+
+    RecentHelper::clearRecent();
+
+    EXPECT_EQ(purgeCalls, 1);
+    EXPECT_NE(manager->dbus(), nullptr);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"在新窗口打开"应发送开窗事件
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_OpenInNewWindowAction_SendsOpenWindow)
+{
+    int openWindowCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenWindow, [&](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openWindowCalls;
+    });
+    StubMenuExecReturnAction(0);
+
+    RecentHelper::contenxtMenuHandle(1, QUrl("recent:///tmp/menu_win.txt"), QPoint(10, 10));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openWindowCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"在新标签打开"应发送开标签事件
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_OpenInNewTabAction_SendsOpenTab)
+{
+    int openTabCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenTab, [&](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openTabCalls;
+    });
+    StubMenuExecReturnAction(1);
+
+    RecentHelper::contenxtMenuHandle(2, QUrl("recent:///tmp/menu_tab.txt"), QPoint(0, 0));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openTabCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 选中"清空最近记录"应调用 PurgeItems
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_ClearHistoryAction_PurgesRecent)
+{
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+
+    int purgeCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [&]() {
+        __DBG_STUB_INVOKE__
+        ++purgeCalls;
+        return QDBusPendingReply<>();
+    });
+    StubMenuExecReturnAction(3);   // "Clear recent history"
+
+    RecentHelper::contenxtMenuHandle(3, QUrl("recent:///tmp/menu_clear.txt"), QPoint(5, 5));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(purgeCalls, 1);
+}
+
+/**
+ * @brief contenxtMenuHandle 未选中任何菜单项时不应产生副作用
+ */
+TEST_F(RecentManagerTest, ContexntMenuHandle_NoSelection_TakesNoAction)
+{
+    int openWindowCalls = 0;
+    stub.set_lamda(&RecentEventCaller::sendOpenWindow, [&](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ++openWindowCalls;
+    });
+    StubMenuExecReturnAction(-1);   // simulate no action triggered
+
+    RecentHelper::contenxtMenuHandle(4, QUrl("recent:///tmp/menu_none.txt"), QPoint(1, 1));
+
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(openWindowCalls, 0);
+}
+
+/**
+ * @brief openFileLocation 普通用户走桌面服务展示文件
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_DesktopUser_ShowsFileItem)
+{
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *) {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(SysInfoUtils, isRootUser), []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    bool shown = false;
+    stub.set_lamda(static_cast<bool (*)(const QUrl &, const QString &)>(&DDesktopServices::showFileItem),
+                   [&](const QUrl &, const QString &) {
+                       __DBG_STUB_INVOKE__
+                       shown = true;
+                       return true;
+                   });
+
+    EXPECT_TRUE(RecentHelper::openFileLocation(QUrl("recent:///tmp/show_me.txt")));
+    EXPECT_TRUE(shown);
+}
+
+/**
+ * @brief openFileLocation root 用户走 dde-file-manager 进程
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_RootUser_StartsFileManagerProcess)
+{
+    stub.set_lamda(ADDR(UniversalUtils, urlsTransformToLocal),
+                   [](const QList<QUrl> &, QList<QUrl> *) {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(SysInfoUtils, isRootUser), []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    typedef bool (*StartDetachedFn)(const QString &, const QStringList &,
+                                    const QString &, qint64 *);
+    bool detached = false;
+    stub.set_lamda(static_cast<StartDetachedFn>(&QProcess::startDetached),
+                   [&](const QString &program, const QStringList &,
+                       const QString &, qint64 *) {
+                       __DBG_STUB_INVOKE__
+                       detached = program == QStringLiteral("dde-file-manager");
+                       return true;
+                   });
+
+    EXPECT_TRUE(RecentHelper::openFileLocation(QUrl("recent:///tmp/root_case.txt")));
+    EXPECT_TRUE(detached);
+}
+
+/**
+ * @brief openFileLocation 列表版本逐个转发
+ */
+TEST_F(RecentManagerTest, OpenFileLocation_UrlList_ForwardsEachUrl)
+{
+    int singleCalls = 0;
+    stub.set_lamda(static_cast<bool (*)(const QUrl &)>(&RecentHelper::openFileLocation),
+                   [&](const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                       ++singleCalls;
+                       return true;
+                   });
+
+    QList<QUrl> urls { QUrl("recent:///tmp/one.txt"), QUrl("recent:///tmp/two.txt"),
+                       QUrl("recent:///tmp/three.txt") };
+    RecentHelper::openFileLocation(urls);
+
+    EXPECT_EQ(singleCalls, 3);
+}
+
+/**
+ * @brief propetyExtensionFunc 应产出包含源路径的扩展字段
+ */
+TEST_F(RecentManagerTest, PropetyExtensionFunc_ReturnsSourcePathField)
+{
+    const QString filePath = tempDir->filePath("src.txt");
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly));
+    file.close();
+
+    const ExpandFieldMap map = RecentHelper::propetyExtensionFunc(RecentHelper::recentUrl(filePath));
+
+    ASSERT_TRUE(map.contains("kFieldInsert"));
+    const BasicExpand &expand = map.value("kFieldInsert");
+    ASSERT_TRUE(expand.contains("kFileModifiedTime"));
+    EXPECT_EQ(expand.value("kFileModifiedTime").second, filePath);
+    EXPECT_FALSE(expand.value("kFileModifiedTime").first.isEmpty());
+}
+
+/**
+ * @brief processPendingItems 按批次(50条)消费队列并停止定时器
+ */
+TEST_F(RecentManagerTest, ProcessPendingItems_ConsumesQueueInBatches)
+{
+    StubInfoFactoryCreate();
+    for (int i = 0; i < 52; ++i) {
+        RecentManager::PendingItem item;
+        item.path = tempDir->filePath(QString("batch_%1.txt").arg(i));
+        item.href = QString("file:///tmp/batch_%1.txt").arg(i);
+        item.modified = i;
+        manager->pendingItems.enqueue(item);
+    }
+
+    manager->processPendingItems();
+
+    EXPECT_EQ(manager->recentItems.size(), 50);
+    EXPECT_EQ(manager->pendingItems.size(), 2);
+
+    manager->processPendingItems();
+
+    EXPECT_EQ(manager->recentItems.size(), 52);
+    EXPECT_TRUE(manager->pendingItems.isEmpty());
+    EXPECT_FALSE(manager->batchTimer.isActive());   // drained -> timer stopped
+}
+
+/**
+ * @brief ReloadFinished DBus 信号触发批量加载，ItemAdded 信号触发缓存新增
+ */
+TEST_F(RecentManagerTest, ReloadFinishedSignal_QueuesAndDrainsRecentItems)
+{
+    StubInfoFactoryCreate();
+    stub.set_lamda(&RecentManagerDBusInterface::Reload, []() {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<qlonglong>();
+    });
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+    manager->init();
+    ASSERT_NE(manager->dbus(), nullptr);
+
+    // Empty reply: resetRecentNodes still runs, starts the batch timer and the
+    // empty queue drains on the first tick.
+    int itemsInfoCalls = 0;
+    stub.set_lamda(&RecentManagerDBusInterface::GetItemsInfo,
+                   [&](RecentManagerDBusInterface *) -> QDBusPendingReply<QVariantList> {
+                       __DBG_STUB_INVOKE__
+                       ++itemsInfoCalls;
+                       return QDBusPendingReply<QVariantList>();
+                   });
+
+    // Non-zero timestamp triggers resetRecentNodes() which starts the timer.
+    QMetaObject::invokeMethod(manager->dbus(), "ReloadFinished",
+                              Qt::DirectConnection, Q_ARG(qlonglong, 1700000000));
+    EXPECT_EQ(itemsInfoCalls, 1);
+    EXPECT_TRUE(manager->pendingItems.isEmpty());
+    EXPECT_TRUE(manager->batchTimer.isActive());
+
+    // Let the 10ms batch tick drain the (empty) queue and stop the timer.
+    QTest::qWait(50);
+    EXPECT_FALSE(manager->batchTimer.isActive());
+
+    // Zero timestamp must not reload again.
+    QMetaObject::invokeMethod(manager->dbus(), "ReloadFinished",
+                              Qt::DirectConnection, Q_ARG(qlonglong, 0));
+    EXPECT_EQ(itemsInfoCalls, 1);
+
+    // After the once-flag connections are wired, the item signals drive the slots.
+    const QString extraPath = tempDir->filePath("dbus_extra.txt");
+    QMetaObject::invokeMethod(manager->dbus(), "ItemAdded",
+                              Q_ARG(QString, extraPath),
+                              Q_ARG(QString, "file:///tmp/dbus_extra.txt"),
+                              Q_ARG(qlonglong, 42));
+    EXPECT_EQ(manager->recentItems.size(), 1);
+
+    QMetaObject::invokeMethod(manager->dbus(), "ItemsRemoved",
+                              Q_ARG(QStringList, QStringList { extraPath }));
+    EXPECT_EQ(manager->recentItems.size(), 0);
 }


### PR DESCRIPTION
## Summary
- Extend RecentManager tests (+21 cases): item add/remove/change, removeRecentFile, reload/clear, context-menu handling incl. action lambdas, openFileLocation, property extension, batched pending items, DBus signal chains
- Extend FollowEvents real-flow tests (+5 cases): real followEvents/bindEvents then trigger all hooks/signals via dpfHookSequence->run() / dpfSignalDispatcher->publish(), incl. negative branches
- Fix ghost-stub types in test_recent.cpp (RecentManager -> RecentEventReceiver, linkFile signature -> setPermissionHandle), removing 8 unreachable EventHelper instantiations

## Verification
- ut-dfmplugin-recent: 132/132 passed

## Coverage impact
- eventhelper.h dfmplugin_recent instantiations: 82/82 covered
- recentmanager.cpp 29/30, recenteventreceiver.cpp 15/16, recentfilehelper.cpp 9/9, recenteventcaller.cpp 7/7

Replaces the recent part of closed #4441. Base: c13ee5bb

## Summary by Sourcery

Extend dfmplugin-recent tests to validate RecentManager behavior and real event handling across the plugin’s supported workflows.

Enhancements:
- Expand RecentManager coverage across item lifecycle, cache management, DBus reload and purge behavior, context-menu actions, file-location handling, property extensions, and batched item processing.
- Exercise real Recent plugin hook and signal registration paths, including successful and rejected recent-file operations and event chains.

Tests:
- Add comprehensive unit tests for RecentManager and real follow-events flows, covering all registered hooks and bound signals with positive and negative cases.
- Correct stale event receiver and permission-handler type references in existing follow-event tests and remove unreachable helper instantiations.