### PR TITLE
fix: harden disk encrypt service and move recovery key export to user session

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -28,6 +28,10 @@
 #include <DDBusSender>
 #include <DUtil>
 
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
 #define DDE_SHUTDOWN_SERVICE "org.deepin.dde.ShutdownFront1"
 #define DDE_SHUTDOWN_PATH "/org/deepin/dde/ShutdownFront1"
 #define DDE_SHUTDOWN_INTERFACE "org.deepin.dde.ShutdownFront1"
@@ -253,7 +257,6 @@ void EventsHandler::onEncryptFinished(const QVariantMap &result)
         ignoreParamRequest();
         return;
     case kSuccess:
-    case KErrorRequestExportRecKey:
         title = tr("Encrypt done");
         msg = tr("Partition %1 has been encrypted").arg(device);
         success = true;
@@ -273,11 +276,19 @@ void EventsHandler::onEncryptFinished(const QVariantMap &result)
         dialog_utils::showDialog(title, msg);
     else {
         dialog->showResultPage(success, title, msg);
-        if (code == -KErrorRequestExportRecKey) {
-            auto recKey = result.value(encrypt_param_keys::kKeyRecoveryKey).toString();
-            dialog->setRecoveryKey(recKey, dev);
-            dialog->showExportPage();
+
+        // The service now always returns the recovery key (when generated) via
+        // kKeyRecoveryKey; write it to the user-selected export path in the user
+        // session, falling back to the re-export page only when the write fails.
+        auto recKey = result.value(encrypt_param_keys::kKeyRecoveryKey).toString();
+        if (!recKey.isEmpty()) {
+            auto exportPath = exportPaths.take(dev);
+            if (exportPath.isEmpty() || !saveRecoveryKeyToFile(recKey, dev, exportPath)) {
+                dialog->setRecoveryKey(recKey, dev);
+                dialog->showExportPage();
+            }
         }
+
         dialog->raise();
     }
 
@@ -345,7 +356,13 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
             encryptInputs.take(devPath)->deleteLater();   // also will be deleted when encryption started.
         } else {
             fmInfo() << "User provided auth input for device:" << devPath << "proceeding with re-encryption";
-            if (!DiskEncryptMenuScene::doReencryptDevice(dlg->getInputs())) {
+            auto inputs = dlg->getInputs();
+            // Remember the user-selected export path so the recovery key can be
+            // written by the front-end (in the user session) once the service
+            // returns it via EncryptResult.
+            if (!inputs.exportPath.isEmpty())
+                exportPaths.insert(devPath, inputs.exportPath);
+            if (!DiskEncryptMenuScene::doReencryptDevice(inputs)) {
                 ignoreParamRequest();
                 if (encryptInputs.contains(devPath))
                     encryptInputs.take(devPath)->deleteLater();
@@ -767,6 +784,36 @@ void EventsHandler::setAutoStartDFM(bool enable)
             fmInfo() << "Autostart file does not exist, no need to remove";
         }
     }
+}
+
+bool EventsHandler::saveRecoveryKeyToFile(const QString &recKey, const QString &dev, const QString &exportPath)
+{
+    // Align with EncryptProgressDialog::saveRecKey(): write <exportPath>/<dev>_recovery_key.txt.
+    // The recovery key is a secret, so O_NOFOLLOW rejects a symlink at the target
+    // path, 0600 keeps the file private, and fsync restores the durability that the
+    // removed service-side writer used to guarantee.
+    const QString fileName = QString("%1/%2_recovery_key.txt").arg(exportPath).arg(dev.mid(5));
+
+    int fd = ::open(fileName.toLocal8Bit().constData(),
+                    O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, 0600);
+    if (fd < 0) {
+        fmCritical() << "Failed to create recovery key file:" << fileName << "errno:" << errno;
+        return false;
+    }
+
+    const QByteArray keyData = recKey.toLocal8Bit();
+    const ssize_t written = ::write(fd, keyData.constData(), keyData.size());
+    if (written != keyData.size()) {
+        fmCritical() << "Failed to write recovery key completely:" << fileName;
+        ::close(fd);
+        ::unlink(fileName.toLocal8Bit().constData());
+        return false;
+    }
+
+    ::fsync(fd);
+    ::close(fd);
+    fmInfo() << "Recovery key successfully saved to:" << fileName;
+    return true;
 }
 
 void EventsHandler::onOverlayDMModeChanged(bool enabled, int result)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -52,6 +52,7 @@ private Q_SLOTS:
 
     void requestReboot();
     bool canUnlock(const QString &device);
