### PR TITLE
fix(emblem): read fresh metadata::emblems via temporary DFileInfo

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -86,7 +86,12 @@ QMap<int, QIcon> GioEmblemWorker::getGioEmblems(const FileInfoPointer &info) con
 
     if (!info)
         return {};
-    const QStringList &emblemData = info->customAttribute("metadata::emblems", DFileInfo::DFileAttributeType::kTypeStringV).toStringList();
+
+    const QUrl &url = info->urlOf(UrlInfoType::kUrl);
+    DFMIO::DFileInfo dfi(url);
+    if (!dfi.initQuerier())
+        return emblemsMap;
+    const QStringList &emblemData = dfi.customAttribute("metadata::emblems", DFileInfo::DFileAttributeType::kTypeStringV).toStringList();
 
     if (emblemData.isEmpty())
         return emblemsMap;
@@ -163,18 +168,20 @@ bool GioEmblemWorker::iconNamesEqual(const QList<QIcon> &first, const QList<QIco
     if (first.size() != second.size())
         return false;
 
-    QVector<QString> firstNames { first.size(), QString() };
-    QVector<QString> secondNames { second.size(), QString() };
+    for (int i = 0; i < first.size(); ++i) {
+        const auto &nameA = first.at(i).name();
+        const auto &nameB = second.at(i).name();
 
-    std::transform(first.begin(), first.end(), firstNames.begin(), [](const QIcon &icon) {
-        return icon.name();
-    });
+        if (!nameA.isEmpty() || !nameB.isEmpty()) {
+            if (nameA != nameB)
+                return false;
+        } else {
+            if (first.at(i).cacheKey() != second.at(i).cacheKey())
+                return false;
+        }
+    }
 
-    std::transform(second.begin(), second.end(), secondNames.begin(), [](const QIcon &icon) {
-        return icon.name();
-    });
-
-    return firstNames == secondNames;
+    return true;
 }
 
 void GioEmblemWorker::setEmblemIntoIcons(const QString &pos, const QIcon &emblem, QMap<int, QIcon> *iconMap) const


### PR DESCRIPTION
## Root Cause Analysis

Commit `5994ac79f` changed `getGioEmblems()` to use the cached `FileInfo` passed from the model instead of creating a fresh one. The cached `FileInfo`'s internal `DFileInfo` holds a stale `GFileInfo*` snapshot — `queryInfoSync()` returns cached data without re-querying GIO when `!infoReseted && gfileinfo`. As a result, `customAttribute("metadata::emblems")` reads outdated data, so emblem changes made via `gio set` go undetected until the file manager process is restarted.

Key evidence: `dfileinfo.cpp:228` (cached snapshot return), `dfileinfo.cpp:986` (customAttribute reads from stale snapshot).

## Fix

Create a lightweight `DFMIO::DFileInfo` in `getGioEmblems()` to query GIO directly for the `metadata::emblems` attribute, bypassing the stale cache. Also fix `iconNamesEqual()` to fall back to `cacheKey()` comparison when `QIcon::name()` is empty (path-based image icons), preventing different image emblems from being falsely equal.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- No function signature changes, no public API changes — both modifications are internal logic adjustments within `getGioEmblems()` and `iconNamesEqual()`.
- The bug-introducing commit `5994ac79f` was a performance optimization; this fix preserves its direction (avoiding full FileInfo recreation) while ensuring correctness by querying only the single needed attribute via a lightweight DFileInfo.
- No conflicts with related PMS bug fixes (375625, 332599, 327231) — those affect `systemEmblems()` and `EmblemHelper`, not `getGioEmblems()`.

### Business Impact Scope

Affected module: **file emblem display** — the GIO emblem (`metadata::emblems`) rendering in the file manager view.

- Users setting emblems via `gio set` will now see automatic refresh without restarting the file manager.
- Right-click refresh also correctly updates emblems.
- Theme-based emblems (e.g., `emblem-symbolic-link`) are unaffected — `iconNamesEqual` still uses `name()` comparison for non-empty names.

### Verification Suggestion

1. Use `gio set <file> -t stringv metadata::emblems "<path>;<position>"` to set/modify/clear emblems; verify the file manager view refreshes automatically.
2. Switch between different image path emblems and confirm the icon updates correctly (validates `iconNamesEqual` fix).
3. Verify theme-based emblems (symlink, readonly) still display normally.

---

## 根因分析

commit `5994ac79f` 将 `getGioEmblems()` 从新建 FileInfo 改为使用模型传入的缓存 FileInfo。缓存 FileInfo 内部的 `DFileInfo` 持有过期的 `GFileInfo*` 快照——`queryInfoSync()` 在 `!infoReseted && gfileinfo` 时直接返回缓存数据不重新查询 GIO。因此 `customAttribute("metadata::emblems")` 读取到过期数据，通过 `gio set` 设置的角标变化无法被检测到，直到重启文件管理器进程。

关键证据：`dfileinfo.cpp:228`（缓存快照返回）、`dfileinfo.cpp:986`（customAttribute 从过期快照读取）。

## 修复方案

在 `getGioEmblems()` 中创建轻量 `DFMIO::DFileInfo` 直接查询 GIO 读取 `metadata::emblems` 属性，绕过过期缓存。同时修复 `iconNamesEqual()`，在 `QIcon::name()` 为空（路径图片图标）时回退到 `cacheKey()` 比较，防止不同图片角标被误判为相同。

## 改动安全评估

### 代码安全

- **风险等级**：低
- 无函数签名变更，无公开 API 变更——两处修改均为 `getGioEmblems()` 和 `iconNamesEqual()` 的内部逻辑调整。
- 引入 bug 的 commit `5994ac79f` 是性能优化；本修复保留其优化方向（避免完整 FileInfo 重建），仅通过轻量 DFileInfo 查询单个属性来保证正确性。
- 与关联 PMS bug 修复（375625、332599、327231）无冲突——那些修改影响 `systemEmblems()` 和 `EmblemHelper`，不影响 `getGioEmblems()`。

### 业务影响范围

受影响模块：**文件角标显示**——文件管理器视图中的 GIO 角标（`metadata::emblems`）渲染。

- 用户通过 `gio set` 设置角标后，文件管理器视图将自动刷新，无需重启进程。
- 右键刷新也能正确更新角标。
- 主题图标角标（如 `emblem-symbolic-link`）不受影响——`iconNamesEqual` 对非空 name 仍使用 `name()` 比较。

### 验证建议

1. 通过 `gio set <file> -t stringv metadata::emblems "<path>;<position>"` 设置/修改/清除角标，验证文件管理器视图是否自动刷新。
2. 切换不同图片路径的角标，确认图标正确更新（验证 `iconNamesEqual` 修复）。
3. 验证主题图标角标（符号链接、只读）仍正常显示。

## Summary by Sourcery

Ensure file emblem updates are read from fresh GIO metadata and accurately reflected in the file manager.

Bug Fixes:
- Refresh GIO emblems from current metadata so emblem changes are detected without restarting the file manager.
- Correctly distinguish path-based image emblems when comparing icons.