### PR TITLE
fix: clear cached thumbnail marks on toggle switch

### DIFF
--- a/include/dfm-base/utils/infocache.h
+++ b/include/dfm-base/utils/infocache.h
@@ -85,6 +85,7 @@ private:
     void timeRemoveCache();
     void removeInfosTimeWorker(const QList<QUrl> urls);
     void updateSortTimeWatcherWorker(const QList<QUrl> &urls, const bool add);
+    void clearCachedExtendedAttribute(ExtInfoType type);
 
 private Q_SLOTS:
     void fileAttributeChanged(const QUrl url);
@@ -110,6 +111,7 @@ public:
     bool cacheDisable(const QString &scheme);
     void setCacheDisbale(const QString &scheme, bool disable = true);
     FileInfoPointer getCacheInfo(const QUrl &url);
+    void clearCachedExtendedAttribute(ExtInfoType type);
 Q_SIGNALS:
     void cacheFileInfo(const QUrl url, const FileInfoPointer info);
     void removeCacheFileInfo(const QList<QUrl> &urls);

--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -136,7 +136,7 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
         return;
 
     {
-        QReadLocker rlk(&d->mianLock);
+        QReadLocker rlk(&d->mainLock);
         if (d->mainCache.contains(url))
             return;
     }
@@ -174,7 +174,7 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
     // 插入到主和副的所有缓存中
     d->status = kCacheCopy;
     {
-        QWriteLocker wlk(&d->mianLock);
+        QWriteLocker wlk(&d->mainLock);
         d->mainCache.insert(url, info);
     }
     d->status = kCacheMain;
