### PR TITLE
fix: clear InfoCache on refresh and fix emblem clear notification

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -297,8 +297,9 @@ bool EmblemHelper::isExtEmblemProhibited(const FileInfoPointer &info, const QUrl
 
 void EmblemHelper::onEmblemChanged(const QUrl &url, const Product &product)
 {
+    bool hadEmblem = !productQueue.value(url).isEmpty();
     productQueue[url] = product;
-    if (product.isEmpty())
+    if (product.isEmpty() && !hadEmblem)
         return;
     auto eventID { DPF_NAMESPACE::Event::instance()->eventType("ddplugin_canvas", "slot_FileInfoModel_UpdateFile") };
     if (eventID != DPF_NAMESPACE::EventTypeScope::kInValid)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -967,6 +967,11 @@ void FileSortWorker::handleRefresh()
     }
 
     {
+        QReadLocker lk(&childrenDataLocker);
+        emit dfmbase::InfoCacheController::instance().removeCacheFileInfo(childrenDataMap.keys());
+    }
+
+    {
         QWriteLocker lk(&childrenDataLocker);
         childrenDataMap.clear();
     }


### PR DESCRIPTION
## Root Cause Analysis

1. **Refresh not updating emblems**: `FileSortWorker::handleRefresh()` cleared local `childrenDataMap` but did not clear `InfoCacheController` cache. When `FileItemData` lazily created `FileInfo` via `InfoFactory::create`, the cache hit returned a stale `FileInfo` with old `kFileEmblems`, skipping `updateAttributes()`. Emblems were not refreshed until restart.

2. **Clearing emblems needs two refreshes**: `EmblemHelper::onEmblemChanged()` returned early when product was empty, skipping the workspace notification. On first refresh after clearing emblems, `productQueue` still held the old non-empty emblem, so the view showed stale emblems. The async GIO query then returned empty and called `onEmblemChanged(url, {})`, but the early return prevented notification, leaving stale emblems until a second refresh.

## Fix

1. **Refresh**: Add `InfoCacheController::removeCacheFileInfo()` call in `handleRefresh()` before clearing `childrenDataMap`, using `childrenDataMap.keys()` to collect all child URLs. This forces lazy-loaded `FileInfo` to trigger `updateAttributes()` and fetch fresh GIO `metadata::emblems`.

2. **Emblem clear**: Add `hadEmblem` check before updating `productQueue`. Only skip notification when transitioning from empty to empty (first load with no emblem). When emblems transition from non-empty to empty, the notification is sent so the workspace updates immediately.

## Change Safety Assessment

- **Code safety**: Low risk. The InfoCache clear only happens on explicit F5 refresh, not during normal browsing. The `hadEmblem` check is a minimal conditional addition that doesn't change existing notification logic for non-empty cases.
- **Business impact**: File emblem display in icon/list/tree views after F5 refresh. No impact on normal browsing performance (InfoCache only cleared on explicit refresh).
- **Verification**: Test setting/clearing file emblems via `gio set` and pressing F5 to verify they appear/disappear correctly in a single refresh.

PMS: BUG-376615

## Summary by Sourcery

Refresh file metadata caches and correctly propagate emblem removals so displayed emblems stay in sync.

Bug Fixes:
- Ensure file emblems are refreshed correctly after an explicit workspace refresh.
- Notify the workspace when emblems are cleared so stale emblems disappear after a single refresh.