### PR TITLE
fix: migrate terminal launch to AM1 for executables

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -862,7 +862,9 @@ bool LocalFileHandlerPrivate::openExcutableScriptFile(const QString &path, int f
     case 2: {
         QStringList args;
         args << "-e" << path;
-        result = UniversalUtils::runCommand(q->defaultTerminalPath(), args, QUrl(path).adjusted(QUrl::RemoveFilename).toString());
+        const QString workdir = QUrl(path).adjusted(QUrl::RemoveFilename).toString();
+        if (!AppLaunchUtils::instance().executeCommand(q->defaultTerminalPath(), args, QStringLiteral("shortcut"), workdir))
+            result = QProcess::startDetached(q->defaultTerminalPath(), args, workdir);
         break;
     }
     case 3:
@@ -884,7 +886,9 @@ bool LocalFileHandlerPrivate::openExcutableFile(const QString &path, int flag)
     case 1: {
         QStringList args;
         args << "-e" << path;
-        result = UniversalUtils::runCommand(q->defaultTerminalPath(), args, QUrl(path).adjusted(QUrl::RemoveFilename).toString());
+        const QString workdir = QUrl(path).adjusted(QUrl::RemoveFilename).toString();
+        if (!AppLaunchUtils::instance().executeCommand(q->defaultTerminalPath(), args, QStringLiteral("shortcut"), workdir))
+            result = QProcess::startDetached(q->defaultTerminalPath(), args, workdir);
         break;
     }
     case 2: {


### PR DESCRIPTION
## 改动说明

将可执行脚本/二进制文件"在终端中运行"分支从 `QProcess::startDetached`（经 `UniversalUtils::runCommand`）迁移到 AM1 `AppLaunchUtils::executeCommand`，与已迁移的"运行"分支保持一致，AM1 不可用时回退 `QProcess::startDetached`。

### 改动位置

- `src/dfm-base/file/local/localfilehandler.cpp:862` — `openExcutableScriptFile` case 2（脚本"在终端中运行"）
- `src/dfm-base/file/local/localfilehandler.cpp:886` — `openExcutableFile` case 1（二进制"在终端中运行"）

### 根因

提交 `4da08b647` 将"运行"分支迁移到 AM1 `AppLaunchUtils::executeCommand`，但两处"在终端中运行"分支仍使用 `UniversalUtils::runCommand`（内部即 `QProcess::startDetached`），未纳入 AM1 统一纳管。

### 测试影响

1. 测试 .sh 脚本选择"在终端中运行"
2. 测试可执行二进制文件选择"在终端中运行"
3. 验证终端正确打开并执行脚本/二进制
4. 测试 AM1 服务不可用时的回退行为

关联 issue: V-2666

## Summary by Sourcery

Migrate terminal execution of executable scripts and binaries to AM1 with a detached-launch fallback.

Bug Fixes:
- Route executable scripts and binaries launched in a terminal through AM1 management, restoring consistent application-launch handling.

Enhancements:
- Retain detached process launching as a fallback when the AM1 service is unavailable.