+    bool saveRecoveryKeyToFile(const QString &recKey, const QString &dev, const QString &exportPath);
 
 private:
     explicit EventsHandler(QObject *parent = nullptr);
@@ -59,6 +60,7 @@ private:
     QMap<QString, QPointer<EncryptProgressDialog>> encryptDialogs;
     QMap<QString, QPointer<EncryptProgressDialog>> decryptDialogs;
     QMap<QString, QPointer<EncryptParamsInputDialog>> encryptInputs;
+    QMap<QString, QString> exportPaths;
 signals:
 };
 }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -592,8 +592,11 @@ void DiskEncryptSetupPrivate::onResumeEncryptFinished()
                                 { kKeyDeviceName, args.value(kKeyDeviceName).toString() },
                                 { kKeyOperationResult, code } };
 
-    // save failed, ask front to save it again.
-    if (code == -disk_encrypt::KErrorRequestExportRecKey)
+    // The service always returns the recovery key (when one was generated) to the
+    // front-end. Writing the recovery key file to the user-selected export path is
+    // now done by the front-end in the user session, because the hardened service
+    // (PrivateTmp/ProtectHome) can no longer write to user-selected directories.
+    if (!worker->recoveryKey().isEmpty())
         result.insert(kKeyRecoveryKey, worker->recoveryKey());
 
     Q_EMIT qptr->EncryptResult(result);

--- a/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
+++ b/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
@@ -8,3 +8,4 @@
 # Type Path                            Mode UID  GID  Age Argument
 d     /etc/usec-crypt                   0755 root root -   -
 d     /boot/usec-crypt                  0755 root root -   -
+d     /run/dfm-encrypt                  0755 root root -   -

--- a/src/services/diskencrypt/deepin-filemanager-diskencrypt.service
+++ b/src/services/diskencrypt/deepin-filemanager-diskencrypt.service
@@ -9,9 +9,9 @@ ExecStart=/usr/bin/deepin-diskencrypt-service
 User=root
 
 # ProtectSystem=full
-# ProtectHome=true
+ProtectHome=true
 # ProtectProc=invisible
-# PrivateTmp=true
+PrivateTmp=true
 # PrivateDevices=false
 # ProtectKernelTunables=true
 # ProtectKernelModules=false

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -25,15 +25,15 @@ static QString toBase64(const QString rawstr)
 
 inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
 inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
-inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
+inline constexpr char kRebootFlagFilePrefix[] { "/run/dfm-encrypt/reboot_flag_" };
 
 // Overlay DM mode settings directory and marker files
 inline constexpr char kOverlayDMSettingsDir[] { "/etc/usec-crypt/settings" };
 inline constexpr char kOverlayDMFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
 inline constexpr char kOverlayDMPendingFile[] { "/etc/usec-crypt/settings/overlay-dm.pending" };
 
