### PR TITLE
feat: add custom logo to computer property dialog

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.propertydialog.json
+++ b/assets/configs/org.deepin.dde.file-manager.propertydialog.json
@@ -1,0 +1,72 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "computerCustomLogo.enable":{
+            "value": false,
+            "serial":0,
+            "flags":["global"],
+            "name":"Enable custom logo on the computer property dialog",
+            "name[zh_CN]":"启用计算机属性对话框自定义图标",
+            "description[zh_CN]":"用于控制计算机属性对话框中是否显示自定义图标",
+            "description":"It's used to control whether to display the custom logo in the computer property dialog",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.resourcePath":{
+            "value": "",
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo resource path",
+            "name[zh_CN]":"自定义图标资源路径",
+            "description[zh_CN]":"自定义图标图片的本地文件路径，为空时不显示",
+            "description":"The local file path of the custom logo image. It is not displayed when empty",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.verticalOffset":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo vertical offset",
+            "name[zh_CN]":"自定义图标垂直偏移",
+            "description[zh_CN]":"自定义图标的垂直偏移量（逻辑像素）。不与系统 logo 重叠：大于等于 0 在其下方（间距即偏移量），小于 0 在其上方（绝对值为间距）",
+            "description":"The vertical offset of the custom logo (in logical pixels). It does not overlap the system logo: >=0 places it below (offset is the gap), <0 places it above (absolute value is the gap)",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.horizontalOffset":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo horizontal offset",
+            "name[zh_CN]":"自定义图标水平偏移",
+            "description[zh_CN]":"自定义图标的水平偏移量（逻辑像素），0 与系统 logo 水平居中，大于 0 向右，小于 0 向左",
+            "description":"The horizontal offset of the custom logo (in logical pixels). 0 centers it horizontally on the system logo, greater than 0 moves right, less than 0 moves left",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.width":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo width",
+            "name[zh_CN]":"自定义图标宽度",
+            "description[zh_CN]":"自定义图标的最大宽度（逻辑像素），作为等比缩放约束框",
+            "description":"The maximum width of the custom logo (in logical pixels), used as the proportional scaling bounding box",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "computerCustomLogo.height":{
+            "value": 0,
+            "serial":0,
+            "flags":["global"],
+            "name":"Custom logo height",
+            "name[zh_CN]":"自定义图标高度",
+            "description[zh_CN]":"自定义图标的最大高度（逻辑像素），作为等比缩放约束框",
+            "description":"The maximum height of the custom logo (in logical pixels), used as the proportional scaling bounding box",
+            "permissions":"readwrite",
+            "visibility":"public"
+        }
+    }
+}

--- a/src/plugins/common/dfmplugin-propertydialog/CMakeLists.txt
+++ b/src/plugins/common/dfmplugin-propertydialog/CMakeLists.txt
@@ -4,8 +4,8 @@ project(dfmplugin-propertydialog)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Include plugin configuration
-include(DFMPluginConfig)
+# Include shared dependencies configuration
+include(${CMAKE_CURRENT_SOURCE_DIR}/dependencies.cmake)
 
 # 设置二进制文件名
 set(BIN_NAME dfm-propertydialog-plugin)
@@ -34,8 +34,8 @@ add_library(${BIN_NAME}
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_COMMON_DIR})
 
