### PR TITLE
fix: exclude directories from desktop file detection

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -247,7 +247,7 @@ bool FileUtils::isDesktopFile(const QUrl &url)
         return false;
 
     if (isDesktopFileSuffix(url))
-        return true;
+        return QFileInfo(url.toLocalFile()).isFile();
 
     const QString &target = symlinkTarget(url);
     if (!target.isEmpty()
@@ -273,7 +273,7 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
     Q_ASSERT(info);
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
     if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop)
-        return true;
+        return !info->isAttributes(OptInfoType::kIsDir);
 
     if ((info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
          || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())


### PR DESCRIPTION
## Root Cause Analysis

Commit `8e64a7b2c` optimized desktop file detection by replacing MIME-type checks with pure suffix matching to eliminate network I/O from the paint path. However, `isDesktopFile` and `isDesktopFileInfo` only check whether the filename ends with `.desktop` without verifying the path is a regular file. As a result, directories named `*.desktop` (e.g., `org.deepin.dde.file-manager.desktop`) are misidentified as desktop files, causing the rename handler to route them through the desktop-entry modification path which fails for directories.

## Fix

Add `QFileInfo::isFile()` check in `isDesktopFile` and `isAttributes(kIsDir)` check in `isDesktopFileInfo` to exclude directories. `isDesktopFileSuffix` (used in the paint/sort path) is intentionally left unchanged to preserve performance.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Commit `8e64a7b2c` introduced the optimization; this change does not revert it — it only adds a directory exclusion check on top of the existing suffix match.
- `isDesktopFileSuffix` (called from `fileviewsorter.cpp` in the paint path) is unchanged, so paint path performance is not affected.

### Business Impact Scope

- **File rename**: Directories named `*.desktop` can now be renamed normally instead of being routed through the desktop-entry rename path.
- **File preview / open-with / context menu / clipboard / drag-drop**: Directories with `.desktop` suffix no longer trigger desktop-file-specific behavior.
- **File view sorting (paint path)**: Unchanged — still uses `isDesktopFileSuffix` for performance.

### Verification Suggestion

1. Create a directory named `test.desktop`, verify it can be renamed normally.
2. Verify normal `.desktop` files still hide emblems, show desktop context menu, and open correctly.
3. Scroll file view containing `.desktop` files with disconnected SMB — verify no performance regression.

---

## 根因分析

提交 `8e64a7b2c` 为消除 paint 路径中的网络 I/O，将 desktop 文件检测从 MIME 类型判断改为纯后缀匹配。但 `isDesktopFile` 和 `isDesktopFileInfo` 仅检查文件名是否以 `.desktop` 结尾，不区分文件和目录。导致以 `.desktop` 结尾的目录（如 `org.deepin.dde.file-manager.desktop`）被误判为 desktop 文件，重命名时走 desktop entry 修改路径，对目录操作失败。

## 修复方案

在 `isDesktopFile` 中增加 `QFileInfo::isFile()` 检查，在 `isDesktopFileInfo` 中增加 `isAttributes(kIsDir)` 检查，排除目录。`isDesktopFileSuffix`（paint/排序路径使用）保持不变，不影响性能。

## 改动安全评估

### 代码安全评估

- **风险等级**：低
- 提交 `8e64a7b2c` 引入了优化，本次修改不撤销该优化——仅在后缀匹配基础上增加目录排除检查。
- `isDesktopFileSuffix`（`fileviewsorter.cpp` paint 路径调用）未修改，paint 路径性能不受影响。

### 业务影响范围

- **文件重命名**：名为 `*.desktop` 的目录可正常重命名，不再走 desktop entry 修改路径。
- **文件预览 / 打开方式 / 右键菜单 / 剪贴板 / 拖拽**：以 `.desktop` 结尾的目录不再触发 desktop 文件专属行为。
- **文件视图排序（paint 路径）**：不变——仍使用 `isDesktopFileSuffix` 保证性能。

### 验证建议

1. 新建目录名为 `test.desktop`，验证可正常重命名。
2. 验证正常 `.desktop` 文件仍隐藏角标、显示 desktop 右键菜单、正常打开。
3. 在 SMB 断连情况下滚动含 `.desktop` 文件的视图，验证无性能回退。

## Summary by Sourcery

Bug Fixes:
- Exclude directories with a `.desktop` suffix from desktop-file-specific handling so they can be renamed and managed normally.