### PR TITLE
fix: eliminate task dialog resize jitter

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.propertydialog.json
+++ b/assets/configs/org.deepin.dde.file-manager.propertydialog.json
@@ -1,0 +1,72 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "computerCustomLogo.enable":{
+            "value": false,
+            "serial":0,
+            "flags":["global"],
+            "name":"Enable custom logo on the computer property dialog",
+            "name[zh_CN]":"启用计算机属性对话框自定义图标",
+            "description[zh_CN]":"用于控制计算机属性对话框中是否显示自定义图标",
+            "description":"It's used to control whether to display the custom logo in the computer property dialog",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.resourcePath":{
+            "value": "",
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo resource path",
+            "name[zh_CN]":"自定义图标资源路径",
+            "description[zh_CN]":"自定义图标图片的本地文件路径，为空时不显示",
+            "description":"The local file path of the custom logo image. It is not displayed when empty",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.verticalOffset":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo vertical offset",
+            "name[zh_CN]":"自定义图标垂直偏移",
+            "description[zh_CN]":"自定义图标的垂直偏移量（逻辑像素）。不与系统 logo 重叠：大于等于 0 在其下方（间距即偏移量），小于 0 在其上方（绝对值为间距）",
+            "description":"The vertical offset of the custom logo (in logical pixels). It does not overlap the system logo: >=0 places it below (offset is the gap), <0 places it above (absolute value is the gap)",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.horizontalOffset":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo horizontal offset",
+            "name[zh_CN]":"自定义图标水平偏移",
+            "description[zh_CN]":"自定义图标的水平偏移量（逻辑像素），0 与系统 logo 水平居中，大于 0 向右，小于 0 向左",
+            "description":"The horizontal offset of the custom logo (in logical pixels). 0 centers it horizontally on the system logo, greater than 0 moves right, less than 0 moves left",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.width":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo width",
+            "name[zh_CN]":"自定义图标宽度",
+            "description[zh_CN]":"自定义图标的最大宽度（逻辑像素），作为等比缩放约束框",
+            "description":"The maximum width of the custom logo (in logical pixels), used as the proportional scaling bounding box",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.height":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo height",
+            "name[zh_CN]":"自定义图标高度",
+            "description[zh_CN]":"自定义图标的最大高度（逻辑像素），作为等比缩放约束框",
+            "description":"The maximum height of the custom logo (in logical pixels), used as the proportional scaling bounding box",
+            "permissions":"readwrite",
+            "visibility":"public"
+        }
+    }
+}

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -13,6 +13,7 @@
 #include <QMutex>
 #include <QKeyEvent>
 #include <QScreen>
+#include <QTimer>
 
 using namespace dfmbase;
 
@@ -46,7 +47,7 @@ void TaskDialog::addTask(const JobHandlePointer taskHandler)
 
     wid = new TaskWidget(this);
 
-    connect(wid, &TaskWidget::heightChanged, this, &TaskDialog::adjustSize, Qt::QueuedConnection);
+    connect(wid, &TaskWidget::heightChanged, this, &TaskDialog::scheduleResize, Qt::QueuedConnection);
     connect(this, &TaskDialog::closed, wid, &TaskWidget::parentClose, Qt::QueuedConnection);
     taskHandler->connect(taskHandler.get(), &AbstractJobHandler::requestRemoveTaskWidget, this, &TaskDialog::removeTask);
 
@@ -137,10 +138,7 @@ void TaskDialog::addTaskWidget(const JobHandlePointer taskHandler, TaskWidget *w
 
     setWindowFlags(Qt::WindowMinimizeButtonHint | Qt::WindowCloseButtonHint);
     setTitle(taskListWidget->count());
-    adjustSize();
-
-    if (taskItems.count() == 1)
-        moveToCenter();
+    scheduleResize();
 
     setModal(false);
     show();
@@ -156,18 +154,35 @@ void TaskDialog::setTitle(int taskCount)
 }
 
 /*!
- * \brief TaskDialog::adjustSize 调整整个进度显示的高度，当每个item中的widget发生变化时
+ * \brief TaskDialog::scheduleResize 合并同帧内的多次几何请求，事件循环末帧只执行一次几何更新
+ * 新增/移除任务、widget 内部高度变化都会触发本方法，用布尔标志去重，
+ * 保证单帧内无论触发多少次，都只做一次 resizeAndCenter，从而消除抖动。
  */
