### PR TITLE
fix: trigger async emblem detection on cache hit to fix stale emblems

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -39,6 +39,12 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
     const auto &infoEmblems = info->extendAttributes(ExtInfoType::kFileEmblems);
     if (infoEmblems.isValid()) {
         emblems = infoEmblems.value<QList<QIcon>>();
+        const QUrl &url = info->urlOf(UrlInfoType::kUrl);
+        if (!helper->isExtEmblemProhibited(info, url)) {
+            helper->pending(info);
+            QList<QIcon> tmpEmblems;
+            EmblemEventSequence::instance()->doFetchExtendEmblems(url, &tmpEmblems);
+        }
     } else {
         // add system emblem icons
         emblems = helper->systemEmblems(info);


### PR DESCRIPTION
## Root Cause Analysis

The `kFileEmblems` cache (introduced in commit `62a094289`) in `EmblemManager::paintEmblems()` skips `helper->pending(info)` and `EmblemEventSequence::instance()->doFetchExtendEmblems()` when the cache is valid. These two calls are not just data collectors — they also trigger asynchronous emblem change detection worker threads (`GioEmblemWorker` and `EmblemIconWorker`). When the cache hits, these workers never run, so external emblem changes (e.g. from dfm-extension plugins) go undetected and file views don't refresh until a manual F5 clears the `kFileEmblems` cache.

Key evidence:
- `emblemmanager.cpp:32-36` — cache-hit branch returns early, skipping `pending()` and `doFetchExtendEmblems()`
- `extensionemblemmanager.cpp:305,363` — `doFetchExtendEmblems` → 500ms timer → `EmblemIconWorker` → `onEmblemIconChanged` → `updateFile()` clears `kFileEmblems`; this chain never fires on cache hit
- `fileviewmodel.cpp:847` — `updateFile()` clears `kFileEmblems`, explaining why F5 recovers but auto-refresh does not

## Fix

Restore `helper->pending(info)` and `doFetchExtendEmblems()` calls inside the cache-hit branch of `paintEmblems()`, while still drawing with cached emblems. A throwaway `tmpEmblems` list receives any synchronous results (discarded); the actual detection runs asynchronously on worker threads. This matches the pre-cache behavior where both calls executed on every paint.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Blame history shows the cache-hit branch was introduced by commit `62a094289` (the same optimization that introduced the bug). The `pending()` and `doFetchExtendEmblems()` calls in the else branch predate the cache (commit `832a305270`). This change restores the original trigger frequency without reverting any historical fix.
- All 4 delegate callers (`canvasitemdelegate.cpp`, `iconitemdelegate.cpp`, `listitemdelegate.cpp`) call `paintEmblems()` unchanged; no interface or call-site modification.

### Business Impact Scope

Affected modules: emblem display in file views (icon view, list view, desktop canvas). User scenario: after a dfm-extension plugin modifies a file's emblem, the file view now automatically refreshes to show the updated emblem without requiring manual F5. Users who rely on third-party or extension-provided emblems (e.g. sync status, version control badges) will see correct, up-to-date emblems.

### Verification Suggestion

1. Install a dfm-extension plugin that sets custom emblems, modify an emblem while a file view is open, and verify the view updates without manual refresh.
2. Verify emblem display still works correctly after F5 refresh (no regression in the cache-miss path).

---

## 根因分析

`EmblemManager::paintEmblems()` 中的 `kFileEmblems` 缓存（commit `62a094289` 引入）在缓存命中时跳过了 `helper->pending(info)` 和 `doFetchExtendEmblems()`。这两个调用不仅收集角标数据，还承担触发异步角标变更检测工作线程（`GioEmblemWorker` 和 `EmblemIconWorker`）的副作用。缓存命中时这些工作线程不运行，外部角标变更（如 dfm-extension 插件修改角标）无法被检测，文件视图不刷新，直到手动 F5 清除 `kFileEmblems` 缓存。

关键证据：
- `emblemmanager.cpp:32-36` — 缓存命中分支提前返回，跳过 `pending()` 和 `doFetchExtendEmblems()`
- `extensionemblemmanager.cpp:305,363` — `doFetchExtendEmblems` → 500ms 定时器 → `EmblemIconWorker` → `onEmblemIconChanged` → `updateFile()` 清除 `kFileEmblems`；缓存命中时此链不触发
- `fileviewmodel.cpp:847` — `updateFile()` 清除 `kFileEmblems`，解释了 F5 能恢复但自动刷新不能

## 修复方案

在 `paintEmblems()` 缓存命中分支中恢复 `helper->pending(info)` 和 `doFetchExtendEmblems()` 调用，绘制仍使用缓存角标。临时变量 `tmpEmblems` 接收同步结果（丢弃），实际检测异步在工作线程执行。与缓存优化前每次绘制都调用这两个触发点的行为一致。

## 改动安全评估

### 代码安全评估

- **风险等级**：低
- Blame 历史显示缓存命中分支由 commit `62a094289`（即引入 bug 的优化提交）引入。else 分支中的 `pending()` 和 `doFetchExtendEmblems()` 调用早于缓存（commit `832a305270`）。本次改动恢复原始触发频率，不撤销任何历史修复。
- 4 个 delegate 调用者（`canvasitemdelegate.cpp`、`iconitemdelegate.cpp`、`listitemdelegate.cpp`）调用 `paintEmblems()` 方式不变，无接口或调用点修改。

### 业务影响范围

受影响模块：文件视图中的角标显示（图标视图、列表视图、桌面画布）。用户场景：dfm-extension 插件修改文件角标后，文件视图自动刷新显示更新后的角标，无需手动 F5。依赖第三方或扩展角标（如同步状态、版本控制标记）的用户将看到正确的实时角标。

### 验证建议

1. 安装设置自定义角标的 dfm-extension 插件，在文件视图打开时修改角标，验证视图无需手动刷新即更新。
2. 验证 F5 刷新后角标显示正常（缓存未命中路径无回归）。

## Summary by Sourcery

Bug Fixes:
- Restore asynchronous emblem change detection on emblem-cache hits so file views automatically refresh when external emblems change.