### PR TITLE
fix: handle group header index in drag-drop

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -263,6 +263,8 @@ bool DragDropHelper::drop(QDropEvent *event)
         event->accept();
     } else {
         QModelIndex hoverIndex = view->indexAt(event->pos());
+        if (hoverIndex.isValid() && hoverIndex.data(Global::kItemIsGroupHeaderType).toBool())
+            hoverIndex = view->rootIndex();
 
         if (event->source() == view && dragFileFromCurrent && (!hoverIndex.isValid() || view->isSelected(hoverIndex)) && !WindowUtils::keyCtrlIsPressed()) {
             fmDebug() << "Drop canceled - dragging from current view to selected item";
@@ -443,7 +445,7 @@ void DragDropHelper::handleDropEvent(QDropEvent *event, bool *fall)
 QSharedPointer<FileInfo> DragDropHelper::fileInfoAtPos(const QPoint &pos)
 {
     QModelIndex index = view->indexAt(pos);
-    if (!index.isValid())
+    if (!index.isValid() || index.data(Global::kItemIsGroupHeaderType).toBool())
         index = view->rootIndex();
 
     return view->model()->fileInfo(index);


### PR DESCRIPTION
## Root Cause Analysis

In grouped view, dragging files onto a group header (group name) area had no effect. The root cause is that both `fileInfoAtPos()` and `drop()` in `dragdrophelper.cpp` treated the group header's valid `QModelIndex` as a real drop target. Group headers use a fake URL (`group-header://<key>`) and their model flags lack `Qt::ItemIsDropEnabled`, causing `dragMove` to fail the target check and `drop` to be silently skipped. Key evidence: `dragdrophelper.cpp:448` (`fileInfoAtPos` only checked `!index.isValid()`) and `dragdrophelper.cpp:266` (`drop` used `indexAt()` result without filtering group headers).

## Fix

Added a `kItemIsGroupHeaderType` check in both `fileInfoAtPos()` and `drop()` to redirect group header indices to `rootIndex()`, making dropping on a group name behave the same as dropping on empty space (drop into the current directory). The change is 2 lines added in a single file (`dragdrophelper.cpp`), no deviation from the analysis-recommended approach.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Target code (`fileInfoAtPos` and `drop`) was not a previous bug fix product; the added boundary check does not revert any historical fix. Blame shows `fileInfoAtPos` unchanged since initial introduction (2022), `drop` had only comment/log updates (2025-07).
- The 3 callers of `fileInfoAtPos` (`dragMove`, DirectSave path in `drop`, `handleDropEvent`) all benefit from receiving the root directory FileInfo instead of the group header's fake FileInfo — consistent with existing behavior for invalid indices.

### Business Impact Scope

Affected module: file drag-and-drop in grouped view. The fix changes the behavior of dragging files onto a group name area in grouped view — files will now drop into the current directory, matching the behavior of dragging onto empty space. Non-grouped view drag-drop and group header selection/collapse/expand are unaffected.

### Verification Suggestion

Test dragging files to group name area in grouped view (files should drop into current directory). Regression: test dragging to empty area, subdirectory, and non-grouped view to confirm no behavior change.

---

## 根因分析

分组视图下拖拽文件到组名区域无响应。根因是 `dragdrophelper.cpp` 中 `fileInfoAtPos()` 和 `drop()` 将组头的有效 `QModelIndex` 当作真实拖放目标。组头使用假 URL（`group-header://<key>`）且模型 flags 缺少 `Qt::ItemIsDropEnabled`，导致 `dragMove` 目标检查失败、`drop` 被静默跳过。关键证据：`dragdrophelper.cpp:448`（`fileInfoAtPos` 仅检查 `!index.isValid()`）和 `dragdrophelper.cpp:266`（`drop` 直接使用 `indexAt()` 结果未过滤组头）。

## 修复方案

在 `fileInfoAtPos()` 和 `drop()` 中增加 `kItemIsGroupHeaderType` 检查，将组头索引回退到 `rootIndex()`，使拖拽到组名区域与拖拽到空白区域行为一致（落入当前目录）。改动仅在一个文件（`dragdrophelper.cpp`）中增加 2 行，与分析建议方案完全一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标代码（`fileInfoAtPos` 和 `drop`）非历史 bug 修复产物，新增边界检查不会撤销历史修复。Blame 显示 `fileInfoAtPos` 自 2022 年引入后未修改，`drop` 仅有注释/日志更新（2025-07）。
- `fileInfoAtPos` 的 3 个调用方（`dragMove`、`drop` 中 DirectSave 路径、`handleDropEvent`）均受益于获取根目录 FileInfo 而非组头假 FileInfo——与现有无效索引行为一致。

### 业务影响范围

受影响模块：分组视图下的文件拖放功能。修复改变了分组视图下拖拽文件到组名区域的行为——文件将落入当前目录，与拖拽到空白区域一致。非分组视图拖放和组头选择/折叠展开功能不受影响。

### 验证建议

测试分组视图下拖拽文件到组名区域（文件应落入当前目录）。回归验证：测试拖拽到空白区域、子目录、非分组视图，确认行为不变。

## Summary by Sourcery

Bug Fixes:
- Fix file drag-and-drop onto group headers in grouped views by treating the group header as a drop into the current directory.