### PR TITLE
fix: make crash backtrace handler async-signal-safe

### DIFF
--- a/autotests/libs/dfm-framework/test_backtrace.cpp
+++ b/autotests/libs/dfm-framework/test_backtrace.cpp
@@ -272,38 +272,30 @@ TEST_F(BacktraceTest, PrintStack_Skip)
 
 /**
  * @brief 测试stackTraceHandler函数
- * 验证信号处理器的行为
+ * 验证信号处理器的行为 — async-signal-safe 版本
+ *
+ * 新版 handler 不再调用 signal()/strsignal()/printStack()，
+ * 改为调用 backtrace()/backtrace_symbols_fd()/write()/raise()。
  */
 TEST_F(BacktraceTest, StackTraceHandler)
 {
-    // 保存原始信号处理器
-    auto original_handler = signal(SIGTERM, SIG_DFL);
-
-    // 打桩signal函数以避免实际修改信号处理器
-    int signal_calls = 0;
-    stub.set_lamda(&signal, [&signal_calls](int sig, sighandler_t handler) -> sighandler_t {
+    // 打桩backtrace函数，避免实际堆栈遍历
+    stub.set_lamda(&::backtrace, [](void **buffer, int size) -> int {
         __DBG_STUB_INVOKE__
-        signal_calls++;
-        Q_UNUSED(sig)
-        Q_UNUSED(handler)
-        return SIG_DFL;
+        Q_UNUSED(buffer)
+        Q_UNUSED(size)
+        return 5;   // 模拟5个帧
     });
 
-    // 打桩strsignal函数
-    stub.set_lamda(&strsignal, [](int sig) -> char * {
+    // 打桩backtrace_symbols_fd，避免写入stderr
+    bool bt_symbols_called = false;
+    stub.set_lamda(&backtrace_symbols_fd, [&bt_symbols_called](void *const *buffer, int size, int fd) -> void {
         __DBG_STUB_INVOKE__
-        Q_UNUSED(sig)
-        return const_cast<char *>("Test signal");
+        Q_UNUSED(buffer)
+        Q_UNUSED(size)
+        Q_UNUSED(fd)
+        bt_symbols_called = true;
     });
-
-    // 打桩printStack函数
-    bool print_stack_called = false;
-    stub.set_lamda(static_cast<void (*)(int)>(&dpf::backtrace::inner::printStack),
-                   [&print_stack_called](int skip) {
-                       __DBG_STUB_INVOKE__
-                       print_stack_called = true;
-                       EXPECT_EQ(skip, 3);   // 应该跳过3帧
-                   });
 
     // 打桩raise函数以避免实际发送信号
     bool raise_called = false;
@@ -317,30 +309,29 @@ TEST_F(BacktraceTest, StackTraceHandler)
     // 调用信号处理器
     dpf::backtrace::inner::stackTraceHandler(SIGTERM);
 
-    // 验证各个函数被正确调用
-    EXPECT_GT(signal_calls, 0);   // signal应该被调用
-    EXPECT_TRUE(print_stack_called);   // printStack应该被调用
+    // 验证各函数被正确调用
+    EXPECT_TRUE(bt_symbols_called);   // backtrace_symbols_fd应该被调用
     EXPECT_TRUE(raise_called);   // raise应该被调用
-
-    // 恢复原始信号处理器
-    signal(SIGTERM, original_handler);
 }
 
 /**
  * @brief 测试installStackTraceHandler的once_flag机制
  * 验证多次调用只执行一次的机制
+ *
+ * 新版使用 sigaction 替代 signal。
  */
 TEST_F(BacktraceTest, InstallStackTraceHandler_OnceFlag)
 {
-    int signal_call_count = 0;
+    int sigaction_call_count = 0;
 
-    // 打桩signal函数来计数调用次数
-    stub.set_lamda(&signal, [&signal_call_count](int sig, sighandler_t handler) -> sighandler_t {
+    // 打桩sigaction函数来计数调用次数
+    stub.set_lamda(&sigaction, [&sigaction_call_count](int signum, const struct sigaction *act, struct sigaction *oldact) -> int {
         __DBG_STUB_INVOKE__
-        signal_call_count++;
-        Q_UNUSED(sig)
-        Q_UNUSED(handler)
-        return SIG_DFL;
+        sigaction_call_count++;
+        Q_UNUSED(signum)
+        Q_UNUSED(act)
+        Q_UNUSED(oldact)
+        return 0;
     });
 
     // 多次调用安装函数
@@ -348,40 +339,43 @@ TEST_F(BacktraceTest, InstallStackTraceHandler_OnceFlag)
         dpf::backtrace::installStackTraceHandler();
     }
 
-    // 由于once_flag机制，signal应该只在第一次调用时被调用。
+    // 由于once_flag机制，sigaction应该只在第一次调用时被调用。
     // 注意：共享库中的 static once_flag 在进程生命周期内一旦设置就不会重置，
     // 如果之前的测试（如 InstallStackTraceHandler_Basic）已经触发了 once_flag，
-    // 那么 signal stub 不会被调用，signal_call_count 为 0 也是合法的。
+    // 那么 sigaction stub 不会被调用，sigaction_call_count 为 0 也是合法的。
     // 验证：多次调用不会崩溃（once_flag 保证单次执行）
-    EXPECT_GE(signal_call_count, 0);
+    EXPECT_GE(sigaction_call_count, 0);
 
     // 再次调用，计数不应增加（once_flag 阻止重复执行）
-    int previous_count = signal_call_count;
+    int previous_count = sigaction_call_count;
     dpf::backtrace::installStackTraceHandler();
-    EXPECT_EQ(signal_call_count, previous_count);
+    EXPECT_EQ(sigaction_call_count, previous_count);
 }
 
 /**
  * @brief 测试条件编译分支
  * 验证DPF_FULLSIG_STRACE_ENABLE相关代码
+ *
+ * 新版使用 sigaction 替代 signal。
  */
 TEST_F(BacktraceTest, InstallStackTraceHandler_ConditionalCompilation)
 {
     std::vector<int> registered_signals;
 
-    // 打桩signal函数来记录注册的信号
-    stub.set_lamda(&signal, [&registered_signals](int sig, sighandler_t handler) -> sighandler_t {
+    // 打桩sigaction函数来记录注册的信号
+    stub.set_lamda(&sigaction, [&registered_signals](int signum, const struct sigaction *act, struct sigaction *oldact) -> int {
         __DBG_STUB_INVOKE__
-        registered_signals.push_back(sig);
-        Q_UNUSED(handler)
-        return SIG_DFL;
+        registered_signals.push_back(signum);
+        Q_UNUSED(act)
+        Q_UNUSED(oldact)
+        return 0;
     });
 
     // 调用安装函数
     dpf::backtrace::installStackTraceHandler();
 
     // 注意：共享库中的 static once_flag 在进程生命周期内一旦设置就不会重置，
-    // 如果之前的测试已经触发了 once_flag，signal stub 不会被调用，
+    // 如果之前的测试已经触发了 once_flag，sigaction stub 不会被调用，
     // registered_signals 为空也是合法的。验证：函数不会崩溃。
     if (!registered_signals.empty()) {
         bool found_sigsegv = false;
@@ -403,18 +397,21 @@ TEST_F(BacktraceTest, InstallStackTraceHandler_ConditionalCompilation)
 /**
  * @brief 测试多线程环境下的安全性
  * 验证在多线程环境下installStackTraceHandler的线程安全性
+ *
+ * 新版使用 sigaction 替代 signal。
  */
 TEST_F(BacktraceTest, InstallStackTraceHandler_ThreadSafety)
 {
-    std::atomic<int> signal_call_count { 0 };
+    std::atomic<int> sigaction_call_count { 0 };
 
-    // 打桩signal函数
-    stub.set_lamda(&signal, [&signal_call_count](int sig, sighandler_t handler) -> sighandler_t {
+    // 打桩sigaction函数
+    stub.set_lamda(&sigaction, [&sigaction_call_count](int signum, const struct sigaction *act, struct sigaction *oldact) -> int {
         __DBG_STUB_INVOKE__
-        signal_call_count++;
-        Q_UNUSED(sig)
-        Q_UNUSED(handler)
-        return SIG_DFL;
+        sigaction_call_count++;
+        Q_UNUSED(signum)
+        Q_UNUSED(act)
+        Q_UNUSED(oldact)
+        return 0;
     });
 
     // 创建多个线程同时调用安装函数
@@ -432,9 +429,9 @@ TEST_F(BacktraceTest, InstallStackTraceHandler_ThreadSafety)
         thread.join();
     }
 
-    // 由于once_flag机制，signal只被调用有限次数（或0次如果之前已触发）
-    EXPECT_GE(signal_call_count.load(), 0);
-    EXPECT_LT(signal_call_count.load(), thread_count * 10);
+    // 由于once_flag机制，sigaction只被调用有限次数（或0次如果之前已触发）
+    EXPECT_GE(sigaction_call_count.load(), 0);
+    EXPECT_LT(sigaction_call_count.load(), thread_count * 10);
 }
 
 /**

--- a/include/dfm-framework/backtrace/backtrace.h
+++ b/include/dfm-framework/backtrace/backtrace.h
@@ -10,11 +10,50 @@
 DPF_BEGIN_NAMESPACE
 namespace backtrace {
 namespace inner {
+
+/*!
+ * \brief Demangle a symbol address into a human-readable string.
+ *
+ * \note NOT async-signal-safe — uses ostringstream, dladdr, and
+ * __cxa_demangle. Intended for non-signal debugging paths only.
+ * The signal handler does NOT call this function.
+ */
 std::string demangle(void *value);
+
+/*!
+ * \brief Print a stack trace from a frame array.
+ *
+ * \note NOT async-signal-safe — calls demangle() internally.
+ * Intended for non-signal debugging paths only.
+ */
 void printStack(void *frames[], int numFrames);
+
+/*!
+ * \brief Print a stack trace, skipping the first N frames.
+ *
+ * \note NOT async-signal-safe — calls demangle() internally.
+ * Intended for non-signal debugging paths only.
+ */
 void printStack(int firstFramesToSkip);
+
+/*!
+ * \brief Async-signal-safe crash backtrace handler.
+ *
+ * Only calls async-signal-safe functions (write, backtrace,
+ * backtrace_symbols_fd, raise). Installed via sigaction with
+ * SA_RESETHAND | SA_ONSTACK on an alternate signal stack.
+ */
 void stackTraceHandler(int sig);
 }   // namespace inner
+
+/*!
+ * \brief Install the async-signal-safe crash backtrace handler.
+ *
+ * Sets up an alternate signal stack (sigaltstack) and registers
+ * the handler via sigaction. Pre-warms backtrace() and
+ * backtrace_symbols_fd() to avoid glibc lazy dlopen under crash.
+ * Safe to call multiple times (std::once_flag guarded).
+ */
 void installStackTraceHandler();
 }   // namespace backtrace
 DPF_END_NAMESPACE

--- a/src/dfm-framework/backtrace/backtrace.cpp
+++ b/src/dfm-framework/backtrace/backtrace.cpp
@@ -9,10 +9,13 @@
 #include <mutex>
 #include <csignal>
 #include <sstream>
+#include <cstring>
 
 #include <execinfo.h>
 #include <cxxabi.h>
 #include <dlfcn.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 DPF_BEGIN_NAMESPACE
 namespace backtrace {
@@ -81,66 +84,181 @@ void printStack(int firstFramesToSkip)
     printStack(&frames[firstFramesToSkip], numFrames - firstFramesToSkip);
 }
 
+// --- async-signal-safe helpers (anonymous namespace) ---
+
+namespace {
+
+// Fixed-size alternate stack: SIGSTKSZ is a runtime value on glibc 2.34+,
+// so we use a compile-time constant instead.
+constexpr int kAltStackSize = 64 * 1024;
+alignas(64) char altStack[kAltStackSize];
+
+// Application name cached at install time for async-signal-safe output.
+char g_appName[256] = "";
+
+// Compile-time signal name table — strsignal() is not async-signal-safe.
+struct SigInfo {
+    int signo;
+    const char *name;
+};
+
+const SigInfo sigTable[] = {
+    { SIGSEGV, "SIGSEGV" },
+    { SIGABRT, "SIGABRT" },
+    { SIGBUS,  "SIGBUS"  },
+    { SIGILL,  "SIGILL"  },
+    { SIGFPE,  "SIGFPE"  },
+    { SIGINT,  "SIGINT"  },
+};
+
+const char *sigName(int sig)
+{
+    for (const auto &s : sigTable) {
+        if (s.signo == sig)
+            return s.name;
+    }
+    return "UNKNOWN";
+}
+
+// Write a null-terminated string to stderr — async-signal-safe.
+// (simple loop instead of strlen, which may use global state)
+void writeStr(const char *s)
+{
+    size_t len = 0;
+    while (s[len])
+        ++len;
+    if (len > 0)
+        write(STDERR_FILENO, s, len);
+}
+
+// Write a decimal integer to stderr — async-signal-safe.
+void writeInt(int val)
+{
+    char buf[16];
+    int pos = static_cast<int>(sizeof(buf)) - 1;
+    buf[pos] = '\0';
+
+    bool negative = val < 0;
+    unsigned int uval = negative ? static_cast<unsigned int>(-val)
+                                 : static_cast<unsigned int>(val);
+    if (uval == 0) {
+        buf[--pos] = '0';
+    } else {
+        while (uval > 0) {
+            buf[--pos] = static_cast<char>('0' + (uval % 10));
+            uval /= 10;
+        }
+    }
+    if (negative)
+        buf[--pos] = '-';
+
+    write(STDERR_FILENO, buf + pos, sizeof(buf) - 1 - static_cast<size_t>(pos));
+}
+
+}   // anonymous namespace
+
 /*!
- * \brief Install a signal handler to print callstack on the following signals:
- *  SIGILL SIGSEGV SIGBUS SIGABRT
- * \param sig
+ * \brief Async-signal-safe crash backtrace handler.
+ *
+ * Only calls async-signal-safe functions: write(), backtrace(),
+ * backtrace_symbols_fd(), raise(). No heap allocation, no Qt
+ * logging, no std::string / ostringstream / strsignal.
+ *
+ * \param sig signal number
  */
 void stackTraceHandler(int sig)
 {
-    // reset to default handler
-    signal(sig, SIG_DFL);
-    qCCritical(logDPF, "Received signal %d (%s)\n", sig, strsignal(sig));
+    writeStr("****************** ");
+    if (g_appName[0])
+        writeStr(g_appName);
+    else
+        writeStr("application");
+    writeStr(" crashed backtrace ******************\n");
 
-    QString head;
-    head = QString("****************** %0 crashed backtrace ******************")
-                   .arg(qApp->applicationName());
-    QString end { head.size(), '*' };
-    qCCritical(logDPF, "%s", head.toStdString().data());
+    writeStr("Received signal ");
+    writeInt(sig);
+    writeStr(" (");
+    writeStr(sigName(sig));
+    writeStr(")\n");
+
+    const int kMaxFrames = 100;
+    void *frames[kMaxFrames];
+    int numFrames = ::backtrace(frames, kMaxFrames);
 
     // skip the top three signal handler related frames
-    printStack(3);
+    const int kSkip = 3;
+    if (numFrames > kSkip)
+        backtrace_symbols_fd(frames + kSkip, numFrames - kSkip, STDERR_FILENO);
 
-    qCCritical(logDPF, "%s", end.toStdString().data());
+    writeStr("****************** end backtrace ******************\n");
 
-    // Efforts to fix or suppress TSAN warnings "signal-unsafe call inside of
-    // a signal" have failed, so just warn the user about them.
 #ifdef __SANITIZE_THREAD__
-    fprintf(stderr,
-            "==> NOTE: any above warnings about \"signal-unsafe call\" are\n"
-            "==> ignorable, as they are expected when generating a stack\n"
-            "==> trace because of a signal under TSAN. Consider why the\n"
-            "==> signal was generated to begin with, and the stack trace\n"
-            "==> in the TSAN warning can be useful for that. (The stack\n"
-            "==> trace printed by the signal handler is likely obscured\n"
-            "==> by TSAN output.)\n");
+    writeStr(
+        "==> NOTE: any above warnings about \"signal-unsafe call\" are\n"
+        "==> ignorable, as they are expected when generating a stack\n"
+        "==> trace because of a signal under TSAN.\n");
 #endif
 
-    qCInfo(logDPF) << "Re-raising signal" << sig << "to default handler";
     // re-signal to default handler (so we still get core dump if needed...)
+    // SA_RESETHAND was set in sigaction, so the handler is already reset.
     raise(sig);
 }
 }   // namespace inner
 /*!
- * \brief initbacktrace
- * Register signal handler.
+ * \brief installStackTraceHandler
+ * Install the async-signal-safe crash backtrace handler.
+ *
+ * Sets up an alternate signal stack (sigaltstack) so the handler can
+ * run even on stack overflow. Uses sigaction with SA_RESETHAND | SA_ONSTACK.
+ * Pre-warms backtrace()/backtrace_symbols_fd() to trigger glibc's lazy
+ * dlopen of libgcc_s, which may fail under heap corruption.
  */
 void installStackTraceHandler()
 {
     static std::once_flag flag;
     std::call_once(flag, []() {
-        qCInfo(logDPF) << "Installing stack trace signal handlers";
-        // just use the plain old signal as it's simple and sufficient
-        // for this use case
-        signal(SIGSEGV, inner::stackTraceHandler);
-        qCDebug(logDPF) << "Registered SIGSEGV handler";
+        // Cache application name for async-signal-safe output in handler
+        if (qApp) {
+            QByteArray name = qApp->applicationName().toLocal8Bit();
+            size_t len = name.size();
+            if (len >= sizeof(inner::g_appName))
+                len = sizeof(inner::g_appName) - 1;
+            memcpy(inner::g_appName, name.constData(), len);
+            inner::g_appName[len] = '\0';
+        }
+
+        // Pre-warm backtrace()/backtrace_symbols_fd() — glibc lazily
+        // dlopens libgcc_s on first call, which may fail under heap
+        // corruption, resulting in zero frames.
+        {
+            void *dummy = nullptr;
+            ::backtrace(&dummy, 1);
+            int devNull = ::open("/dev/null", O_WRONLY | O_CLOEXEC);
+            if (devNull >= 0) {
+                backtrace_symbols_fd(&dummy, 1, devNull);
+                ::close(devNull);
+            }
+        }
+
+        // Set up alternate signal stack for stack overflow protection
+        stack_t ss = {};
+        ss.ss_sp = inner::altStack;
+        ss.ss_size = inner::kAltStackSize;
+        ss.ss_flags = 0;
+        sigaltstack(&ss, nullptr);
+
+        // Install handler with sigaction — async-signal-safe registration
+        struct sigaction sa = {};
+        sa.sa_handler = inner::stackTraceHandler;
+        sa.sa_flags = SA_RESETHAND | SA_ONSTACK;
+        sigemptyset(&sa.sa_mask);
+
+        sigaction(SIGSEGV, &sa, nullptr);
 #ifdef DPF_FULLSIG_STRACE_ENABLE
-        signal(SIGINT, stackTraceHandler);
-        signal(SIGBUS, stackTraceHandler);
-        signal(SIGABRT, stackTraceHandler);
-        qCDebug(logDPF) << "Registered additional signal handlers: SIGINT, SIGBUS, SIGABRT";
+        sigaction(SIGABRT, &sa, nullptr);
+        sigaction(SIGBUS, &sa, nullptr);
+        sigaction(SIGINT, &sa, nullptr);
 #endif
-        qCInfo(logDPF) << "Stack trace signal handlers installation completed";
     });
 }
 }   // namespace backtrace


### PR DESCRIPTION
## Root Cause Analysis

The crash backtrace handler `stackTraceHandler` in `dfm-framework` used non-async-signal-safe functions (`qCCritical`, `QString`, `strsignal`, `printStack`→`demangle` with `ostringstream`/`dladdr`/`__cxa_demangle`). During heap-corruption crashes, these heap-allocating calls can cause secondary crashes or deadlocks, preventing backtrace output. Additionally, `signal()` registration lacked `sigaltstack`, so stack-overflow SIGSEGV could not run the handler at all.

Key evidence:
- `src/dfm-framework/backtrace/backtrace.cpp`: `stackTraceHandler` calls `qCCritical`/`QString`/`strsignal`/`printStack` — none are POSIX async-signal-safe
- No `sigaltstack` protection: stack-overflow signals leave no usable stack for the handler
- No `backtrace()` pre-warm: glibc lazy-dlopens libgcc_s on first call, which may fail under heap corruption

## Fix

Rewrote `stackTraceHandler` to use `write(STDERR_FILENO, ...)` + `backtrace_symbols_fd()` for async-signal-safe output. Replaced `signal()` with `sigaction()` + `SA_ONSTACK | SA_RESETHAND` and added a fixed 64 KiB `sigaltstack`. Introduced a compile-time signal name table instead of `strsignal()`. Added `backtrace()`/`backtrace_symbols_fd()` pre-warm at install time. Retained `demangle`/`printStack` public API for non-signal paths; the handler no longer calls them.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- `stackTraceHandler` core logic was unchanged for years; this is the first async-signal-safety fix — no prior fix is reverted
- 5 `main.cpp` entry points call `installStackTraceHandler()` with unchanged signature — no impact on callers
- UT stub updated from `signal()` to `sigaction()` — test behavior preserved

### Business Impact Scope

Affects crash backtrace output in all dde-file-manager processes. Crash logs change from Qt log format to raw stderr writes. No functional behavior changes in normal operation; only crash-time output format changes.

### Verification Suggestion

1. Trigger SIGSEGV in a test process and verify backtrace prints to stderr
2. Trigger a stack-overflow crash and verify the alternate stack allows backtrace output
3. Run existing `test_backtrace` unit tests to confirm no regression

---

## 根因分析

`dfm-framework` 的崩溃堆栈处理器 `stackTraceHandler` 调用了非 async-signal-safe 的函数（`qCCritical`、`QString`、`strsignal`、`printStack`→`demangle` 使用 `ostringstream`/`dladdr`/`__cxa_demangle`）。堆损坏类崩溃时这些堆分配操作可能二次崩溃或死锁，导致堆栈无法打印。此外 `signal()` 注册未设置 `sigaltstack`，栈溢出型 SIGSEGV 时 handler 无法执行。

关键证据：
- `src/dfm-framework/backtrace/backtrace.cpp`：`stackTraceHandler` 调用的函数均不在 POSIX async-signal-safe 列表
- 无 `sigaltstack` 保护：栈溢出信号无可用栈执行 handler
- 无 `backtrace()` 预热：glibc 首次调用 lazy dlopen libgcc_s，堆损坏时可能失败

## 修复方案

重写 `stackTraceHandler` 使用 `write(STDERR_FILENO, ...)` + `backtrace_symbols_fd()` 实现信号安全输出。`signal()` 替换为 `sigaction()` + `SA_ONSTACK | SA_RESETHAND` 并添加固定 64 KiB `sigaltstack`。引入编译期信号名表替代 `strsignal()`。安装时预热 `backtrace()`/`backtrace_symbols_fd()`。保留 `demangle`/`printStack` 公开 API 供非信号路径使用，handler 内不再调用。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低
- `stackTraceHandler` 核心逻辑长期未变，本次为首次引入信号安全修复，未撤销历史修复
- 5 个 `main.cpp` 入口调用 `installStackTraceHandler()` 签名不变，调用者无感知
- UT stub 从 `signal()` 适配为 `sigaction()`，测试行为保持一致

### 业务影响范围

影响所有 dde-file-manager 进程的崩溃堆栈输出。崩溃日志从 Qt 日志格式变为直接 stderr 输出。正常运行无功能行为变化，仅崩溃时输出格式改变。

### 验证建议

1. 在测试进程中触发 SIGSEGV，验证堆栈信息输出到 stderr
2. 触发栈溢出崩溃，验证备用栈生效，堆栈可打印
3. 运行现有 `test_backtrace` 单元测试确保无回归

## Summary by Sourcery

Harden crash backtrace generation so fatal signals can reliably produce diagnostics without unsafe runtime dependencies.

Bug Fixes:
- Make crash backtrace handling resilient during heap corruption and stack-overflow crashes by restricting signal-time work to async-signal-safe operations and supporting alternate signal stacks.

Enhancements:
- Preserve symbol demangling and formatted stack printing for non-signal debugging paths while separating them from crash-time handling.

Tests:
- Update backtrace tests to validate the async-signal-safe handler and sigaction-based registration.