-void TaskDialog::adjustSize(int hight)
+void TaskDialog::scheduleResize()
 {
-    auto widgit = sender();
+    if (m_resizeScheduled)
+        return;
+    m_resizeScheduled = true;
+    QTimer::singleShot(0, this, [this]() {
+        m_resizeScheduled = false;
+        resizeAndCenter();
+    });
+}
+
+/*!
+ * \brief TaskDialog::resizeAndCenter 计算任务列表高度并一次性完成窗口高度调整与居中
+ * 将「变高/变矮」与「居中移动」合并到同一次事件处理中，中间不产生错位帧，避免视觉抖动。
+ */
+void TaskDialog::resizeAndCenter()
+{
     int listHeight = 2;
     for (int i = 0; i < taskListWidget->count(); i++) {
         QListWidgetItem *item = taskListWidget->item(i);
         auto wg = taskListWidget->itemWidget(item);
-        int h = widgit == wg && hight > 0 ? hight : wg->height();
-        item->setSizeHint(QSize(item->sizeHint().width(), h));
-        listHeight += h;
+        if (!wg)
+            continue;
+        item->setSizeHint(QSize(item->sizeHint().width(), wg->height()));
+        listHeight += wg->height();
     }
 
     int oldHeight = height();
@@ -180,9 +195,15 @@ void TaskDialog::adjustSize(int hight)
     }
 
     layout()->setSizeConstraint(QLayout::SetNoConstraint);
-    
-    // 如果高度发生了变化，重新居中对话框以避免位置偏移
-    if (oldHeight != height()) {
+
+    // 高度未变化时无需移动，避免无谓的窗口重定位
+    if (oldHeight == height())
+        return;
+
+    // 未显示时整体居中；已显示时仅重算纵向位置，保持水平位置不变
+    if (!isVisible()) {
+        moveToCenter();
+    } else {
         moveYCenter();
     }
 }
