### PR TITLE
fix: handle TPM auth cancellation in disk encrypt unlock

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -424,14 +424,24 @@ bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *c
 
     // test tpm
     bool testTPM = (type == kPin || type == kTpm);
-    if (testTPM && tpm_utils::checkTPM() != 0) {
-        fmWarning() << "TPM service is not available for device:" << dev;
-        int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"));
-        // unlock by recovery key.
-        if (ret == 0)
-            *pwd = acquirePassphraseByRec(dev, *cancelled);
+    if (testTPM) {
+        bool authFailed = false;
+        int tpmRet = tpm_utils::checkTPM(&authFailed);
+        if (authFailed) {
+            // PolicyKit authorization failed/cancelled by user, treat as cancel this unlock.
+            fmInfo() << "TPM authorization cancelled by user for device:" << dev;
+            *cancelled = true;
+            return true;
+        }
+        if (tpmRet != 0) {
+            fmWarning() << "TPM service is not available for device:" << dev;
+            int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"));
+            // unlock by recovery key.
+            if (ret == 0)
+                *pwd = acquirePassphraseByRec(dev, *cancelled);
 
-        return true;
+            return true;
+        }
     }
 
     switch (type) {

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -62,8 +62,11 @@ QString config_utils::cipherType()
     return cipher;
 }
 
-int tpm_utils::checkTPM()
+int tpm_utils::checkTPM(bool *authFailed)
 {
+    if (authFailed)
+        *authFailed = false;
+
     QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
     iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
@@ -72,7 +75,17 @@ int tpm_utils::checkTPM()
     }
 
     QDBusReply<int> reply = iface.call("IsTPMAvailable");
-    return reply.isValid() ? reply.value() : -1;
+    if (!reply.isValid()) {
+        fmWarning() << "IsTPMAvailable DBus call failed";
+        return -1;
+    }
+
+    int ret = reply.value();
+    // A valid reply carrying -1 means the service side returned kAuthFailed
+    // (PolicyKit authorization failed/cancelled by user).
+    if (authFailed)
+        *authFailed = (ret == -1);
+    return ret;
 }
 
 int tpm_utils::checkTPMLockoutStatus()

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -18,7 +18,7 @@ typedef QSharedPointer<dfmmount::DBlockDevice> BlockDev;
 namespace dfmplugin_diskenc {
 
 namespace tpm_utils {
-int checkTPM();
+int checkTPM(bool *authFailed = nullptr);
 int checkTPMLockoutStatus();
 int getRandomByTPM(int size, QString *output);
 int isSupportAlgoByTPM(const QString &algoName, bool *support);


### PR DESCRIPTION
Cherry-pick of a757b86a0ce0e0c5ef2dea3d22490b541547dfee onto release/snipe.

正确处理磁盘加密解锁时的 TPM 授权取消：
1. 为 tpm_utils::checkTPM() 增加可选的 authFailed 输出参数，区分 DBus 返回值 -1（PolicyKit 失败/用户取消）与真正的 TPM 不可用错误。
2. 在 EventsHandler::onAcquireDevicePwd 中检测到认证取消时直接取消解锁流程，不再弹出 TPM 状态异常提示。
3. TPM 不可用但未被取消时保留恢复密钥解锁流程。
4. 单独打印 DBus 调用失败日志。

BUG: https://pms.uniontech.com/bug-view-376185.html

## Summary by Sourcery

Correctly handle TPM authorization cancellation during disk-encryption unlock flows.

Bug Fixes:
- Handle TPM authorization cancellation during encrypted-disk unlocking as a user cancellation instead of reporting an abnormal TPM status.
- Preserve recovery-key unlocking when TPM is unavailable for reasons other than authorization cancellation.

Enhancements:
- Distinguish PolicyKit authorization failures from other TPM availability errors and log failed DBus availability checks separately.