### PR TITLE
fix: set render hints before early return and add icon fallback for empty desktop files

### DIFF
--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -16,6 +16,7 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <QAtomicInteger>
+#include <QStyle>
 #include <DGuiApplicationHelper>
 #include <DPlatformTheme>
 
@@ -251,7 +252,10 @@ QIcon DesktopFileInfo::fileIcon()
     // 或所有解析路径均失败时，最终回退到 ProxyFileInfo（进而解析为 unknown 图标）
     if (d->icon.isNull()) {
         d->useProxyIcon.storeRelease(true);
-        return ProxyFileInfo::fileIcon();
+        QIcon proxyIcon = ProxyFileInfo::fileIcon();
+        if (!proxyIcon.isNull())
+            return proxyIcon;
+        return QIcon(QApplication::style()->standardIcon(QStyle::SP_FileIcon));
     }
 
     return d->icon;

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -33,6 +33,8 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
     Q_ASSERT(painter);
     Q_ASSERT(paintArea);
 
+    painter->setRenderHints(QPainter::SmoothPixmapTransform);
+
     if (role != kItemIconRole || info.isNull())
         return false;
     QList<QIcon> emblems;
@@ -67,8 +69,6 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
 
     if (emblems.isEmpty())
         return false;
-
-    painter->setRenderHints(QPainter::SmoothPixmapTransform);
 
     const QList<QRectF> &paintRects = helper->emblemRects(*paintArea);
     for (int i = 0; i < qMin(paintRects.count(), emblems.count()); ++i) {


### PR DESCRIPTION
## 修复 3 个单元测试失败用例

关联 issue: V-4116, V-4099

### 失败用例

1. **DesktopFileInfoTest.FileIconZeroByteDesktopFileFallback** — 0 字节 .desktop 文件（无 Icon= 条目）时 `fileIcon()` 返回空图标
2. **DesktopFileInfoTest.FileIconEmptyIconEntryFallback** — .desktop 文件存在 `Icon=` 但值为空时 `fileIcon()` 返回空图标
3. **UT_EmblemManager.PaintEmblems_SetsRenderHints** — emblems 为空时 `paintEmblems()` 提前返回，`SmoothPixmapTransform` 渲染提示从未设置

### 修复内容

**Fix 1 — emblemmanager.cpp** (`src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp`)

将 `painter->setRenderHints(QPainter::SmoothPixmapTransform)` 移至 `Q_ASSERT` 之后、所有 early return 之前，确保无论 emblems 是否为空都会设置渲染提示。

**Fix 2 — desktopfileinfo.cpp** (`src/dfm-base/file/local/desktopfileinfo.cpp`)

在 `ProxyFileInfo::fileIcon()` 返回 null 时，追加 `QApplication::style()->standardIcon(QStyle::SP_FileIcon)` 作为终极保底回退，确保 `fileIcon()` 永不返回空图标。新增 `#include <QStyle>`。

### 变更统计

2 个文件，+7 -3

### 验证

受影响的两个测试二进制在修复后全部通过（0 失败 0 崩溃）：

| 测试二进制 | 通过 / 失败 / 总数 |
|-----------|-------------------|
| `ut-dfm-base` | 1881 / 0 / 1881 |
| `ut-dfmplugin-emblem` | 67 / 0 / 67 |

## Summary by Sourcery

Ensure desktop file icons and emblem rendering remain reliable in empty or fallback cases.

Bug Fixes:
- Guarantee a standard file icon fallback when desktop file icon resolution produces no icon.
- Ensure emblem painting configures smooth pixmap rendering even when no emblems are available or other early-return conditions apply.