@@ -231,7 +252,7 @@ void TaskDialog::removeTask()
     if (taskListWidget->count() == 0) {
         close();
     } else {
-        adjustSize();
+        scheduleResize();
     }
 }
 /*!

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -42,7 +42,8 @@ Q_SIGNALS:
 private Q_SLOTS:
     void moveYCenter();
     void removeTask();
-    void adjustSize(int hight = 0);
+    void scheduleResize();
+    void resizeAndCenter();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -56,6 +57,7 @@ private:
     static constexpr uint32_t kInvalidScreenSaverCookie = 0;
     uint32_t screenSaverCookie { kInvalidScreenSaverCookie };
     static int kMaxHeight;
+    bool m_resizeScheduled { false };
 };
 
 }

--- a/src/plugins/common/dfmplugin-propertydialog/CMakeLists.txt
+++ b/src/plugins/common/dfmplugin-propertydialog/CMakeLists.txt
@@ -4,8 +4,8 @@ project(dfmplugin-propertydialog)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Include plugin configuration
-include(DFMPluginConfig)
+# Include shared dependencies configuration
+include(${CMAKE_CURRENT_SOURCE_DIR}/dependencies.cmake)
 
 # 设置二进制文件名
 set(BIN_NAME dfm-propertydialog-plugin)
@@ -34,8 +34,8 @@ add_library(${BIN_NAME}
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_COMMON_DIR})
 
-# Use default plugin configuration
-dfm_apply_default_plugin_config(${BIN_NAME})
+# Apply propertydialog plugin specific configuration
+dfm_setup_propertydialog_dependencies(${BIN_NAME})
 
 # 安装库文件
 install(TARGETS
@@ -44,6 +44,9 @@ install(TARGETS
     DESTINATION
     ${DFM_PLUGIN_COMMON_CORE_DIR}
 )
+
+# install dconfig files.
+INSTALL_DCONFIG("org.deepin.dde.file-manager.propertydialog.json")
 
 
 

--- a/src/plugins/common/dfmplugin-propertydialog/dependencies.cmake
+++ b/src/plugins/common/dfmplugin-propertydialog/dependencies.cmake
@@ -1,0 +1,27 @@
+# dependencies.cmake - Dependencies configuration for dfmplugin-propertydialog
+# This file defines the specific dependencies and configuration for the propertydialog plugin
+
+cmake_minimum_required(VERSION 3.10)
+
+# Include DFM plugin configuration module
+include(DFMPluginConfig)
+
+# Function to setup propertydialog plugin dependencies
+function(dfm_setup_propertydialog_dependencies target_name)
+    message(STATUS "DFM: Setting up propertydialog plugin dependencies for: ${target_name}")
+
+    # Find required packages
+    find_package(Qt6 REQUIRED COMPONENTS Core Svg)
+
+    # Apply default plugin configuration first
+    dfm_apply_default_plugin_config(${target_name})
+
+    # Add propertydialog-specific dependencies
+    target_link_libraries(${target_name} PRIVATE
+        Qt6::Svg
+    )
+
+    message(STATUS "DFM: Propertydialog plugin dependencies configured successfully")
+endfunction()
+
+message(STATUS "DFM: Propertydialog plugin dependencies configuration loaded")

--- a/src/plugins/common/dfmplugin-propertydialog/propertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/propertydialog.cpp
@@ -6,15 +6,25 @@
 #include "events/propertyeventreceiver.h"
 #include "menu/propertymenuscene.h"
 #include "utils/propertydialogmanager.h"
+#include "views/computerpropertydialog.h"
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
 namespace dfmplugin_propertydialog {
 DFM_LOG_REGISTER_CATEGORY(DPPROPERTYDIALOG_NAMESPACE)
+DFMBASE_USE_NAMESPACE
 
 void PropertyDialog::initialize()
 {
     PropertyEventReceiver::instance()->bindEvents();
+
+    QString err;
+    auto ret = DConfigManager::instance()->addConfig(ComputerCustomLogoConfig::kConfName, &err);
+    if (!ret) {
+        fmWarning() << "PropertyDialog: create dconfig failed:" << err;
+    }
 }
 
 bool PropertyDialog::start()

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -4,6 +4,7 @@
 
 #include "computerpropertydialog.h"
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <DSysInfo>
 #include <DFontSizeManager>
@@ -12,8 +13,14 @@
 
 #include <QVBoxLayout>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QPainter>
 #include <QDBusInterface>
+#include <QImageReader>
+#include <QtSvg/QSvgRenderer>
 
+#include <algorithm>
 #include <cmath>
 
 #define SYSTEM_INFO_SERVICE "org.deepin.dde.SystemInfo1"
@@ -23,6 +30,8 @@ static constexpr int kMaximumHeightOfTwoRow { 52 };
 static constexpr int kMaximumHeightOfOneRow { 31 };
 inline constexpr int kIconWidth { 152 };
 inline constexpr int kIconHeight { 39 };
+inline constexpr int kMaxCustomerLogoBytes { 500 << 10 };
+inline constexpr int kMaxCustomerLogoSize { 1024 };
 
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
@@ -53,7 +62,10 @@ void ComputerPropertyDialog::iniUI()
     DFontSizeManager::instance()->bind(titleLabel, DFontSizeManager::T5, QFont::DemiBold);
     titleLabel->setForegroundRole(DPalette::TextTitle);
 
-    computerIcon = new DLabel(this);
+    logoContainer = new QWidget(this);
+    logoContainer->setFixedSize(kIconWidth, kIconHeight);
+
+    computerIcon = new DLabel(logoContainer);
     QString distributerLogoPath = DSysInfo::distributionOrgLogo();
     QIcon logoIcon;
     if (!distributerLogoPath.isEmpty() && QFile::exists(distributerLogoPath)) {
@@ -66,6 +78,11 @@ void ComputerPropertyDialog::iniUI()
     computerIcon->setFixedSize(iconSize);
     computerIcon->setAlignment(Qt::AlignCenter);
     computerIcon->setPixmap(logoIcon.pixmap(iconSize, dpr));
+    computerIcon->move(0, 0);
+
+    customerLogo = new DLabel(logoContainer);
+    customerLogo->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    customerLogo->hide();
 
     basicInfo = new DLabel(tr("Basic Info"), this);
     DFontSizeManager::instance()->bind(basicInfo, DFontSizeManager::T5, QFont::DemiBold);
@@ -127,7 +144,7 @@ void ComputerPropertyDialog::iniUI()
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->addWidget(titleLabel);
     mainLayout->addSpacing(10);
-    mainLayout->addWidget(computerIcon, 0, Qt::AlignHCenter);
+    mainLayout->addWidget(logoContainer, 0, Qt::AlignHCenter);
     mainLayout->addSpacing(15);
     mainLayout->addWidget(basicInfoFrame);
 
@@ -183,8 +200,109 @@ void ComputerPropertyDialog::computerProcess(QMap<ComputerInfoItem, QString> com
 
 void ComputerPropertyDialog::showEvent(QShowEvent *event)
 {
+    loadCustomerLogoConfig();
     thread->startThread();
     DDialog::showEvent(event);
+}
+
+static QPixmap loadLogoPixmap(const QString &uri, const QSize &size, qreal pixelRatio, QSize *logicalSize)
+{
+    if (logicalSize)
+        *logicalSize = QSize();
+
+    QFileInfo file(uri);
+    if (!file.exists()) {
+        fmWarning() << "customer logo file does not exist:" << uri;
+        return QPixmap();
+    }
+
+    if (file.size() > kMaxCustomerLogoBytes) {
+        fmWarning() << "customer logo size exceed 500KB!";
+        return QPixmap();
+    }
+
+    QPixmap pix;
+    if (file.suffix().compare("svg", Qt::CaseInsensitive) == 0) {
+        QSvgRenderer svg(uri);
+        QSize natural = svg.defaultSize();
+        if (natural.isEmpty()) {
+            const QRectF viewBox = svg.viewBoxF();
+            if (!viewBox.isEmpty())
+                natural = viewBox.size().toSize();
+        }
+        if (natural.isEmpty())
+            return pix;
+
+        const QSize fitted = natural.scaled(size, Qt::KeepAspectRatio);
+        const QSize physical = fitted * pixelRatio;
+
+        pix = QPixmap(physical);
+        pix.fill(Qt::transparent);
+        {
+            QPainter painter(&pix);
+            svg.render(&painter, QRect(QPoint(0, 0), pix.size()));
+        }
+        pix.setDevicePixelRatio(pixelRatio);
+        if (logicalSize)
+            *logicalSize = fitted;
+    } else {
+        QImageReader reader(uri);
+        reader.setScaledSize(size * pixelRatio);
+        const QImage image = reader.read();
+        if (image.isNull())
+            return pix;
+        pix = QPixmap::fromImage(image);
+        pix.setDevicePixelRatio(pixelRatio);
+        if (logicalSize)
+            *logicalSize = pix.deviceIndependentSize().toSize();
+    }
+
+    return pix;
+}
+
+void ComputerPropertyDialog::loadCustomerLogoConfig()
+{
+    const bool enable = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kEnable, false).toBool();
+    QString resourcePath = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kResourcePath, QString()).toString();
+    const int verticalOffset = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kVerticalOffset, 0).toInt();
+    const int horizontalOffset = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kHorizontalOffset, 0).toInt();
+    const int width = std::clamp(DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kWidth, 0).toInt(), 0, kMaxCustomerLogoSize);
+    const int height = std::clamp(DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kHeight, 0).toInt(), 0, kMaxCustomerLogoSize);
+
+    if (!enable || resourcePath.isEmpty() || width <= 0 || height <= 0) {
+        customerLogo->hide();
+        computerIcon->move(0, 0);
+        logoContainer->setFixedSize(kIconWidth, kIconHeight);
+        return;
+    }
+
+    if (resourcePath.startsWith("~/"))
+        resourcePath.replace(0, 1, QDir::homePath());
+
+    QSize actualSize;
+    QPixmap logoPixmap = loadLogoPixmap(resourcePath, QSize(width, height), devicePixelRatioF(), &actualSize);
+    if (logoPixmap.isNull()) {
+        customerLogo->hide();
+        computerIcon->move(0, 0);
+        logoContainer->setFixedSize(kIconWidth, kIconHeight);
+        return;
+    }
+
+    const int logoX = (kIconWidth - actualSize.width()) / 2 + horizontalOffset;
+    const int logoY = verticalOffset >= 0 ? kIconHeight + verticalOffset : verticalOffset - actualSize.height();
+
+    const int left = (std::min)(0, logoX);
+    const int top = (std::min)(0, logoY);
+    const int right = (std::max)(kIconWidth, logoX + actualSize.width());
+    const int bottom = (std::max)(kIconHeight, logoY + actualSize.height());
+
+    customerLogo->setPixmap(logoPixmap);
+    customerLogo->setFixedSize(actualSize);
+    customerLogo->move(logoX - left, logoY - top);
+    customerLogo->show();
+
+    computerIcon->move(-left, -top);
+    logoContainer->setFixedSize(right - left, bottom - top);
 }
 
 void ComputerPropertyDialog::closeEvent(QCloseEvent *event)

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.h
@@ -16,6 +16,16 @@
 #include <QThread>
 
 namespace dfmplugin_propertydialog {
+namespace ComputerCustomLogoConfig {
+inline constexpr char kConfName[] { "org.deepin.dde.file-manager.propertydialog" };
+inline constexpr char kEnable[] { "computerCustomLogo.enable" };
+inline constexpr char kResourcePath[] { "computerCustomLogo.resourcePath" };
+inline constexpr char kVerticalOffset[] { "computerCustomLogo.verticalOffset" };
+inline constexpr char kHorizontalOffset[] { "computerCustomLogo.horizontalOffset" };
+inline constexpr char kWidth[] { "computerCustomLogo.width" };
+inline constexpr char kHeight[] { "computerCustomLogo.height" };
+}
+
 class ComputerInfoThread : public QThread
 {
     Q_OBJECT
@@ -72,6 +82,7 @@ public:
 private:
     void iniUI();
     void iniThread();
+    void loadCustomerLogoConfig();
 
 signals:
 
@@ -84,7 +95,9 @@ protected:
 
 private:
     DTK_WIDGET_NAMESPACE::DLabel *computer { nullptr };
+    QWidget *logoContainer { nullptr };
     DTK_WIDGET_NAMESPACE::DLabel *computerIcon { nullptr };
+    DTK_WIDGET_NAMESPACE::DLabel *customerLogo { nullptr };
     DTK_WIDGET_NAMESPACE::DLabel *basicInfo { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *computerName { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *computerVersionNum { nullptr };


### PR DESCRIPTION
1. Coalesce multiple geometry requests within a single frame using
a boolean
   flag and QTimer::singleShot, ensuring only one resize per event loop
cycle
2. Rename adjustSize into scheduleResize and resizeAndCenter to clarify
the
   two-phase approach (schedule then apply)
3. Use each widget's actual height instead of the sender-supplied height
   parameter, making height calculation more reliable
4. Skip window repositioning entirely when the height has not changed,
   avoiding unnecessary window moves
5. When the dialog is already visible, only recalculate the vertical
position
   and keep the horizontal position stable, preventing sideways drift
6. When the dialog is not yet visible, perform a full moveToCenter as
before

Log: 修复任务对话框尺寸变化时的窗口抖动问题，优化窗口居中逻辑

Influence:
1. Test adding multiple tasks to the dialog and verify the dialog
remains
   stable without flickering or jitter during height changes
2. Test removing tasks and confirm the window shrinks smoothly without
   horizontal position drift
3. Test adding the first task and confirm the dialog opens centered
on screen
4. Test continuously adding/removing tasks rapidly to verify all resize
   requests within the same frame are coalesced into one geometry update
5. Test on multi-screen setups to ensure the dialog stays on the correct
   screen when recentering vertically
6. Verify the task progress list remains fully visible after resize
and no
   content is clipped

fix: 消除任务对话框尺寸变化时的窗口抖动

1. 使用布尔标志和 QTimer::singleShot 合并同一帧内的多次几何请求，确保
每个
   事件循环周期只执行一次尺寸调整
2. 将 adjustSize 拆分为 scheduleResize 和 resizeAndCenter，明确两阶段
流程
3. 改用每个 widget 的实际高度而非发送者传入的高度参数，使高度计算更可靠
4. 当高度未变化时直接跳过窗口重定位，避免无意义的窗口移动
5. 窗口已显示时仅重新计算纵向位置，保持水平位置不变，防止横向漂移
6. 窗口未显示时仍然调用 moveToCenter 进行整体居中

Log: 修复任务对话框尺寸变化时的窗口抖动问题，优化窗口居中逻辑

Influence:
1. 测试向对话框中添加多个任务，验证窗口在高度变化过程中保持稳定，
   无闪烁或抖动
2. 测试移除任务，确认窗口平滑收缩且水平位置不偏移
3. 测试添加第一个任务，确认对话框在屏幕上居中显示
4. 测试快速连续添加/移除任务，验证同一帧内的所有尺寸请求被合并
   为一次几何更新
5. 在多屏环境下测试，确保垂直居中时对话框仍停留在正确的屏幕上
6. 确认尺寸调整后任务进度列表完全可见，内容未被裁剪

BUG: https://pms.uniontech.com/bug-view-375283.html

## Summary by Sourcery

Stabilize task dialog resizing and add configurable custom branding to the computer properties dialog.

New Features:
- Add configurable custom logos to the computer properties dialog, including support for raster and SVG assets with size, offset, and enablement settings.

Bug Fixes:
- Eliminate task dialog resize jitter and horizontal drift during task list updates.

Enhancements:
- Improve task dialog geometry handling by coalescing resize requests and preserving stable positioning during visible-dialog resizes.

Build:
- Add property dialog configuration installation and dedicated dependency setup.