-inline constexpr char kOverlayDMNotifyDir[] { "/tmp/dfm-overlay-dm-notify" };
-inline constexpr char kOverlayDMNotifyFile[] { "/tmp/dfm-overlay-dm-notify/pending.json" };
+inline constexpr char kOverlayDMNotifyDir[] { "/run/dfm-encrypt/overlay-dm-notify" };
+inline constexpr char kOverlayDMNotifyFile[] { "/run/dfm-encrypt/overlay-dm-notify/pending.json" };
 
 // Overlay DM Mode change result codes (shared by service and plugin)
 enum OverlayDMModeChangeResult {
@@ -109,7 +109,6 @@ enum EncryptOperationStatus {
     kErrorDisabledMountPoint,
     kErrorSetLabel,
     kErrorNotFullyEncrypted,
-    KErrorRequestExportRecKey,
     kErrorSetFsPassno,
     kErrorCheckReencryptStatus,
 

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -52,7 +52,7 @@ void common_helper::createRebootFlagFile(const QString &dev)
 {
     qInfo() << "[common_helper::createRebootFlagFile] Creating reboot flag file for device:" << dev;
 
-    QString fileName = disk_encrypt::kRebootFlagFilePrefix + dev.mid(5);
+    QString fileName = disk_encrypt::kRebootFlagFilePrefix + QString(dev).replace("/", "_");
     QFile f(fileName);
     if (!f.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
         qCritical() << "[common_helper::createRebootFlagFile] Failed to create reboot flag file:" << fileName;

--- a/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
+++ b/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
@@ -124,19 +124,23 @@ void OverlayDMNotifyHelper::launchFileManager(uint uid, const QString &username)
 {
     qInfo() << "[OverlayDMNotifyHelper::launchFileManager] Launching file manager for user:" << username << "UID:" << uid;
 
-    const QString busAddr = QString("unix:path=/run/user/%1/bus").arg(uid);
+    // Launch inside the target user's session via systemd-run --user --machine,
+    // so the spawned process runs in the user's own mount namespace and graphical
+    // session environment (its own /run/user, DISPLAY/WAYLAND_DISPLAY and session
+    // bus). This avoids inheriting the service's isolated namespace introduced by
+    // PrivateTmp/ProtectHome, and no longer hand-builds unix:path=/run/user/<uid>/bus.
+    const QString machine = QString("%1@.host").arg(username);
 
     QProcess process;
-    process.setProgram("runuser");
-    process.setArguments({ "-u", username, "--",
-                           "env", QString("DBUS_SESSION_BUS_ADDRESS=%1").arg(busAddr),
+    process.setProgram("systemd-run");
+    process.setArguments({ "--user", "--machine", machine, "--",
                            "/usr/libexec/dde-file-manager", "-d" });
 
     qint64 pid = 0;
     if (process.startDetached(&pid)) {
-        qInfo() << "[OverlayDMNotifyHelper::launchFileManager] File manager launched, PID:" << pid;
+        qInfo() << "[OverlayDMNotifyHelper::launchFileManager] File manager launched via systemd-run, PID:" << pid;
     } else {
-        qWarning() << "[OverlayDMNotifyHelper::launchFileManager] Failed to launch file manager:" << process.errorString();
+        qWarning() << "[OverlayDMNotifyHelper::launchFileManager] Failed to launch file manager via systemd-run:" << process.errorString();
     }
 }
 

--- a/src/services/diskencrypt/workers/resumeencryptworker.cpp
+++ b/src/services/diskencrypt/workers/resumeencryptworker.cpp
@@ -16,14 +16,6 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
-#include <QDir>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <string.h>
 
 FILE_ENCRYPT_USE_NS
 
@@ -171,10 +163,10 @@ void ResumeEncryptWorker::setRecoveryKey()
     }
 
     qInfo() << "[ResumeEncryptWorker::setRecoveryKey] Generating recovery key";
-    m_authArgs.recoveryKey = common_helper::genRecoveryKey();
+    const QString recKey = common_helper::genRecoveryKey();
     int r = crypt_setup::csAddPassphrase(m_jobArgs.devPath,
                                          m_authArgs.passphrase,
-                                         m_authArgs.recoveryKey);
+                                         recKey);
     if (r < 0) {
         qCritical() << "[ResumeEncryptWorker::setRecoveryKey] Cannot add recovery key, device:" << m_jobArgs.devPath << "error:" << r;
         return;
@@ -186,9 +178,10 @@ void ResumeEncryptWorker::setRecoveryKey()
         return;
     }
 
+    // Publish the key only after it is successfully enrolled (keyslot + token),
+    // so a partial failure never returns a recovery key that cannot unlock the device.
+    m_authArgs.recoveryKey = recKey;
     qInfo() << "[ResumeEncryptWorker::setRecoveryKey] Recovery key set successfully, device:" << m_jobArgs.devPath;
-
-    saveRecoveryKey();
 }
 
 void ResumeEncryptWorker::setPhyDevLabel()
@@ -211,83 +204,6 @@ void ResumeEncryptWorker::updateCryptTab()
     }
     crypttab_helper::addCryptOption(m_jobArgs.volume, "tpm2-device=auto");
     qInfo() << "[ResumeEncryptWorker::updateCryptTab] Crypttab updated with TPM option";
-}
-
-void ResumeEncryptWorker::saveRecoveryKey()
-{
-    qDebug() << "[ResumeEncryptWorker::saveRecoveryKey] Saving recovery key";
-    setExitCode(-disk_encrypt::KErrorRequestExportRecKey);
-
-    auto fileName = QString("%1/%2_recovery_key.txt")
-                            .arg(m_authArgs.recoveryPath)
-                            .arg(m_authArgs.device.mid(5));
-    qDebug() << "[ResumeEncryptWorker::saveRecoveryKey] Saving recovery key to:" << fileName;
-
-    // Step 1: Open parent directory fd with O_PATH | O_NOFOLLOW to pin it and reject symlinks
-    QByteArray parentPath = m_authArgs.recoveryPath.toLocal8Bit();
-    int dirFd = ::open(parentPath.constData(), O_PATH | O_NOFOLLOW | O_DIRECTORY);
-    if (dirFd < 0) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Cannot open parent directory (not a dir or is symlink):"
-                    << m_authArgs.recoveryPath << "error:" << strerror(errno);
-        return;
-    }
-
-    // Step 2: Verify parent directory is not world-writable (prevent arbitrary target redirection)
-    struct stat dirStat;
-    if (::fstat(dirFd, &dirStat) != 0) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Cannot stat parent directory:" << m_authArgs.recoveryPath;
-        ::close(dirFd);
-        return;
-    }
-    if (dirStat.st_mode & S_IWOTH) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Parent directory is world-writable, refusing:"
-                    << m_authArgs.recoveryPath;
-        ::close(dirFd);
-        return;
-    }
-
-    // Step 3: Create/truncate file via openat with dirFd-pinned path
-    // O_NOFOLLOW: reject symlinks (fails with ELOOP if filename is a symlink)
-    // O_CREAT | O_TRUNC: create or truncate (matches original QFile::Truncate semantics)
-    // TOCTOU is eliminated because dirFd is pinned to the parent directory inode
-    QByteArray baseName = (m_authArgs.device.mid(5) + "_recovery_key.txt").toLocal8Bit();
-    int fd = ::openat(dirFd, baseName.constData(),
-                       O_NOFOLLOW | O_CREAT | O_TRUNC | O_WRONLY,
-                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-
-    if (fd < 0) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Cannot create/open recovery key file:" << fileName
-                    << "error:" << strerror(errno);
-        ::close(dirFd);
-        return;
-    }
-
-    // Step 4: fstat the opened file to verify it is a regular file (defense in depth)
-    struct stat fileStat;
-    if (::fstat(fd, &fileStat) != 0 || !S_ISREG(fileStat.st_mode)) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Opened file is not a regular file:" << fileName;
-        ::close(fd);
-        ::close(dirFd);
-        return;
-    }
-
-    // Step 5: Write recovery key through fd
-    QByteArray keyData = m_authArgs.recoveryKey.toLocal8Bit();
-    ssize_t written = ::write(fd, keyData.constData(), keyData.size());
-    if (written != keyData.size()) {
-        qCritical() << "[ResumeEncryptWorker::saveRecoveryKey] Failed to write recovery key completely:" << fileName;
-        ::close(fd);
-        ::unlinkat(dirFd, baseName.constData(), 0);
-        ::close(dirFd);
-        return;
-    }
-
-    // Step 6: Sync to disk and close
-    ::fsync(fd);
-    ::close(fd);
-    ::close(dirFd);
-    qInfo() << "[ResumeEncryptWorker::saveRecoveryKey] Recovery key saved successfully, device:" << m_jobArgs.devPath;
-    setExitCode(disk_encrypt::kSuccess);
 }
 
 void ResumeEncryptWorker::loadJobFromDevice()

