### PR TITLE
fix: support MIME type aliases for ISO image recognition

### DIFF
--- a/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
+++ b/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
@@ -112,6 +112,16 @@ FileInfo::FileType MimeTypeDisplayManager::displayNameToEnum(const QString &mime
         return FileInfo::FileType::kUnknown;
     }
 
+    // Check aliases — handles cases where shared-mime-info renames a MIME type
+    // but keeps the old name as an alias (e.g. application/vnd.efi.iso aliases
+    // application/x-cd-image).
+    for (const QString &alias : resolvedMime.aliases()) {
+        const FileInfo::FileType aliasType = displayNameToEnumDirect(alias);
+        if (aliasType != FileInfo::FileType::kUnknown) {
+            return aliasType;
+        }
+    }
+
     // Fallback to ancestor MIME types so vendor-specific overrides can still
     // inherit the same top-level category as their standard parent MIME.
     for (const QString &ancestorMimeType : resolvedMime.allAncestors()) {

--- a/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
@@ -86,9 +86,8 @@ void BurnEventReceiver::handlePasteTo(const QList<QUrl> &urls, const QUrl &dest,
         bool isBlank { DeviceUtils::isBlankOpticalDisc(devId) };
 
         auto fi { InfoFactory::create<FileInfo>(urls.front()) };
-        static const QSet<QString> imageTypes { Global::Mime::kTypeCdImage, Global::Mime::kTypeISO9660Image };
 
-        if (isBlank && fi && imageTypes.contains(fi->nameOf(NameInfoType::kMimeTypeName)) && destDir.count() == 0) {
+        if (isBlank && fi && BurnHelper::isMountableImage(fi->nameOf(NameInfoType::kMimeTypeName)) && destDir.count() == 0) {
             int r { BurnHelper::showOpticalImageOpSelectionDialog() };
             if (r == 1) {
                 qint64 srcSize { fi->size() };

--- a/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
@@ -230,8 +230,7 @@ bool SendToDiscMenuScene::create(QMenu *parent)
     // mount image
     auto focusInfo { InfoFactory::create<FileInfo>(d->focusFile) };
     if (focusInfo) {
-        static QSet<QString> mountable { "application/x-cd-image", "application/x-iso9660-image" };
-        if (mountable.contains(focusInfo->nameOf(NameInfoType::kMimeTypeName))) {
+        if (BurnHelper::isMountableImage(focusInfo->nameOf(NameInfoType::kMimeTypeName))) {
             QAction *act { parent->addAction(d->predicateName[ActionId::kMountImageKey]) };
             act->setProperty(ActionPropertyKey::kActionID, ActionId::kMountImageKey);
             d->predicateAction.insert(ActionId::kMountImageKey, act);

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
@@ -22,6 +22,9 @@
 #include <QStandardPaths>
 #include <QRegularExpression>
 #include <QApplication>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QSet>
 
 using namespace dfmplugin_burn;
 DWIDGET_USE_NAMESPACE
@@ -272,4 +275,20 @@ QFileInfoList BurnHelper::localFileInfoListRecursive(const QString &path, QDir::
     }
 
     return fileList;
+}
+
+bool BurnHelper::isMountableImage(const QString &mimeTypeName)
+{
+    static const QSet<QString> mountable { Global::Mime::kTypeCdImage, Global::Mime::kTypeISO9660Image };
+    if (mountable.contains(mimeTypeName))
+        return true;
+
+    const QMimeType mime = QMimeDatabase().mimeTypeForName(mimeTypeName);
+    if (mime.isValid()) {
+        for (const QString &alias : mime.aliases()) {
+            if (mountable.contains(alias))
+                return true;
+        }
+    }
+    return false;
 }

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
@@ -32,6 +32,7 @@ public:
     static bool burnIsOnLocalStaging(const QUrl &url);
     static QFileInfoList localFileInfoList(const QString &path);
     static QFileInfoList localFileInfoListRecursive(const QString &path, QDir::Filters filters = (QDir::Files | QDir::NoSymLinks));
+    static bool isMountableImage(const QString &mimeTypeName);
 };
 
 }   // namespace dfmplugin_burn


### PR DESCRIPTION
fix: support MIME type aliases for ISO image recognition

1. Root cause: shared-mime-info 2.4 renamed EFI-bootable ISO MIME
   type to application/vnd.efi.iso with application/x-cd-image as
   alias; dde-file-manager only matched canonical names, missing
   the new type in file display, mount menu, and burn detection
2. Fix: add alias-aware matching — check QMimeType::aliases() when
   canonical name lookup fails; add BurnHelper::isMountableImage()
   to centralize alias-aware ISO type matching for burn plugin
3. Impact: ISO files with renamed MIME types now correctly display
   as archives, show mount option in context menu, and are recognized
   as burn sources; existing canonical-name matches unaffected

Log: Fix ISO file type display and mount menu for new MIME aliases

Influence:
1. Test right-click mount option on standard ISO files (regression)
2. Test right-click mount option on EFI-bootable ISO files
3. Verify ISO file type displays as "Archive" not "Unknown"
4. Verify burn feature recognizes EFI ISO as valid image source

fix: 支持ISO镜像MIME类型别名的识别

1. 根因：shared-mime-info 2.4 将EFI可启动ISO的MIME类型重命名为
   application/vnd.efi.iso，旧名application/x-cd-image保留为别名；
   文件管理器仅匹配规范名，导致新类型在文件显示、挂载菜单和
   刻录识别中均匹配失败
2. 方案：新增别名感知匹配——规范名匹配失败时检查QMimeType::
   aliases()；新增BurnHelper::isMountableImage()集中封装刻录
   插件的别名感知ISO类型匹配逻辑
3. 影响：MIME类型被重命名的ISO文件现在能正确显示为压缩文件、
   右键显示挂载选项、被识别为刻录源；已有规范名匹配不受影响

Log: 修复ISO文件MIME类型别名导致类型显示未知和挂载选项缺失

Influence:
1. 测试标准ISO文件右键挂载选项（回归）
2. 测试EFI可启动ISO文件右键挂载选项
3. 验证ISO文件类型显示为"压缩文件"而非"未知"
4. 验证刻录功能识别EFI ISO为有效镜像源

PMS: BUG-376745

## Summary by Sourcery

Support MIME type aliases when identifying mountable ISO images.

Bug Fixes:
- Restore recognition of EFI-bootable and other ISO images when shared MIME types use aliases, including file display, mount actions, and burn-source detection.

Enhancements:
- Centralize alias-aware mountable-image detection for burn-related actions while preserving existing canonical MIME matching.