### PR TITLE
fix: add notifyFileChangeManual to delete paths for remote mount refresh

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -113,9 +113,9 @@ bool DoDeleteFilesWorker::deleteFilesByFts()
     // Flush any buffered fileDeleted signals on every exit path.
     dfmbase::FinallyUtil atFinish([&] { flushFileDeletedBatch(); });
 
-    // FTS only traverses local files (non-local sources are filtered above), so the
-    // local inotify watcher already delivers delete notifications - no manual notify
-    // is needed here (mirrors deleteFilesOnCanNotRemoveDevice's local behavior).
+    // FTS traverses local file paths; for GVFS FUSE-mounted remote shares (FTP/SMB/etc.)
+    // these paths are file:// URLs that inotify cannot monitor, so notifyFileChangeManual
+    // is called per-file to trigger view refresh on protocols that lack file watchers.
     QSet<QUrl> sourceUrlsSet(sourceUrls.begin(), sourceUrls.end());
     bool success = true;
     int errorCount = 0;
@@ -197,6 +197,7 @@ bool DoDeleteFilesWorker::deleteFilesByFts()
             continue;
 
         batchEmitFileDeleted(url);
+        FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, url);
 
         if (sourceUrlsSet.contains(url)) {
             completeSourceFiles.append(url);


### PR DESCRIPTION
fix: add notifyFileChangeManual to delete paths for remote mount refresh

FTP/SMB/NFS files deleted via GVFS FUSE mount paths (file:// URLs) were
not triggering view refresh because deleteFilesByFts() and
deleteFilesOnCanNotRemoveDevice() did not call
FileUtils::notifyFileChangeManual(), while create/mkdir/rename paths
(touchFile, mkdir, renameFile) already did.

GVFS FUSE-mounted remote paths have file:// scheme so inotify watchers
are created successfully but GIO file monitoring does not produce events
for them. notifyFileChangeManual() handles this by detecting remote
mounts (isRemoteMount) and manually calling watcher->notifyFileDeleted()
to refresh the view. For purely local files, isRemoteMount returns false
and the function is a no-op, so there is no risk of double-notification.

The fix adds notifyFileChangeManual(kFileDeleted, url) after
batchEmitFileDeleted(url) in both deleteFilesByFts() and
deleteFilesOnCanNotRemoveDevice(), matching the existing pattern in
deleteFileOnOtherDevice().

Fixes: BUG-376689

## Summary by Sourcery

Bug Fixes:
- Refresh views when deleting files from GVFS-mounted remote shares by manually notifying file watchers.