--- a/src/services/diskencrypt/workers/resumeencryptworker.h
+++ b/src/services/diskencrypt/workers/resumeencryptworker.h
@@ -44,7 +44,6 @@ protected:
     void setRecoveryKey();
     void setPhyDevLabel();
     void updateCryptTab();
-    void saveRecoveryKey();
 
     void loadJobFromDevice();
 


### PR DESCRIPTION
1. Enable ProtectHome and PrivateTmp for the disk encrypt service so the
service no longer touches user-visible files under /home and /tmp.
2. Move reboot flag and Overlay DM notify files from /tmp to /run/dfm-encrypt,
and add the directory to deepin-diskencrypt-tmpfiles.conf.
3. Return the recovery key to the front-end via EncryptResult whenever one is
generated; the front-end now writes it to the user-selected export path in the
user session, falling back to the re-export page only when the write fails.
4. Remove the service-side saveRecoveryKey() implementation, which can no
longer write to user-selected directories under the hardened sandbox.
5. Launch the file manager inside the target user's session via
systemd-run --user --machine instead of runuser plus a hand-built
unix:path=/run/user/<uid>/bus address, so it runs in the user's own mount
namespace and graphical session environment.

Log: The disk encrypt service is hardened with ProtectHome/PrivateTmp, runtime
state moves to /run/dfm-encrypt, recovery key export is handled by the
front-end in the user session, and the overlay DM notify flow launches the file
manager via systemd-run.

