### PR TITLE
feat(menu): add dconfig switch to disable desktop context menu

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.desktop.json
+++ b/assets/configs/org.deepin.dde.file-manager.desktop.json
@@ -100,6 +100,17 @@
 			"description[zh_CN]": "用于填充桌面壁纸的样式。使用数字表示：0 表示填充，1 表示适应，2 表示拉伸，3 表示平铺，4 表示居中。",
 			"permissions": "readwrite",
 			"visibility": "public"
+		},
+		"enableContextMenu": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable the context menu on the desktop",
+			"name[zh_CN]": "启用桌面右键菜单",
+			"description": "It's used to control whether to display the context menu on the desktop.",
+			"description[zh_CN]": "用于控制是否启用桌面右键菜单",
+			"permissions": "readwrite",
+			"visibility": "public"
 		}
 	}
 }

--- a/src/plugins/common/dfmplugin-menu/utils/menuhelper.cpp
+++ b/src/plugins/common/dfmplugin-menu/utils/menuhelper.cpp
@@ -69,6 +69,12 @@ bool isHiddenMenu(const QString &app)
 
 bool isHiddenDesktopMenu()
 {
+    bool enableMenu { DConfigManager::instance()
+                              ->value(kDesktopDConfName, "enableContextMenu", true)
+                              .toBool() };
+    if (!enableMenu)
+        return true;
+
     return Application::appObtuselySetting()->value("ApplicationAttribute", "DisableDesktopContextMenu", false).toBool();
 }
 


### PR DESCRIPTION
## 改动说明

- 在 `org.deepin.dde.file-manager.desktop.json`（桌面专用配置）中新增 `enableContextMenu`（默认 true，public，驼峰命名跟随该文件既有风格），用于控制桌面右键菜单的启用/禁用
- 在 `Helper::isHiddenDesktopMenu()` 中优先读取该配置项，置为 false 时整体屏蔽桌面右键菜单，原有 gsettings/应用属性控制不受影响
- V25 适配：`kDesktopDConfName` 直接复用 dfm-base `GlobalDConfDefines::ConfigPath` 中既有常量（V20 版本是在文件内新增的匿名命名空间常量）

## 关联

- Gerrit V20 (release/1073): https://gerrit.uniontech.com/c/dde-file-manager/+/377835
- Gerrit V20 (release/107x): https://gerrit.uniontech.com/c/dde-file-manager/+/378898
- Task: https://pms.uniontech.com/task-view-395169.html

## Summary by Sourcery

Add configurable control over whether the desktop context menu is available.

New Features:
- Add a desktop configuration switch for enabling or disabling the desktop context menu.

Enhancements:
- Preserve existing settings-based context-menu controls while applying the new configuration override first.