### PR TITLE
fix: clear InfoCache on refresh and fix emblem clear notification

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -297,8 +297,9 @@ bool EmblemHelper::isExtEmblemProhibited(const FileInfoPointer &info, const QUrl
 
 void EmblemHelper::onEmblemChanged(const QUrl &url, const Product &product)
 {
+    bool hadEmblem = !productQueue.value(url).isEmpty();
     productQueue[url] = product;
-    if (product.isEmpty())
+    if (product.isEmpty() && !hadEmblem)
         return;
     auto eventID { DPF_NAMESPACE::Event::instance()->eventType("ddplugin_canvas", "slot_FileInfoModel_UpdateFile") };
     if (eventID != DPF_NAMESPACE::EventTypeScope::kInValid)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -972,6 +972,11 @@ void FileSortWorker::handleRefresh()
     }
 
     {
+        QReadLocker lk(&childrenDataLocker);
+        emit dfmbase::InfoCacheController::instance().removeCacheFileInfo(childrenDataMap.keys());
+    }
+
+    {
         QWriteLocker lk(&childrenDataLocker);
         childrenDataMap.clear();
     }


### PR DESCRIPTION
fix: clear InfoCache on refresh and fix emblem clear notification

1. Root cause (refresh not updating emblems): FileSortWorker::handleRefresh()
   cleared local childrenDataMap but did not clear InfoCacheController cache.
   When FileItemData lazily created FileInfo via InfoFactory::create, the cache
   hit returned a stale FileInfo with old kFileEmblems, skipping
   updateAttributes(). Emblems were not refreshed until restart.

2. Fix (refresh): Add InfoCacheController::removeCacheFileInfo() call in
   handleRefresh() before clearing childrenDataMap, using childrenDataMap.keys()
   to collect all child URLs. This forces lazy-loaded FileInfo to trigger
   updateAttributes() and fetch fresh GIO metadata::emblems.

3. Root cause (clearing emblems needs two refreshes): EmblemHelper::onEmblemChanged()
   returned early when product was empty, skipping the workspace notification.
   On first refresh after clearing emblems, productQueue still held the old
   non-empty emblem, so the view showed stale emblems. The async GIO query
   then returned empty and called onEmblemChanged(url, {}), but the early
   return prevented notification, leaving stale emblems until a second refresh.

4. Fix (emblem clear): Add hadEmblem check before updating productQueue. Only
   skip notification when transitioning from empty to empty (first load with no
   emblem). When emblems transition from non-empty to empty, the notification
   is sent so the workspace updates immediately.

Log: fix emblem not refreshing on F5 and needing two refreshes to clear
Influence:
1. Test setting file emblems via gio set and pressing F5 to verify they appear
2. Test clearing file emblems via gio set and pressing F5 once to verify they disappear
3. Test emblem display in icon/list/tree views after refresh
4. Test that normal browsing performance is not affected (InfoCache only cleared on explicit refresh)

fix: 刷新时清除 InfoCache 并修复角标清空通知

1. 根因（刷新不更新角标）：FileSortWorker::handleRefresh() 清除了本地
   childrenDataMap 但未清除 InfoCacheController 缓存。FileItemData 懒加载
   FileInfo 时 InfoFactory::create 命中缓存返回旧 FileInfo，跳过
   updateAttributes()，旧 kFileEmblems 保留，角标不刷新。

2. 修复（刷新）：在 handleRefresh() 清除 childrenDataMap 前调用
   InfoCacheController::removeCacheFileInfo()，使用 childrenDataMap.keys()
   收集所有子文件 URL，强制懒加载 FileInfo 触发 updateAttributes() 获取
   最新 GIO metadata::emblems。

3. 根因（清空角标需两次刷新）：EmblemHelper::onEmblemChanged() 在 product
   为空时直接 return，跳过 workspace 通知。首次刷新时 productQueue 仍存
   旧角标，视图显示旧角标；异步 GIO 查询返回空后调用
   onEmblemChanged(url, {})，但因 early return 不通知，需第二次刷新才清空。

4. 修复（角标清空）：更新 productQueue 前检查 hadEmblem，仅在从空到空
   （首次加载无角标）时跳过通知，从有到空时发送通知使 workspace 立即更新。

Log: 修复 F5 刷新不更新角标及清空角标需两次刷新的问题
Influence:
1. 测试通过 gio set 设置角标后按 F5 刷新验证角标显示
2. 测试通过 gio set 清空角标后按 F5 刷新一次验证角标消失
3. 测试图标/列表/树视图中刷新后角标显示
4. 测试正常浏览性能不受影响（仅显式刷新时清除 InfoCache）

## Summary by Sourcery

Refresh cached file metadata and propagate emblem-clearing updates so emblem changes appear immediately after one refresh.

Bug Fixes:
- Ensure file emblems are refreshed after an explicit directory refresh by invalidating cached file information.
- Notify workspace views when emblems are cleared so stale emblems disappear after a single refresh.