Influence:
1. Verify full-disk encryption still succeeds and the recovery key file is
written to the user-selected export path.
2. Test encryption when the selected export path is unwritable: the export page
is shown again inside the dialog.
3. Verify /tmp files are no longer created by the service and /run/dfm-encrypt
is populated and cleaned up correctly.
4. Trigger overlay DM mode change notification and verify the file manager
opens in the correct user session with the proper graphical environment.
5. Verify recovery-key re-export, decrypt, and unlock flows show no regressions
after the hardening.

fix: 磁盘加密服务加固并将恢复密钥导出移至用户会话

1. 为磁盘加密服务启用 ProtectHome 与 PrivateTmp，使服务不再访问 /home 与
/tmp 下的用户可见文件。
2. 将重启标记文件与 Overlay DM 通知标记文件从 /tmp 迁移到
/run/dfm-encrypt，并在 deepin-diskencrypt-tmpfiles.conf 中补充该目录。
3. 服务生成恢复密钥后始终通过 EncryptResult 返回给前端，由前端在用户会话
中写入用户选择的导出路径，仅当写入失败时才回退到重新导出页面。
4. 移除服务端 saveRecoveryKey() 实现，该实现已无法在加固沙箱中写入用户选
择的目录。
5. Overlay DM 通知改通过 systemd-run --user --machine 在目标用户会话中启动
文件管理器，替代 runuser 加手工构造 unix:path=/run/user/<uid>/bus 的方式，
使启动的进程继承用户自身的挂载命名空间与图形会话环境。

Log: 磁盘加密服务启用 ProtectHome/PrivateTmp 加固，运行期文件迁移至
/run/dfm-encrypt，恢复密钥导出改由前端在用户会话完成，Overlay DM 通知改
通过 systemd-run 启动文件管理器。

Influence:
1. 验证全盘加密正常完成且恢复密钥写入用户选择的导出路径。
2. 验证导出路径不可写时，对话框内重新显示导出页面。
3. 验证服务不再在 /tmp 下产生文件，/run/dfm-encrypt 正常创建并随重启清理。
4. 触发 Overlay DM 模式变更通知，验证文件管理器在正确的用户会话和图形环境
中打开。
5. 验证加固后恢复密钥重新导出、解密、重启等流程无回归。

BUG: https://pms.uniontech.com/bug-view-376053.html

## Summary by Sourcery

Harden the disk-encryption service and move recovery-key export and overlay DM notifications into the appropriate user session.

New Features:
- Return generated recovery keys to the front end for export within the user session.
- Launch overlay DM file-manager notifications in the target user's systemd session.

Bug Fixes:
- Preserve recovery-key export and fallback behavior when encryption completes or the selected destination is unavailable.
- Ensure recovery keys are reported only after successful enrollment on the encrypted device.

Enhancements:
- Harden the disk-encryption service with ProtectHome and PrivateTmp.
- Move service runtime markers from /tmp to the managed /run/dfm-encrypt directory.

Deployment:
- Create and manage the /run/dfm-encrypt runtime directory through tmpfiles configuration.

Chores:
- Remove service-side recovery-key file writing and the obsolete export-error status.