### PR TITLE
fix: clear cached thumbnail marks on toggle switch

### DIFF
--- a/include/dfm-base/utils/infocache.h
+++ b/include/dfm-base/utils/infocache.h
@@ -85,6 +85,7 @@ private:
     void timeRemoveCache();
     void removeInfosTimeWorker(const QList<QUrl> urls);
     void updateSortTimeWatcherWorker(const QList<QUrl> &urls, const bool add);
+    void clearCachedExtendedAttribute(ExtInfoType type);
 
 private Q_SLOTS:
     void fileAttributeChanged(const QUrl url);
@@ -110,6 +111,7 @@ public:
     bool cacheDisable(const QString &scheme);
     void setCacheDisbale(const QString &scheme, bool disable = true);
     FileInfoPointer getCacheInfo(const QUrl &url);
+    void clearCachedExtendedAttribute(ExtInfoType type);
 Q_SIGNALS:
     void cacheFileInfo(const QUrl url, const FileInfoPointer info);
     void removeCacheFileInfo(const QList<QUrl> &urls);

--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -281,6 +281,25 @@ FileInfoPointer InfoCache::getCacheInfo(const QUrl &url)
 
     return info;
 }
+
+void InfoCache::clearCachedExtendedAttribute(ExtInfoType type)
+{
+    Q_D(InfoCache);
+    {
+        QReadLocker lk(&d->mianLock);
+        for (const auto &info : d->mainCache) {
+            if (info)
+                info->setExtendedAttributes(type, QVariant());
+        }
+    }
+    {
+        QReadLocker lk(&d->copyLock);
+        for (const auto &info : d->copyCache) {
+            if (info)
+                info->setExtendedAttributes(type, QVariant());
+        }
+    }
+}
 /*!
  * \brief refreshFileInfo 刷新缓存fileinfo
  *
@@ -454,6 +473,11 @@ void InfoCacheController::setCacheDisbale(const QString &scheme, bool disable)
 FileInfoPointer InfoCacheController::getCacheInfo(const QUrl &url)
 {
     return InfoCache::instance().getCacheInfo(url);
+}
+
+void InfoCacheController::clearCachedExtendedAttribute(ExtInfoType type)
+{
+    InfoCache::instance().clearCachedExtendedAttribute(type);
 }
 
 InfoCacheController::InfoCacheController(QObject *parent)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -11,6 +11,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/utils/fileinfohelper.h>
+#include <dfm-base/utils/infocache.h>
 #include <dfm-base/base/standardpaths.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/mimetype/mimetypedisplaymanager.h>
@@ -989,6 +990,8 @@ void FileSortWorker::handleClearThumbnail()
         if (Q_LIKELY(item))
             item->clearThumbnail();
     }
+
+    InfoCacheController::instance().clearCachedExtendedAttribute(ExtInfoType::kFileThumbnail);
 
     Q_EMIT requestUpdateView();
 }


### PR DESCRIPTION
## 问题

缩略图开关切换后返回目录时已缓存图片未刷新为缩略图。

## 根因

`fileIcon()` 使用空 `QIcon()`（valid 但 null）作为"已请求缩略图"标记，而 `handleClearThumbnail()` 仅清除当前视图 items 的标记。当在目录 B 重新打开缩略图时，目录 A 的缓存 FileInfo 仍残留空 `QIcon()` 标记，返回后 `fileIcon()` 不再重新请求缩略图。

## 修复方案

新增通用接口 `InfoCacheController::clearCachedExtendedAttribute(ExtInfoType type)`，清除所有缓存 FileInfo 的指定扩展属性。在 `handleClearThumbnail()` 中调用 `clearCachedExtendedAttribute(ExtInfoType::kFileThumbnail)` 重置所有目录缓存 FileInfo 的缩略图标记。

接口设计为通用型（接受任意 `ExtInfoType` 参数），非缩略图专用，可复用于未来其他缓存失效场景。

## 改动文件

- `include/dfm-base/utils/infocache.h` — 新增 `InfoCache::clearCachedExtendedAttribute()` 和 `InfoCacheController::clearCachedExtendedAttribute()` 声明
- `src/dfm-base/utils/infocache.cpp` — 实现上述方法
- `src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp` — 在 `handleClearThumbnail()` 中追加调用

## Summary by Sourcery

Ensure thumbnail toggles invalidate thumbnail state across the entire file information cache.

Bug Fixes:
- Clear cached thumbnail state across all cached file information when the thumbnail toggle is reset, ensuring thumbnails are requested again after navigating between directories.

Enhancements:
- Add a generic API for clearing a specified extended attribute from all file information held in the cache.