### PR TITLE
fix: support MIME type aliases for ISO image recognition

### DIFF
--- a/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
+++ b/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
@@ -112,6 +112,16 @@ FileInfo::FileType MimeTypeDisplayManager::displayNameToEnum(const QString &mime
         return FileInfo::FileType::kUnknown;
     }
 
+    // Check aliases — handles cases where shared-mime-info renames a MIME type
+    // but keeps the old name as an alias (e.g. application/vnd.efi.iso aliases
+    // application/x-cd-image).
+    for (const QString &alias : resolvedMime.aliases()) {
+        const FileInfo::FileType aliasType = displayNameToEnumDirect(alias);
+        if (aliasType != FileInfo::FileType::kUnknown) {
+            return aliasType;
+        }
+    }
+
     // Fallback to ancestor MIME types so vendor-specific overrides can still
     // inherit the same top-level category as their standard parent MIME.
     for (const QString &ancestorMimeType : resolvedMime.allAncestors()) {

--- a/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
@@ -86,9 +86,8 @@ void BurnEventReceiver::handlePasteTo(const QList<QUrl> &urls, const QUrl &dest,
         bool isBlank { DeviceUtils::isBlankOpticalDisc(devId) };
 
         auto fi { InfoFactory::create<FileInfo>(urls.front()) };
-        static const QSet<QString> imageTypes { Global::Mime::kTypeCdImage, Global::Mime::kTypeISO9660Image };
 
-        if (isBlank && fi && imageTypes.contains(fi->nameOf(NameInfoType::kMimeTypeName)) && destDir.count() == 0) {
+        if (isBlank && fi && BurnHelper::isMountableImage(fi->nameOf(NameInfoType::kMimeTypeName)) && destDir.count() == 0) {
             int r { BurnHelper::showOpticalImageOpSelectionDialog() };
             if (r == 1) {
                 qint64 srcSize { fi->size() };

--- a/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
@@ -230,8 +230,7 @@ bool SendToDiscMenuScene::create(QMenu *parent)
     // mount image
     auto focusInfo { InfoFactory::create<FileInfo>(d->focusFile) };
     if (focusInfo) {
-        static QSet<QString> mountable { "application/x-cd-image", "application/x-iso9660-image" };
-        if (mountable.contains(focusInfo->nameOf(NameInfoType::kMimeTypeName))) {
+        if (BurnHelper::isMountableImage(focusInfo->nameOf(NameInfoType::kMimeTypeName))) {
             QAction *act { parent->addAction(d->predicateName[ActionId::kMountImageKey]) };
             act->setProperty(ActionPropertyKey::kActionID, ActionId::kMountImageKey);
             d->predicateAction.insert(ActionId::kMountImageKey, act);

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
@@ -22,6 +22,9 @@
 #include <QStandardPaths>
 #include <QRegularExpression>
 #include <QApplication>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QSet>
 
 using namespace dfmplugin_burn;
 DWIDGET_USE_NAMESPACE
@@ -281,4 +284,20 @@ QFileInfoList BurnHelper::localFileInfoListRecursive(const QString &path, QDir::
     }
 
     return fileList;
+}
+
+bool BurnHelper::isMountableImage(const QString &mimeTypeName)
+{
+    static const QSet<QString> mountable { Global::Mime::kTypeCdImage, Global::Mime::kTypeISO9660Image };
+    if (mountable.contains(mimeTypeName))
+        return true;
+
+    const QMimeType mime = QMimeDatabase().mimeTypeForName(mimeTypeName);
+    if (mime.isValid()) {
+        for (const QString &alias : mime.aliases()) {
+            if (mountable.contains(alias))
+                return true;
+        }
+    }
+    return false;
 }

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
@@ -33,6 +33,7 @@ public:
     static bool burnIsOnLocalStaging(const QUrl &url);
     static QFileInfoList localFileInfoList(const QString &path);
     static QFileInfoList localFileInfoListRecursive(const QString &path, QDir::Filters filters = (QDir::Files | QDir::NoSymLinks));
+    static bool isMountableImage(const QString &mimeTypeName);
 };
 
 }   // namespace dfmplugin_burn


### PR DESCRIPTION
## 修复内容

ISO 文件 MIME 类型被 `shared-mime-info` 2.4 重命名为 `application/vnd.efi.iso`（旧名 `application/x-cd-image` 保留为别名），导致文件管理器无法识别该类型，表现为：
1. ISO 文件类型显示为"未知"
2. 右键菜单无挂载选项
3. 刻录功能无法识别为有效镜像源

## 根因

文件管理器仅匹配 MIME 规范名（canonical name），未检查别名。当 `shared-mime-info` 将 EFI 可启动 ISO 的 MIME 类型重命名为 `application/vnd.efi.iso` 并将旧名保留为别名后，所有基于硬编码规范名的匹配均失败。

## 方案

采用**别名感知匹配**方案，不新增硬编码类型：

1. `mimetypedisplaymanager.cpp` — 规范名匹配失败后、祖先回退前，新增 `QMimeType::aliases()` 检查
2. `burnhelper.h/cpp` — 新增 `BurnHelper::isMountableImage()`，集中封装别名感知 ISO 类型匹配逻辑
3. `sendtodiscmenuscene.cpp` — 替换硬编码 `mountable` QSet 为 `BurnHelper::isMountableImage()`
4. `burneventreceiver.cpp` — 替换硬编码 `imageTypes` QSet 为 `BurnHelper::isMountableImage()`

未来 MIME 类型再次重命名时，只要旧名保留为别名（freedesktop 标准做法），自动适配。

## 影响范围

- 不修改任何现有函数签名，不删除公开接口
- 仅新增别名检查路径和内部 helper 函数
- 已有规范名匹配行为不变

PMS: BUG-376745

## Summary by Sourcery

Support MIME type aliases so ISO images remain recognized across shared-mime-info MIME type renames.

Bug Fixes:
- Restore recognition of renamed ISO MIME types by matching their registered aliases, preserving file-type display, mounting, and disc-burning workflows.

Enhancements:
- Centralize mountable image detection in a reusable helper with alias-aware MIME matching.
- Extend MIME type classification to inspect aliases before falling back to ancestor types.