### PR TITLE
chore: bump version 6.5.171

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-file-manager (6.5.171) unstable; urgency=medium
+
+  * fix: eliminate task dialog resize jitter
+  * feat: add custom logo to computer property dialog
+  * fix: exclude directories from desktop file detection
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 09 Sep 2026 17:57:38 +0800
+
 dde-file-manager (6.5.170) unstable; urgency=medium
 
   * fix: add metadata::emblems to GIO file attributes query


### PR DESCRIPTION
6.5.171

Log:

## Summary by Sourcery

Chores:
- Update the Debian changelog for version 6.5.171.