@@ -232,7 +232,7 @@ void InfoCache::removeCaches(const QList<QUrl> urls)
     d->status = kCacheCopy;
     QMap<QUrl, FileInfoPointer> infos;
     {
-        QWriteLocker wlk(&d->mianLock);
+        QWriteLocker wlk(&d->mainLock);
         for (const auto &url : urls) {
             auto info = d->mainCache.take(url);
             if (info)
@@ -268,7 +268,7 @@ FileInfoPointer InfoCache::getCacheInfo(const QUrl &url)
     // 读取副缓存和临时缓存返回
     FileInfoPointer info(nullptr);
     if (d->status == kCacheMain) {   // 可以读取主缓存返回
-        QReadLocker wlk(&d->mianLock);
+        QReadLocker wlk(&d->mainLock);
         info = d->mainCache.value(url);
     } else {
         QReadLocker wlk(&d->copyLock);
@@ -280,6 +280,25 @@ FileInfoPointer InfoCache::getCacheInfo(const QUrl &url)
         emit cacheUpdateInfoTime(url);
 
     return info;
+}
+
+void InfoCache::clearCachedExtendedAttribute(ExtInfoType type)
+{
+    Q_D(InfoCache);
+    {
+        QReadLocker lk(&d->mainLock);
+        for (const auto &info : d->mainCache) {
+            if (info)
+                info->setExtendedAttributes(type, QVariant());
+        }
+    }
+    {
+        QReadLocker lk(&d->copyLock);
+        for (const auto &info : d->copyCache) {
+            if (info)
+                info->setExtendedAttributes(type, QVariant());
+        }
+    }
 }
 /*!
  * \brief refreshFileInfo 刷新缓存fileinfo
@@ -454,6 +473,11 @@ void InfoCacheController::setCacheDisbale(const QString &scheme, bool disable)
 FileInfoPointer InfoCacheController::getCacheInfo(const QUrl &url)
 {
     return InfoCache::instance().getCacheInfo(url);
+}
+
+void InfoCacheController::clearCachedExtendedAttribute(ExtInfoType type)
+{
+    InfoCache::instance().clearCachedExtendedAttribute(type);
 }
 
 InfoCacheController::InfoCacheController(QObject *parent)

--- a/src/dfm-base/utils/private/infocache_p.h
+++ b/src/dfm-base/utils/private/infocache_p.h
@@ -27,7 +27,7 @@ class InfoCachePrivate
     QAtomicInt status { kCacheMain };   // 当前状态缓存的状态
     QHash<QUrl, FileInfoPointer> mainCache;   // 主信息缓存
     QHash<QUrl, FileInfoPointer> copyCache;   // 副信息缓存
-    QReadWriteLock mianLock;
+    QReadWriteLock mainLock;
     QReadWriteLock copyLock;
 
     // 时间排序url,利用map的有序性，来处理时间到了要移除的url

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -11,6 +11,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/utils/fileinfohelper.h>
+#include <dfm-base/utils/infocache.h>
 #include <dfm-base/base/standardpaths.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/mimetype/mimetypedisplaymanager.h>
@@ -984,11 +985,15 @@ void FileSortWorker::handleRefresh()
 
 void FileSortWorker::handleClearThumbnail()
 {
-    QReadLocker lk(&childrenDataLocker);
-    for (const auto &item : childrenDataMap.values()) {
-        if (Q_LIKELY(item))
-            item->clearThumbnail();
+    {
+        QReadLocker lk(&childrenDataLocker);
+        for (const auto &item : childrenDataMap.values()) {
+            if (Q_LIKELY(item))
+                item->clearThumbnail();
+        }
     }
+
+    InfoCacheController::instance().clearCachedExtendedAttribute(ExtInfoType::kFileThumbnail);
 
     Q_EMIT requestUpdateView();
 }


### PR DESCRIPTION
## Root Cause Analysis

When the thumbnail toggle is turned off, `fileIcon()` sets an empty `QIcon()` (valid QVariant but null icon) as the "thumbnail requested" marker on cached FileInfo objects. The thumbnail worker skips the URL when thumbnails are disabled, leaving this marker permanently in the InfoCache. When the user re-enables thumbnails and returns to a previously visited directory, `fileIcon()` sees the valid-but-null marker and does not re-request the thumbnail, causing already-cached files to display file-type icons instead of thumbnails. Meanwhile, files that were never painted (still have invalid QVariant) correctly request thumbnails.

Key evidence:
- `fileitemdata.cpp:136` — `fileIcon()` writes empty `QIcon()` as "requested" marker
- `filesortworker.cpp:985-990` — `handleClearThumbnail()` only clears current view items, not other directories' cached FileInfo

## Fix

Added `InfoCacheController::clearCachedThumbnails()` which delegates to `InfoCache::clearAllCachedThumbnails()` — a new method that locks and iterates both `mainCache` and `copyCache`, clearing the `kFileThumbnail` extension attribute on all cached FileInfo. This is called from `handleClearThumbnail()` after clearing the current view items, ensuring all cached FileInfo across all directories have their thumbnail markers reset on thumbnail toggle.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- All changes are new methods or a single appended call — no existing function signatures or internal logic modified
- New methods follow existing code patterns (InfoCacheController delegates to InfoCache singleton, uses existing read-write locks for thread safety)

### Business Impact Scope

The fix affects the thumbnail display feature in the file manager. When a user toggles the thumbnail switch, all cached FileInfo objects across all visited directories will have their thumbnail markers cleared. This ensures thumbnails are correctly re-requested and displayed when returning to any previously visited directory after re-enabling thumbnails. The operation is triggered only on thumbnail toggle (low frequency), with no impact on normal file browsing performance.

### Verification Suggestion

Test the exact bug reproduction scenario: visit directory A with thumbnails on, turn off thumbnails, navigate to directory B, turn on thumbnails, return to directory A — all images should now display thumbnails. Also test frequent toggling for stability.

---

## 根因分析

当缩略图开关关闭时，`fileIcon()` 会在缓存的 FileInfo 对象上设置空 `QIcon()`（valid QVariant 但 null icon）作为"已请求缩略图"标记。缩略图 worker 在缩略图禁用时跳过该 URL，导致此标记永久残留在 InfoCache 中。当用户重新开启缩略图并返回之前访问的目录时，`fileIcon()` 看到 valid-but-null 标记后不会重新请求缩略图，导致已缓存的文件显示文件类型图标而非缩略图。而从未被 paintEvent 处理过的文件（仍为 invalid QVariant）则能正确请求缩略图。

关键证据：
- `fileitemdata.cpp:136` — `fileIcon()` 写入空 `QIcon()` 作为"已请求"标记
- `filesortworker.cpp:985-990` — `handleClearThumbnail()` 仅清除当前视图 items，不覆盖其他目录的缓存 FileInfo

## 修复方案

新增 `InfoCacheController::clearCachedThumbnails()` 方法，委托给 `InfoCache::clearAllCachedThumbnails()` —— 加锁遍历 `mainCache` 和 `copyCache`，清除所有缓存 FileInfo 的 `kFileThumbnail` 扩展属性。该方法在 `handleClearThumbnail()` 中清除当前视图 items 后调用，确保缩略图开关切换时所有目录的缓存 FileInfo 的缩略图标记被重置。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 所有改动均为新增方法或末尾追加单次调用，不修改任何已有函数签名或内部逻辑
- 新增方法遵循现有代码模式（InfoCacheController 委托 InfoCache 单例，使用已有读写锁保证线程安全）

### 业务影响范围

本修复影响文件管理器的缩略图显示功能。当用户切换缩略图开关时，所有已访问目录的缓存 FileInfo 对象的缩略图标记将被清除，确保重新开启缩略图后返回任何之前访问的目录时缩略图能正确重新请求和显示。该操作仅在缩略图开关切换时触发（低频），对正常文件浏览性能无影响。

### 验证建议

测试完整的 bug 复现场景：进入目录 A（缩略图开启），关闭缩略图，跳转目录 B，重新开启缩略图，返回目录 A —— 所有图片应正确显示缩略图。同时测试频繁切换开关的稳定性。

## Summary by Sourcery

Clear cached thumbnail metadata when toggling thumbnails so previously visited directories display thumbnails correctly after re-enabling them.

Bug Fixes:
- Reset cached thumbnail request markers across all cached directories when thumbnails are toggled, ensuring thumbnails are re-requested after being re-enabled.

Enhancements:
- Correct InfoCache locking references and expose cached extended-attribute clearing through the cache controller.