### PR TITLE
fix: improve share name handling and cursor position

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -448,6 +448,15 @@ void ShareControlWidget::updateShare()
 {
     QString filePath = url.toLocalFile();
 
+    // Revert to the previous share name when the editor is emptied.
+    if (shareNameEditor->text().trimmed().isEmpty()) {
+        QString fallback = UserShareHelperInstance->shareNameByPath(filePath);
+        if (fallback.isEmpty() && info)
+            fallback = info->displayOf(DisPlayInfoType::kFileDisplayName);
+        if (!fallback.isEmpty())
+            shareNameEditor->setText(fallback);
+    }
+
     // Get share info before update
     auto oldShareInfo = UserShareHelperInstance->shareInfoByPath(filePath);
     bool wasAnonymous = oldShareInfo.value(ShareInfoKeys::kAnonymous).toBool();
@@ -588,13 +597,28 @@ void ShareControlWidget::onSambaPasswordSet(bool result)
 void ShareControlWidget::onShareNameChanged(const QString &name)
 {
     static const int kShareNameMaxLen { 150 };
-    QString newText(name.trimmed());
+    QLineEdit *lineEdit = shareNameEditor->lineEdit();
+    const int cursorPos = lineEdit->cursorPosition();
+
+    // Count leading whitespace that trimmed() will strip, so the cursor can be
+    // repositioned correctly after the text is rewritten.
+    int leadingSpaces = 0;
+    while (leadingSpaces < name.size() && name.at(leadingSpaces).isSpace())
+        ++leadingSpaces;
+
+    QString newText = name.trimmed().toLower();
     bool showAlert = false;
     while (newText.toLocal8Bit().length() > kShareNameMaxLen) {
         newText.chop(1);
         showAlert = true;
     }
+
     shareNameEditor->setText(newText);
+    // Keep the cursor right after the just-typed character instead of jumping to
+    // the end, regardless of whether the text was lowercased, trimmed or truncated.
+    const int newCursorPos = qMin(qMax(0, cursorPos - leadingSpaces), newText.size());
+    lineEdit->setCursorPosition(newCursorPos);
+
     QTimer::singleShot(0, shareNameEditor, [this, showAlert] {
         if (showAlert)
             shareNameEditor->showAlertMessage(tr("The shared name is too long and will be truncated."));


### PR DESCRIPTION
Cherry-pick of 2c6c69e32be0e914d9cd4c9b68e80209e4a1ebe9 onto release/snipe.

优化共享名称处理与光标位置：
1. 更新共享时若共享名称编辑器被清空，恢复为之前的名称。
2. 优先使用共享辅助模块查询到的共享名称，否则使用文件显示名称。
3. 共享名称规范化：去除首尾空白并转换为小写。
4. 在修剪、转小写或截断后保持光标位置，避免跳到末尾。
5. 保留 150 字节截断限制及对应提示信息。

BUG: https://pms.uniontech.com/bug-view-376373.html

## Summary by Sourcery

Improve shared-name handling by restoring empty names, normalizing input, and maintaining cursor position during edits.

Bug Fixes:
- Restore the previous or display-derived share name when the share name editor is cleared during an update.
- Normalize share names by trimming whitespace and converting text to lowercase while preserving the 150-byte truncation limit and user warning.
- Preserve the editor cursor position when share names are normalized or truncated.