-# Use default plugin configuration
-dfm_apply_default_plugin_config(${BIN_NAME})
+# Apply propertydialog plugin specific configuration
+dfm_setup_propertydialog_dependencies(${BIN_NAME})
 
 # 安装库文件
 install(TARGETS
@@ -44,6 +44,9 @@ install(TARGETS
     DESTINATION
     ${DFM_PLUGIN_COMMON_CORE_DIR}
 )
+
+# install dconfig files.
+INSTALL_DCONFIG("org.deepin.dde.file-manager.propertydialog.json")
 
 
 

--- a/src/plugins/common/dfmplugin-propertydialog/dependencies.cmake
+++ b/src/plugins/common/dfmplugin-propertydialog/dependencies.cmake
@@ -1,0 +1,27 @@
+# dependencies.cmake - Dependencies configuration for dfmplugin-propertydialog
+# This file defines the specific dependencies and configuration for the propertydialog plugin
+
+cmake_minimum_required(VERSION 3.10)
+
+# Include DFM plugin configuration module
+include(DFMPluginConfig)
+
+# Function to setup propertydialog plugin dependencies
+function(dfm_setup_propertydialog_dependencies target_name)
+    message(STATUS "DFM: Setting up propertydialog plugin dependencies for: ${target_name}")
+
+    # Find required packages
+    find_package(Qt6 REQUIRED COMPONENTS Core Svg)
+
+    # Apply default plugin configuration first
+    dfm_apply_default_plugin_config(${target_name})
+
+    # Add propertydialog-specific dependencies
+    target_link_libraries(${target_name} PRIVATE
+        Qt6::Svg
+    )
+
+    message(STATUS "DFM: Propertydialog plugin dependencies configured successfully")
+endfunction()
+
+message(STATUS "DFM: Propertydialog plugin dependencies configuration loaded")

--- a/src/plugins/common/dfmplugin-propertydialog/propertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/propertydialog.cpp
@@ -6,15 +6,25 @@
 #include "events/propertyeventreceiver.h"
 #include "menu/propertymenuscene.h"
 #include "utils/propertydialogmanager.h"
+#include "views/computerpropertydialog.h"
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
 namespace dfmplugin_propertydialog {
 DFM_LOG_REGISTER_CATEGORY(DPPROPERTYDIALOG_NAMESPACE)
+DFMBASE_USE_NAMESPACE
 
 void PropertyDialog::initialize()
 {
     PropertyEventReceiver::instance()->bindEvents();
+
+    QString err;
+    auto ret = DConfigManager::instance()->addConfig(ComputerCustomLogoConfig::kConfName, &err);
+    if (!ret) {
+        fmWarning() << "PropertyDialog: create dconfig failed:" << err;
+    }
 }
 
 bool PropertyDialog::start()

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -4,6 +4,7 @@
 
 #include "computerpropertydialog.h"
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <DSysInfo>
 #include <DFontSizeManager>
@@ -12,8 +13,14 @@
 
 #include <QVBoxLayout>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QPainter>
 #include <QDBusInterface>
+#include <QImageReader>
+#include <QtSvg/QSvgRenderer>
 
+#include <algorithm>
 #include <cmath>
 
 #define SYSTEM_INFO_SERVICE "org.deepin.dde.SystemInfo1"
@@ -23,6 +30,8 @@ static constexpr int kMaximumHeightOfTwoRow { 52 };
 static constexpr int kMaximumHeightOfOneRow { 31 };
 inline constexpr int kIconWidth { 152 };
 inline constexpr int kIconHeight { 39 };
+inline constexpr int kMaxCustomerLogoBytes { 500 << 10 };
+inline constexpr int kMaxCustomerLogoSize { 1024 };
 
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
@@ -53,7 +62,10 @@ void ComputerPropertyDialog::iniUI()
     DFontSizeManager::instance()->bind(titleLabel, DFontSizeManager::T5, QFont::DemiBold);
     titleLabel->setForegroundRole(DPalette::TextTitle);
 
-    computerIcon = new DLabel(this);
+    logoContainer = new QWidget(this);
+    logoContainer->setFixedSize(kIconWidth, kIconHeight);
+
+    computerIcon = new DLabel(logoContainer);
     QString distributerLogoPath = DSysInfo::distributionOrgLogo();
     QIcon logoIcon;
     if (!distributerLogoPath.isEmpty() && QFile::exists(distributerLogoPath)) {
@@ -66,6 +78,11 @@ void ComputerPropertyDialog::iniUI()
     computerIcon->setFixedSize(iconSize);
     computerIcon->setAlignment(Qt::AlignCenter);
     computerIcon->setPixmap(logoIcon.pixmap(iconSize, dpr));
+    computerIcon->move(0, 0);
+
+    customerLogo = new DLabel(logoContainer);
+    customerLogo->setAttribute(Qt::WA_TransparentForMouseEvents, true);
+    customerLogo->hide();
 
     basicInfo = new DLabel(tr("Basic Info"), this);
     DFontSizeManager::instance()->bind(basicInfo, DFontSizeManager::T5, QFont::DemiBold);
@@ -127,7 +144,7 @@ void ComputerPropertyDialog::iniUI()
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->addWidget(titleLabel);
     mainLayout->addSpacing(10);
-    mainLayout->addWidget(computerIcon, 0, Qt::AlignHCenter);
+    mainLayout->addWidget(logoContainer, 0, Qt::AlignHCenter);
     mainLayout->addSpacing(15);
     mainLayout->addWidget(basicInfoFrame);
 
@@ -183,8 +200,109 @@ void ComputerPropertyDialog::computerProcess(QMap<ComputerInfoItem, QString> com
 
 void ComputerPropertyDialog::showEvent(QShowEvent *event)
 {
+    loadCustomerLogoConfig();
     thread->startThread();
     DDialog::showEvent(event);
+}
+
+static QPixmap loadLogoPixmap(const QString &uri, const QSize &size, qreal pixelRatio, QSize *logicalSize)
+{
+    if (logicalSize)
+        *logicalSize = QSize();
+
+    QFileInfo file(uri);
+    if (!file.exists()) {
+        fmWarning() << "customer logo file does not exist:" << uri;
+        return QPixmap();
+    }
+
+    if (file.size() > kMaxCustomerLogoBytes) {
+        fmWarning() << "customer logo size exceed 500KB!";
+        return QPixmap();
+    }
+
+    QPixmap pix;
+    if (file.suffix().compare("svg", Qt::CaseInsensitive) == 0) {
+        QSvgRenderer svg(uri);
+        QSize natural = svg.defaultSize();
+        if (natural.isEmpty()) {
+            const QRectF viewBox = svg.viewBoxF();
+            if (!viewBox.isEmpty())
+                natural = viewBox.size().toSize();
+        }
+        if (natural.isEmpty())
+            return pix;
+
+        const QSize fitted = natural.scaled(size, Qt::KeepAspectRatio);
+        const QSize physical = fitted * pixelRatio;
+
+        pix = QPixmap(physical);
+        pix.fill(Qt::transparent);
+        {
+            QPainter painter(&pix);
+            svg.render(&painter, QRect(QPoint(0, 0), pix.size()));
+        }
+        pix.setDevicePixelRatio(pixelRatio);
+        if (logicalSize)
+            *logicalSize = fitted;
+    } else {
+        QImageReader reader(uri);
+        reader.setScaledSize(size * pixelRatio);
+        const QImage image = reader.read();
+        if (image.isNull())
+            return pix;
+        pix = QPixmap::fromImage(image);
+        pix.setDevicePixelRatio(pixelRatio);
+        if (logicalSize)
+            *logicalSize = pix.deviceIndependentSize().toSize();
+    }
+
+    return pix;
+}
+
+void ComputerPropertyDialog::loadCustomerLogoConfig()
+{
+    const bool enable = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kEnable, false).toBool();
+    QString resourcePath = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kResourcePath, QString()).toString();
+    const int verticalOffset = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kVerticalOffset, 0).toInt();
+    const int horizontalOffset = DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kHorizontalOffset, 0).toInt();
+    const int width = std::clamp(DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kWidth, 0).toInt(), 0, kMaxCustomerLogoSize);
+    const int height = std::clamp(DConfigManager::instance()->value(ComputerCustomLogoConfig::kConfName, ComputerCustomLogoConfig::kHeight, 0).toInt(), 0, kMaxCustomerLogoSize);
+
+    if (!enable || resourcePath.isEmpty() || width <= 0 || height <= 0) {
+        customerLogo->hide();
+        computerIcon->move(0, 0);
+        logoContainer->setFixedSize(kIconWidth, kIconHeight);
+        return;
+    }
+
+    if (resourcePath.startsWith("~/"))
+        resourcePath.replace(0, 1, QDir::homePath());
+
+    QSize actualSize;
+    QPixmap logoPixmap = loadLogoPixmap(resourcePath, QSize(width, height), devicePixelRatioF(), &actualSize);
+    if (logoPixmap.isNull()) {
+        customerLogo->hide();
+        computerIcon->move(0, 0);
+        logoContainer->setFixedSize(kIconWidth, kIconHeight);
+        return;
+    }
+
+    const int logoX = (kIconWidth - actualSize.width()) / 2 + horizontalOffset;
+    const int logoY = verticalOffset >= 0 ? kIconHeight + verticalOffset : verticalOffset - actualSize.height();
+
+    const int left = (std::min)(0, logoX);
+    const int top = (std::min)(0, logoY);
+    const int right = (std::max)(kIconWidth, logoX + actualSize.width());
+    const int bottom = (std::max)(kIconHeight, logoY + actualSize.height());
+
+    customerLogo->setPixmap(logoPixmap);
+    customerLogo->setFixedSize(actualSize);
+    customerLogo->move(logoX - left, logoY - top);
+    customerLogo->show();
+
+    computerIcon->move(-left, -top);
+    logoContainer->setFixedSize(right - left, bottom - top);
 }
 
 void ComputerPropertyDialog::closeEvent(QCloseEvent *event)

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.h
@@ -16,6 +16,16 @@
 #include <QThread>
 
 namespace dfmplugin_propertydialog {
+namespace ComputerCustomLogoConfig {
+inline constexpr char kConfName[] { "org.deepin.dde.file-manager.propertydialog" };
+inline constexpr char kEnable[] { "computerCustomLogo.enable" };
+inline constexpr char kResourcePath[] { "computerCustomLogo.resourcePath" };
+inline constexpr char kVerticalOffset[] { "computerCustomLogo.verticalOffset" };
+inline constexpr char kHorizontalOffset[] { "computerCustomLogo.horizontalOffset" };
+inline constexpr char kWidth[] { "computerCustomLogo.width" };
+inline constexpr char kHeight[] { "computerCustomLogo.height" };
+}
+
 class ComputerInfoThread : public QThread
 {
     Q_OBJECT
@@ -72,6 +82,7 @@ public:
 private:
     void iniUI();
     void iniThread();
+    void loadCustomerLogoConfig();
 
 signals:
 
@@ -84,7 +95,9 @@ protected:
 
 private:
     DTK_WIDGET_NAMESPACE::DLabel *computer { nullptr };
+    QWidget *logoContainer { nullptr };
     DTK_WIDGET_NAMESPACE::DLabel *computerIcon { nullptr };
+    DTK_WIDGET_NAMESPACE::DLabel *customerLogo { nullptr };
     DTK_WIDGET_NAMESPACE::DLabel *basicInfo { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *computerName { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *computerVersionNum { nullptr };


### PR DESCRIPTION
1. Add a DConfig schema `org.deepin.dde.file-manager.propertydialog`
with settings for custom logo enable flag, resource path, horizontal/
vertical offsets, and width/height constraints.
2. Extend the computer property dialog UI to place an optional customer
logo next to the default system logo, dynamically growing the logo
container when the custom logo overflows.
3. Support both SVG and raster image formats, with a 500KB file size
limit and a 1024px maximum logo dimension; invalid or disabled settings
fall back to the default logo layout.
4. Refactor plugin CMake configuration into a dedicated
dependencies.cmake, linking Qt6::Svg and installing the new DConfig
schema file.

Log: Computer property dialog supports OEM custom logo configuration

Influence:
1. Verify the custom logo is displayed when the enable option is true
and a valid resource path is provided.
2. Test with missing files, empty resource paths, disabled enable, and
invalid sizes to confirm a graceful fallback to the original system
logo.
3. Validate SVG and common raster formats, including files greater than
500KB and dimensions beyond the 1024px constraint, ensuring they are
rejected or clamped.
4. Check vertical and horizontal offsets, especially negative offsets,
to ensure the logo does not unexpectedly shift the system logo out of
view.
5. Test rendering under HiDPI scaling to confirm measuring and device
pixel ratio are handled correctly.
6. Verify that toggling Dconfig values at runtime works when reopening
the computer property dialog and does not affect other plugin pages.

feat: 添加计算机属性对话框自定义图标支持

1. 新增 DConfig 配置文件 `org.deepin.dde.file-manager.propertydialog`，
包含自定义图标的启用开关、资源路径、水平/垂直偏移以及宽高约束。
2. 为计算机属性对话框增加可选的自定义图标展示能力，将自定义图标与系统默
认图标同容器布局，并在溢出时自动扩展容器区域。
3. 支持 SVG 与常见位图格式，限制文件大小不超过 500KB，单个边最大 1024 逻
辑像素；配置无效或加载失败时自动回退到默认系统图标布局。
4. 调整插件 CMake 构建结构，引入 dependencies.cmake 统一配置 Qt6::Svg 依
赖，并安装新增的

TASK: https://pms.uniontech.com/task-view-395373.html

## Summary by Sourcery

Enable validated, configurable custom logos in the computer property dialog while preserving the default layout when configuration or resources are invalid.

New Features:
- Add configurable OEM logo support to the computer property dialog, including custom resource path, dimensions, offsets, and enablement settings.
- Support SVG and raster custom logos with validation limits and automatic fallback to the default system logo.

Enhancements:
- Resize and reposition the logo container dynamically so custom logos can coexist with the system logo without clipping.

Build:
- Refactor property dialog dependency configuration and add the Qt6 SVG dependency.
- Install the new DConfig schema for computer property dialog logo settings.